### PR TITLE
Rename release archives to temporal_cli_...

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ archives:
   - id: default
     builds:
       - temporal
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "temporal_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed release archives from ~ `cli_0.2.0_linux_amd64.tar.gz` to `temporal_cli_0.2.0_linux_amd64.tar.gz` 

## Why?
<!-- Tell your future self why have you made these changes -->

clear naming

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Ran locally

```
goreleaser release --skip-validate --skip-publish
...
Creating                                       archive=dist/temporal_cli_0.2.0_linux_amd64.tar.gz
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
