### PR TITLE
Fix server data folder not created & test races

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -349,9 +349,7 @@ func TestCreateDataDirectory_ExistingDirectory(t *testing.T) {
 	temporalCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
 
 	portProvider := sconfig.NewPortProvider()
-	var (
-		port = portProvider.MustGetFreePort()
-	)
+	port := portProvider.MustGetFreePort()
 	portProvider.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -325,9 +325,7 @@ func TestCreateDataDirectory_MissingDirectory(t *testing.T) {
 	temporalCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
 
 	portProvider := sconfig.NewPortProvider()
-	var (
-		port = portProvider.MustGetFreePort()
-	)
+	port := portProvider.MustGetFreePort()
 	portProvider.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.1
-	github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481
+	github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727
 	github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82
 	github.com/urfave/cli/v2 v2.23.7
 	go.temporal.io/api v1.13.1-0.20221110200459-6a3cb21a3415

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ github.com/temporalio/ringpop-go v0.0.0-20220818230611-30bf23b490b2 h1:QIwUh2HCt
 github.com/temporalio/ringpop-go v0.0.0-20220818230611-30bf23b490b2/go.mod h1:ZEYrWwPO7607ZEaPzK7nWRv55cIrTtH4TeBBu3V532U=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b h1:Fs3LdlF7xbnOWHymbFmvIEuxIEt1dNRCfaDkoajSaZk=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
-github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481 h1:zaikUeNmdLQEsUXTyUAy65P2IzKFlt7EAEflQQF2ZUA=
-github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481/go.mod h1:VSiXCSr9dY+0TSRondg2YF5HhQhrMDN63jaRaBHy1+k=
+github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727 h1:Yrisr5sO+sPzc2ATX4LS8K7iM1L1ww71RIbZk8N240Q=
+github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727/go.mod h1:hk/LJCKZNNmtVSWRKepbdUJme+k/4fb/hPkekXk40sk=
 github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82 h1:Ks4uepFdm3I/G6z879Dna3E3v9OwkDfE38bKI5BN2pw=
 github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82/go.mod h1:Fd68+cECpTXc7oZh2oHUA5DQ1tIPa87mg9PPlJ8hPaA=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/server/commands.go
+++ b/server/commands.go
@@ -144,7 +144,7 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 				}
 
 				// Make sure the default db path exists (user does not specify path explicitly)
-				if !c.IsSet(common.FlagDBPath) {
+				if c.IsSet(common.FlagDBPath) {
 					if err := os.MkdirAll(filepath.Dir(c.String(common.FlagDBPath)), os.ModePerm); err != nil {
 						return cli.Exit(err.Error(), 1)
 					}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixes `temporal server start-dev` not creating the folder for Data/DB

## Why?
<!-- Tell your future self why have you made these changes -->

The issue with `temporal server start-dev` not creating the data folder was exposed by merging https://github.com/temporalio/tctl-kit/pull/35 : the `env` feature was creating the folder so the tests were succeeding

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
