### PR TITLE
Allowing configuring UI codec URL via flag

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,8 @@
       "program": "${workspaceFolder}/cmd/temporal",
       "cwd": "${workspaceFolder}",
       "args": [
-        "env",
-        "set",
-        "default.namespace",
-        "default",
+        "server",
+        "start-dev",
       ],
       "env": {
         "CGO_ENABLED": "0",

--- a/common/flags.go
+++ b/common/flags.go
@@ -116,6 +116,7 @@ var (
 	FlagTLSServerName              = "tls-server-name"
 	FlagType                       = "type"
 	FlagUIIP                       = "ui-ip"
+	FlagUICodecEndpoint            = "ui-codec-endpoint"
 	FlagUIPort                     = "ui-port"
 	FlagUnpause                    = "unpause"
 	FlagVisibilityArchivalState    = "visibility-archival-state"

--- a/server/ui.go
+++ b/server/ui.go
@@ -37,11 +37,9 @@ import (
 	uiserveroptions "github.com/temporalio/ui-server/v2/server/server_options"
 )
 
-func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string) (ServerOption, error) {
-	cfg, err := NewUIConfig(
-		frontendAddr,
-		uiIP,
-		uiPort,
+func newUIOption(c *uiconfig.Config, configDir string) (ServerOption, error) {
+	cfg, err := MergeWithConfigFile(
+		c,
 		configDir,
 	)
 	if err != nil {
@@ -50,11 +48,7 @@ func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string)
 	return WithUI(uiserver.NewServer(uiserveroptions.WithConfigProvider(cfg))), nil
 }
 
-func NewUIConfig(frontendAddr string, uiIP string, uiPort int, configDir string) (*uiconfig.Config, error) {
-	cfg := &uiconfig.Config{
-		Host: uiIP,
-		Port: uiPort,
-	}
+func MergeWithConfigFile(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, error) {
 	if configDir != "" {
 		if err := provider.Load(configDir, cfg, "temporal-ui"); err != nil {
 			if !strings.HasPrefix(err.Error(), "no config files found") {
@@ -62,7 +56,6 @@ func NewUIConfig(frontendAddr string, uiIP string, uiPort int, configDir string)
 			}
 		}
 	}
-	cfg.TemporalGRPCAddress = frontendAddr
-	cfg.EnableUI = true
+
 	return cfg, nil
 }

--- a/server/ui_test.go
+++ b/server/ui_test.go
@@ -28,10 +28,18 @@ package server
 
 import (
 	"testing"
+
+	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 )
 
 func TestNewUIConfig(t *testing.T) {
-	cfg, err := NewUIConfig("localhost:7233", "localhost", 8233, "")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := MergeWithConfigFile(c, "")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -42,7 +50,13 @@ func TestNewUIConfig(t *testing.T) {
 }
 
 func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
-	cfg, err := NewUIConfig("localhost:7233", "localhost", 8233, "wibble")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := MergeWithConfigFile(c, "wibble")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -53,7 +67,13 @@ func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
 }
 
 func TestNewUIConfigWithPresentConfigFile(t *testing.T) {
-	cfg, err := NewUIConfig("localhost:7233", "localhost", 8233, "testdata")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := MergeWithConfigFile(c, "testdata")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added flag `--ui-codec-endpoint` for configuring codec endpoint used by UI

copy of https://github.com/temporalio/temporalite/pull/174

resolve https://github.com/temporalio/cli/issues/52

## Why?
<!-- Tell your future self why have you made these changes -->

enables the use of codec via a single run comand

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Manually

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
