### PR TITLE
Remove register alias for namespace create

### DIFF
--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -34,7 +34,6 @@ func NewNamespaceCommands() []*cli.Command {
 		},
 		{
 			Name:      "create",
-			Aliases:   []string{"register"},
 			Usage:     "Register a new Namespace",
 			Flags:     createNamespaceFlags,
 			ArgsUsage: "namespace_name [cluster_name...]",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Kept `temporal operator namespace create` and removed its alias `register`

## Why?
<!-- Tell your future self why have you made these changes -->

No reason for backwards compatibility since the entire `temporal operator` entry is new

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
