### PR TITLE
Allow using custom assets for the UI.

### DIFF
--- a/common/flags.go
+++ b/common/flags.go
@@ -116,6 +116,7 @@ var (
 	FlagTLSServerName              = "tls-server-name"
 	FlagType                       = "type"
 	FlagUIIP                       = "ui-ip"
+	FlagUIAssetPath                = "ui-asset-path"
 	FlagUICodecEndpoint            = "ui-codec-endpoint"
 	FlagUIPort                     = "ui-port"
 	FlagUnpause                    = "unpause"

--- a/go.mod
+++ b/go.mod
@@ -149,3 +149,5 @@ require (
 )
 
 replace github.com/grpc-ecosystem/grpc-gateway => github.com/temporalio/grpc-gateway v1.17.0
+
+replace github.com/temporalio/ui-server/v2 v2.9.1 => github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.1
 	github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481
-	github.com/temporalio/ui-server/v2 v2.9.1
+	github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82
 	github.com/urfave/cli/v2 v2.23.7
 	go.temporal.io/api v1.13.1-0.20221110200459-6a3cb21a3415
 	go.temporal.io/sdk v1.19.0
@@ -149,5 +149,3 @@ require (
 )
 
 replace github.com/grpc-ecosystem/grpc-gateway => github.com/temporalio/grpc-gateway v1.17.0
-
-replace github.com/temporalio/ui-server/v2 v2.9.1 => github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b h1:Fs3Ld
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481 h1:zaikUeNmdLQEsUXTyUAy65P2IzKFlt7EAEflQQF2ZUA=
 github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481/go.mod h1:VSiXCSr9dY+0TSRondg2YF5HhQhrMDN63jaRaBHy1+k=
-github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48 h1:gZV/uAqsyGkjCXysBokalSN2xOQUCqE3wH/U6jCUU3s=
-github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48/go.mod h1:Fd68+cECpTXc7oZh2oHUA5DQ1tIPa87mg9PPlJ8hPaA=
+github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82 h1:Ks4uepFdm3I/G6z879Dna3E3v9OwkDfE38bKI5BN2pw=
+github.com/temporalio/ui-server/v2 v2.9.2-0.20230106074906-529addb76f82/go.mod h1:Fd68+cECpTXc7oZh2oHUA5DQ1tIPa87mg9PPlJ8hPaA=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b h1:Fs3Ld
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481 h1:zaikUeNmdLQEsUXTyUAy65P2IzKFlt7EAEflQQF2ZUA=
 github.com/temporalio/tctl-kit v0.0.0-20221128225502-a682971cf481/go.mod h1:VSiXCSr9dY+0TSRondg2YF5HhQhrMDN63jaRaBHy1+k=
-github.com/temporalio/ui-server/v2 v2.9.1 h1:my6I0ow1hG69nbRqSLN2QySi3iw/n9kBQNvlRy640j8=
-github.com/temporalio/ui-server/v2 v2.9.1/go.mod h1:Fd68+cECpTXc7oZh2oHUA5DQ1tIPa87mg9PPlJ8hPaA=
+github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48 h1:gZV/uAqsyGkjCXysBokalSN2xOQUCqE3wH/U6jCUU3s=
+github.com/temporalio/ui-server/v2 v2.9.2-0.20230105175408-7b947c15ce48/go.mod h1:Fd68+cECpTXc7oZh2oHUA5DQ1tIPa87mg9PPlJ8hPaA=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/server/commands.go
+++ b/server/commands.go
@@ -98,6 +98,11 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 					DefaultText: "same as --ip (eg. 127.0.0.1)",
 				},
 				&cli.StringFlag{
+					Name:    common.FlagUIAssetPath,
+					Usage:   `UI Custom Assets path`,
+					EnvVars: nil,
+				},
+				&cli.StringFlag{
 					Name:    common.FlagUICodecEndpoint,
 					Usage:   `UI Remote data converter HTTP endpoint`,
 					EnvVars: nil,
@@ -178,6 +183,7 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 					uiPort          = serverPort + 1000
 					uiIP            = ip
 					uiCodecEndpoint = ""
+					uiAssetPath     = ""
 				)
 
 				if c.IsSet(common.FlagUIPort) {
@@ -186,6 +192,10 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 
 				if c.IsSet(common.FlagUIIP) {
 					uiIP = c.String(common.FlagUIIP)
+				}
+
+				if c.IsSet(common.FlagUIAssetPath) {
+					uiAssetPath = c.String(common.FlagUIAssetPath)
 				}
 
 				if c.IsSet(common.FlagUICodecEndpoint) {
@@ -246,6 +256,7 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 						Port:                uiPort,
 						TemporalGRPCAddress: frontendAddr,
 						EnableUI:            true,
+						UIAssetPath:         uiAssetPath,
 						Codec: uiconfig.Codec{
 							Endpoint: uiCodecEndpoint,
 						},


### PR DESCRIPTION
This makes integration testing of UI changes much easier as we avoid the need to re-compile the ui-server and the Temporal CLI.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added support for using a custom UI asset path.

## Why?
Makes testing UI changes much easier, avoiding any need to recompile ui-server or the Temporal CLI.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
`./temporal server start-dev --ui-asset-path $PWD/../ui/.vercel/output/static/` versus `./temporal server start-dev`. Confirmed the adjusted UI is served when the option is passed.

3. Any docs updates needed?
No.