### PR TITLE
Add complection command usage text

### DIFF
--- a/completion/completion.go
+++ b/completion/completion.go
@@ -51,16 +51,18 @@ complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete temporal
 func NewCompletionCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:  "bash",
-			Usage: "bash completion output",
+			Name:      "bash",
+			Usage:     "bash completion output",
+			UsageText: "source <(temporal completion bash)",
 			Action: func(c *cli.Context) error {
 				fmt.Fprintln(os.Stdout, bash_script)
 				return nil
 			},
 		},
 		{
-			Name:  "zsh",
-			Usage: "zsh completion output",
+			Name:      "zsh",
+			Usage:     "zsh completion output",
+			UsageText: "source <(temporal completion zsh)",
 			Action: func(c *cli.Context) error {
 				fmt.Fprintln(os.Stdout, zsh_script)
 				return nil

--- a/server/commands.go
+++ b/server/commands.go
@@ -73,9 +73,9 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 					Value:   sconfig.DefaultFrontendPort,
 				},
 				&cli.IntFlag{
-					Name:  common.FlagMetricsPort,
-					Usage: "Port for /metrics",
-					Value: sconfig.DefaultMetricsPort,
+					Name:        common.FlagMetricsPort,
+					Usage:       "Port for /metrics",
+					Value:       sconfig.DefaultMetricsPort,
 					DefaultText: "disabled",
 				},
 				&cli.IntFlag{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Clarified the usage

```
temporal completion zsh -h                                                                                                                                                      ✔ 
NAME:
   temporal completion zsh - zsh completion output

USAGE:
   source <(temporal completion zsh)

OPTIONS:
   --help, -h  show help (default: false)

```

## Why?
<!-- Tell your future self why have you made these changes -->

Helps user with finding out how to enable completion

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

executed `source <(temporal completion zsh)` and tried completion `temporal workfl` + Tab

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
