### PR TITLE
Disable dev server search attributes cache by default

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -275,6 +275,11 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 				if err != nil {
 					return err
 				}
+
+				if _, ok := configVals[dynamicconfig.ForceSearchAttributesCacheRefreshOnRead]; !ok {
+					opts = append(opts, WithSearchAttributeCacheDisabled())
+				}
+
 				for k, v := range configVals {
 					opts = append(opts, WithDynamicConfigValue(k, v))
 				}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

set `system.forceSearchAttributesCacheRefreshOnRead=true` by default when starting the server in dev mode

## Why?
<!-- Tell your future self why have you made these changes -->

v0.1 design

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Verified that the flag is still prioritized over the default

```
server start-dev --namespace default --dynamic-config-value system.forceSearchAttributesCacheRefreshOnRead=false
```

When not passed ^ it takes the default 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
