### PR TITLE
Add generated docs as release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod download
+    - go run ./cmd/docgen
 
 archives:
   - id: temporal
@@ -12,30 +13,16 @@ archives:
         format: zip
 
   - id: temporal-doc-gen
-    builds:
-      - temporal-doc-gen
-    name_template: "temporal_cli_doc_gen_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        format: zip
+    builds: []
+    name_template: "temporal_cli_documentation_{{ .Version }}"
+    wrap_in_directory: false
+    files:
+      - docs/*
 
 builds:
   - id: temporal
     dir: cmd/temporal
     binary: temporal
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-      - arm64
-
-  - id: temporal-doc-gen
-    dir: cmd/docgen
-    binary: temporal-doc-gen
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Added generated docs to release artifacts
- Removed doc gen tool from release artifacts

## Why?
<!-- Tell your future self why have you made these changes -->

- Simpler to consume the docs since they are pre-built
- Fewer release artifacts, only a single archive for the docs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

ran locally with `goreleaser --skip-publish --snapshot --rm-dist`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
