### PR TITLE
CLI --help Corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ To compile the source run:
 go build -o dist/temporal ./cmd/temporal
 ```
 
+To compile the documentation, run:
+
+```bash
+go build -o dist/temporal-docgen ./cmd/temporal-docgen
+```
+
 To run all tests:
 
 ```bash

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -28,7 +28,7 @@ func NewActivityCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagActivityID,
-					Usage:    common.FlagActivityCompleteDefinition,
+					Usage:    common.FlagActivityIDDefinition,
 					Required: true,
 					Category: common.CategoryMain,
 				},
@@ -70,7 +70,7 @@ func NewActivityCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagActivityID,
-					Usage:    common.FlagActivityFailDefinition,
+					Usage:    common.FlagActivityIDDefinition,
 					Required: true,
 					Category: common.CategoryMain,
 				},

--- a/app/app.go
+++ b/app/app.go
@@ -89,6 +89,7 @@ func serverCommands(defaultCfg *sconfig.Config) []*cli.Command {
 		{
 			Name:        "server",
 			Usage:       "Commands for managing the Temporal Server.",
+			UsageText:   common.ServerUsageText,
 			Subcommands: server.NewServerCommands(defaultCfg),
 		},
 	}
@@ -133,16 +134,19 @@ var clientCommands = []*cli.Command{
 			{
 				Name:        "namespace",
 				Usage:       common.NamespaceDefinition,
+				UsageText:   common.NamespaceUsageText,
 				Subcommands: namespace.NewNamespaceCommands(),
 			},
 			{
 				Name:        "search-attribute",
 				Usage:       common.SearchAttributeDefinition,
+				UsageText:   common.SearchAttributeUsageText,
 				Subcommands: searchattribute.NewSearchAttributeCommands(),
 			},
 			{
 				Name:        "cluster",
 				Usage:       common.ClusterDefinition,
+				UsageText:   common.ClusterUsageText,
 				Subcommands: cluster.NewClusterCommands(),
 			},
 		},

--- a/app/app.go
+++ b/app/app.go
@@ -98,16 +98,19 @@ var clientCommands = []*cli.Command{
 	{
 		Name:        "workflow",
 		Usage:       common.WorkflowDefinition,
+		UsageText:   common.WorkflowUsageText,	
 		Subcommands: workflow.NewWorkflowCommands(),
 	},
 	{
 		Name:        "activity",
 		Usage:       common.ActivityDefinition,
+		UsageText: 	 common.ActivityUsageText,
 		Subcommands: activity.NewActivityCommands(),
 	},
 	{
 		Name:        "task-queue",
 		Usage:       common.TaskQueueDefinition,
+		UsageText: common.TaskQueueUsageText,
 		Subcommands: taskqueue.NewTaskQueueCommands(),
 	},
 	{
@@ -147,6 +150,7 @@ var clientCommands = []*cli.Command{
 	{
 		Name:        "env",
 		Usage:       common.EnvDefinition,
+		UsageText: common.EnvUsageText,
 		Subcommands: env.NewEnvCommands(),
 	},
 }

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -46,7 +46,7 @@ func NewBatchCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonBatchDefinition,
+					Usage:    common.FlagReasonDefinition,
 					Required: true,
 					Category: common.CategoryMain,
 				},

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -27,7 +27,6 @@ description: {{.Description}}
 tags:
 	- cli
 ---
-
 `
 
 type FrontMatter struct {
@@ -70,20 +69,24 @@ func main() {
 			currentHeader = strings.TrimSpace(line[2:])
 			path = filepath.Join(docsPath, currentHeader)
 			makeFile(path, true, false, scanner, createdFiles)
+			
 		} else if strings.HasPrefix(line, "### ") {
 			fileName = strings.TrimSpace(line[3:])
 			path = filepath.Join(docsPath, currentHeader)
 			if strings.Contains(currentHeader, "operator") {
 				opPath := filepath.Join(path, fileName)
 				makeFile(opPath, true, false, scanner, createdFiles)
+				
 			} else {
 				filePath := filepath.Join(path, fileName+".md")
 				makeFile(filePath, false, false, scanner, createdFiles)
+				
 			}
 		} else if strings.HasPrefix(line, "#### ") {
 			operatorFileName = strings.TrimSpace(line[4:])
 			filePath := filepath.Join(path, fileName, operatorFileName+".md")
 			makeFile(filePath, false, false, scanner, createdFiles)
+			
 
 		} else if strings.HasPrefix(line, "**--") {
 			// split into term and definition
@@ -112,9 +115,13 @@ func main() {
 				aliasName = ""
 			}
 			writeLine(currentOptionFile, strings.TrimSpace(definition))
+			// write additional definition info to file
+			
+
 
 		} else if strings.Contains(line, ">") {
 			writeLine(currentHeaderFile, strings.Trim(line, ">"))
+			
 		} else {
 			writeLine(currentHeaderFile, strings.TrimSpace(line))
 		}
@@ -162,6 +169,7 @@ func makeFile(path string, isIndex bool, isOptions bool, scanner *bufio.Scanner,
 		}
 		if strings.Contains(path, "operator") {
 			writeFrontMatter(operatorFileName, currentHeader, scanner, false, currentHeaderFile)
+			return
 		}
 		writeFrontMatter(fileName, currentHeader, scanner, false, currentHeaderFile)
 	}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -95,7 +95,6 @@ func main() {
 				optionFileName = term
 			}
 			log.Printf("string split successfully into term and definition (%v)", found)
-			definitionArray := strings.Split(definition, "\n")
 
 			optionFileName = strings.TrimPrefix(optionFileName, "**--")
 			optionFileName = strings.TrimSuffix(optionFileName, "**")
@@ -110,14 +109,15 @@ func main() {
 				writeLine(currentOptionFile, aliasArray[0])
 				aliasName = ""
 			}
-			for i := 0; i < len(definitionArray); i++ {
-				writeLine(currentOptionFile,definitionArray[i])
-			}
-
+			writeLine(currentOptionFile, definition)
 		} else if strings.Contains(line, ">") {
 			writeLine(currentHeaderFile, strings.Trim(line, ">"))
 		}  else {
+			if(createdFiles[path] == currentOptionFile) {
+				writeLine(currentOptionFile, strings.TrimSpace(line))
+			} else {
 			writeLine(currentHeaderFile, strings.TrimSpace(line))
+			}
 		}
 	}
 	// close file descriptor after for loop has completed

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -116,7 +116,7 @@ func main() {
 		} else if strings.Contains(line, ">") {
 			writeLine(currentHeaderFile, strings.Trim(line, ">"))
 		}  else {
-			if(createdFiles[path] == currentOptionFile) {
+			if(createdFiles[path] == currentOptionFile) || strings.Contains(line, "┌") || strings.Contains(line , "|") {
 				writeLine(currentOptionFile, strings.TrimSpace(line))
 			} else {
 				writeLine(currentHeaderFile, strings.TrimSpace(line))

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -109,14 +109,17 @@ func main() {
 				writeLine(currentOptionFile, aliasArray[0])
 				aliasName = ""
 			}
-			writeLine(currentOptionFile, definition)
+
+			writeLine(currentOptionFile, strings.TrimSpace(definition))
+			
+			
 		} else if strings.Contains(line, ">") {
 			writeLine(currentHeaderFile, strings.Trim(line, ">"))
 		}  else {
 			if(createdFiles[path] == currentOptionFile) {
 				writeLine(currentOptionFile, strings.TrimSpace(line))
 			} else {
-			writeLine(currentHeaderFile, strings.TrimSpace(line))
+				writeLine(currentHeaderFile, strings.TrimSpace(line))
 			}
 		}
 	}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -95,7 +95,7 @@ func main() {
 				optionFileName = term
 			}
 			log.Printf("string split successfully into term and definition (%v)", found)
-			definitionArray := strings.Split(definition, "\n\t")
+			definitionArray := strings.Split(definition, "\n")
 
 			optionFileName = strings.TrimPrefix(optionFileName, "**--")
 			optionFileName = strings.TrimSuffix(optionFileName, "**")
@@ -111,7 +111,7 @@ func main() {
 				aliasName = ""
 			}
 			for i := 0; i < len(definitionArray); i++ {
-				writeLine(currentOptionFile, strings.TrimSpace(definitionArray[i]))
+				writeLine(currentOptionFile,definitionArray[i])
 			}
 
 		} else if strings.Contains(line, ">") {
@@ -191,9 +191,6 @@ func writeFrontMatter(idName string, titleName string, scanner *bufio.Scanner, i
 		descriptionTxt = strings.TrimSpace(scanner.Text())
 	} else {
 		descriptionTxt = "Definition for the " + idName + " command option."
-	}
-	if strings.Contains(titleName, "operator") {
-		
 	}
 
 	data := FrontMatter{

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -248,6 +248,8 @@ Make sure to write the command as follows:
 `+"`"+`temporal operator cluster health [command options] [arguments]`+"`"+`
 
 `
+const ClusterUsageText = `Cluster commands enabled operations on [Temporal Clusters](/concepts/what-is-a-cluster).`
+
 const ClusterDescribeUsageText = `The `+"`"+`temporal operator cluster describe`+"`"+` command shows information about the [Cluster](/concepts/what-is-a-temporal-cluster).
 
 Use the options listed below to change the output of this command.
@@ -309,6 +311,8 @@ Make sure to write the command as follows:
 `+"`"+`temporal env delete [command options] [arguments]`+"`"+`
 
 `
+const NamespaceUsageText = `Namespace commands allow [Namespace](/concepts/what-is-a-namespace) oeprations to be performed on the [Temporal Cluster](/concepts/what-is-a-cluster).
+`
 const NamespaceDescribeUsageText = `The `+"`"+`temporal operator namespace describe`+"`"+` command provides a description of a [Namespace](/concepts/what-is-a-namespace).
 Namespaces can be identified by name or Namespace ID.
 
@@ -345,6 +349,7 @@ Make sure to write the command as follows:
 `+"`"+`temporal operator namespace delete [command options] [arguments]`+"`"+`
 
 `
+
 const ScheduleCreateUsageText = `The `+"`"+`temporal schedule create`+"`"+` command creates a new [Schedule](/concepts/what-is-a-schedule).
 Newly created Schedules return a Schedule ID to be used in other Schedule commands.
 
@@ -449,6 +454,7 @@ Listing Schedules in [Standard Visibility](/concepts/what-is-standard-visibility
 Use the options below to change the behavior of this command.
 
 `
+const SearchAttributeUsageText = `Search Attribute commands enable operations for the creation, listing, and removal of [Search Attributes](/concepts/what-is-a-search-attribute).`
 const SearchAttributeCreateUsageText = `The `+"`"+`temporal operator search-attribute create`+"`"+` command adds one or more custom [Search Attributes](/concepts/what-is-a-search-attribute).
 These Search Attributes can be used to [filter a list](/concepts/whaat-is-a-list-filter) of [Workflow Executions](/concepts/what-is-a-workflow-execution) that contain the given Search Attributes in their metadata.
 
@@ -524,4 +530,13 @@ Use the options listed below to change the command's behavior.
 Make sure to write the command as follows:
 `+"`"+`temporal workflow trace [command options] [arguments]`+"`"+`
 
+`
+
+const ServerUsageText = `Server commands allow you to start and manage the [Temporal Server](/concepts/what-is-a-temporal-server) from the command line.
+
+Currently, `+"`"+`cli`+"`"+` server functionality extends to starting the Server. 
+`
+
+const StartDevUsageText = `The `+"`"+`temporal server start-dev`+"`"+` command starts the Temporal Server on `+"`"+`localhost:7233`+"`"+`.
+The results of any command run on the Server can be viewed at http://localhost:7233.
 `

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -200,7 +200,7 @@ Make sure to write the command as follows:
 `+"`"+`temporal workflow reset-batch [command options] [arguments]`+"`"+`
 
 `
-const TaskQueueUsageText = `Task Queue commands allow operations to be performed on [Task Queues](concepts/what-is-a-task-queue).
+const TaskQueueUsageText = `Task Queue commands allow operations to be performed on [Task Queues](/concepts/what-is-a-task-queue).
 `
 
 const DescribeTaskQueueUsageText = `The `+"`"+`temporal task-queue describe`+"`"+` command provides [poller](/application-development/worker-performance#poller-count) information for a given [Task Queue](/concepts/what-is-a-task-queue).

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -117,6 +117,9 @@ Make sure to write the command as follows:
 `+"`"+`temporal batch terminate [command options] [arguments]`+"`"+`
 
 `
+const WorkflowUsageText = `Workflow commands allow operations to be performed on [Workflow Executions](/concepts/what-is-a-workflow-execution).
+`
+
 const StartWorkflowUsageText = `The `+"`"+`temporal workflow start`+"`"+` command starts a new [Workflow Execution](/concepts/what-is-a-workflow-execution).
 When invoked successfully, the Workflow and Run ID are returned immediately after starting the [Workflow](/concepts/what-is-a-workflow).
 
@@ -197,6 +200,9 @@ Make sure to write the command as follows:
 `+"`"+`temporal workflow reset-batch [command options] [arguments]`+"`"+`
 
 `
+const TaskQueueUsageText = `Task Queue commands allow operations to be performed on [Task Queues](concepts/what-is-a-task-queue).
+`
+
 const DescribeTaskQueueUsageText = `The `+"`"+`temporal task-queue describe`+"`"+` command provides [poller](/application-development/worker-performance#poller-count) information for a given [Task Queue](/concepts/what-is-a-task-queue).
 
 The [Server](/concepts/what-is-the-temporal-server) records the last time of each poll request.
@@ -217,6 +223,9 @@ const OperatorUsageText = `Operator commands enable actions on [Namespaces](/con
 These actions are performed through subcommands for each Operator area.
 
 To run an Operator command, run `+"`"+`temporal operator [command] [subcommand] [command options] [arguments]`+"`"+`.
+`
+
+const ActivityUsageText = `Activity commands enable operations on [Activity Executions](/concepts/what-is-an-activity-execution).
 `
 const CompleteActivityUsageText = `The `+"`"+`temporal activity complete`+"`"+` command completes an [Activity Execution](/concepts/what-is-an-activity-execution).
 
@@ -273,6 +282,10 @@ const ClusterRemoveUsageText = `The `+"`"+`temporal operator cluster remove`+"`"
 Use the options listed below to change the command's behavior.
 Make sure to write the command as follows:
 `+"`"+`temporal operator cluster remove [command options] [arguments]`+"`"+`
+
+`
+
+const EnvUsageText = `Environment (or 'env') commands allow the user to configure the properties for the environment in use.
 
 `
 const EnvGetUsageText = `The `+"`"+`temporal env get`+"`"+` command prints the environmental properties for the environment in use.

--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -57,19 +57,14 @@ const (
 	FlagSignalName = "Signal Name"
 	FlagInputSignal = "Input for the Signal (JSON)."
 	FlagInputFileSignal = "Input for the Signal from file (JSON)."
-	FlagReasonSignal = "Reason for signaling with List Filter."
 	FlagCancelWorkflow = "Cancel Workflow Execution by Id."
-	FlagReasonCancel = "Reason for canceling with List Filter."
 	FlagWorkflowIDTerminate = "Terminate Workflow Execution by Id."
 	FlagQueryTerminate = "Terminate Workflow Executions by List Filter. See https://docs.temporal.io/concepts/what-is-a-list-filter/."
-	FlagReasonTerminate = "Reason for termination."
 	FlagEventIDDefinition = "The Event Id for any Event after WorkflowTaskStarted you want to reset to (exclusive).\nIt can be WorkflowTaskCompleted, WorkflowTaskFailed or others."
-	FlagReasonReset = "Reason to reset."
 	FlagQueryResetBatch = "Visibility Query of Search Attributes describing the Workflow Executions to reset. See https://docs.temporal.io/docs/tctl/workflow/list#--query."
 	FlagInputFileReset = "Input file that specifies Workflow Executions to reset.\nEach line contains one Workflow Id as the base Run and, optionally, a Run Id."
 	FlagExcludeFileDefinition = "Input file that specifies Workflow Executions to exclude from resetting."
 	FlagInputSeparatorDefinition = "Separator for the input file.\nThe default is a tab (\t)."
-	FlagReasonResetBatch = "Reason for resetting the Workflow Executions."
 	FlagParallelismDefinition = "Number of goroutines to run in parallel.\nEach goroutine processes one line for every second."
 	FlagSkipCurrentOpenDefinition = "Skip a Workflow Execution if the current Run is open for the same Workflow Id as the base Run."
 	FlagSkipBaseDefinition =  "Skip a Workflow Execution if the base Run is not the current Run."
@@ -94,15 +89,13 @@ const (
 	// Activity flag definitions
 	FlagWorkflowIDDefinition = "Identifies the Workflow that the Activity is running on."
 	FlagRunIDDefinition = "Identifies the current Workflow Run."
-	FlagActivityCompleteDefinition = "Identifies the Activity to be completed."
+	FlagActivityIDDefinition = "Identifies the Activity Execution."
 	FlagResultDefinition = "Set the result value of Activity completion."
 	FlagIdentityDefinition = "Specify operator's identity."
-	FlagActivityFailDefinition = "Identifies the Activity to fail."
-	FlagReasonDefinition = "Reason to fail the Activity."
+
 	FlagDetailDefinition = "Detail to fail the Activity."
 
-	// Batch flag definitions
-	FlagReasonBatchDefinition = "Reason to stop the Batch job."
+	FlagReasonDefinition = "Reason to perform a given operation on the Cluster."
 
 	// Cluster flag definition
 	FlagClusterAddressDefinition = "Frontend address of the remote Cluster."
@@ -111,8 +104,7 @@ const (
 
 	// Schedule flag definition
 	FlagOverlapPolicyDefinition = "Overlap policy: Skip, BufferOne, BufferAll, CancelOther, TerminateOther, AllowAll."
-	FlagCalenderDefinition = `Calendar specification in JSON, e.g. {"dayOfWeek":"Fri","hour":"17","minute":"5"}`
-	FlagCronScheduleShortDefinition = `Calendar specification as cron string, e.g. "30 2 * * 5" or "@daily".`
+	FlagCalenderDefinition = `Calendar specification in JSON ({"dayOfWeek":"Fri","hour":"17","minute":"5"}) or as a Cron string ("30 2 * * 5" or "@daily").`
 	FlagIntervalDefinition = "Interval duration, e.g. 90m, or 90m/13m to include phase offset."
 	FlagStartTimeDefinition = "Overall schedule start time."
 	FlagEndTimeDefinition = "Overall schedule end time."
@@ -128,7 +120,6 @@ const (
 	FlagMemoFileScheduleDefinition = "Set a memo from a file. Each line should follow the format key=value. Use valid JSON formats for value."
 	FlagPauseScheduleDefinition = "Pauses the Schedule."
 	FlagUnpauseDefinition = "Unpauses the Schedule."
-	FlagReasonScheduleDefinition = "Free-form text to describe reason for pause/unpause."
 	FlagBackfillStartTime = "Backfill start time."
 	FlagBackfillEndTime = "Backfill end time."
 	FlagPrintRawDefinition = "Print raw data as json (prefer this over -o json for scripting)."

--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -41,15 +41,12 @@ const (
 	"\t│ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday) \n" +
 	"\t│ │ │ │ │ \n" +
 	"\t* * * * *"
-	FlagWorkflowIdReusePolicyDefinition = "Allows the same Workflow Id to be used in a new Workflow Execution. " +
-	"Options: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning."
+	FlagWorkflowIdReusePolicyDefinition = "Allows the same Workflow Id to be used in a new Workflow Execution.\nOptions: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning."
 	FlagInputDefinition = "Optional JSON input to provide to the Workflow.\nPass \"null\" for null values."
-	FlagInputFileDefinition = "Passes optional input for the Workflow from a JSON file.\n" +
-	"If there are multiple JSON files, concatenate them and separate by space or newline.\n" +
-	"Input from the command line will overwrite file input."
-	FlagSearchAttributeDefinition = "Passes Search Attribute in key=value format. Use valid JSON formats for value."
-	FlagMemoDefinition = "Passes a memo in key=value format. Use valid JSON formats for value."
-	FlagMemoFileDefinition = "Passes a memo as file input, with each line following key=value format. Use valid JSON formats for value."
+	FlagInputFileDefinition = "Passes optional input for the Workflow from a JSON file.\nIf there are multiple JSON files, concatenate them and separate by space or newline.\nInput from the command line will overwrite file input."
+	FlagSearchAttributeDefinition = "Passes Search Attribute in key=value format.\nUse valid JSON formats for value."
+	FlagMemoDefinition = "Passes a memo in key=value format.\nUse valid JSON formats for value."
+	FlagMemoFileDefinition = "Passes a memo as file input, with each line following key=value format.\nUse valid JSON formats for value."
 
 	// Other Workflow flags
 	FlagResetPointsUsage = "Only show auto-reset points."
@@ -66,14 +63,14 @@ const (
 	FlagWorkflowIDTerminate = "Terminate Workflow Execution by Id."
 	FlagQueryTerminate = "Terminate Workflow Executions by List Filter. See https://docs.temporal.io/concepts/what-is-a-list-filter/."
 	FlagReasonTerminate = "Reason for termination."
-	FlagEventIDDefinition = "The Event Id for any Event after WorkflowTaskStarted you want to reset to (exclusive). It can be WorkflowTaskCompleted, WorkflowTaskFailed or others."
+	FlagEventIDDefinition = "The Event Id for any Event after WorkflowTaskStarted you want to reset to (exclusive).\nIt can be WorkflowTaskCompleted, WorkflowTaskFailed or others."
 	FlagReasonReset = "Reason to reset."
 	FlagQueryResetBatch = "Visibility Query of Search Attributes describing the Workflow Executions to reset. See https://docs.temporal.io/docs/tctl/workflow/list#--query."
-	FlagInputFileReset = "Input file that specifies Workflow Executions to reset. Each line contains one Workflow Id as the base Run and, optionally, a Run Id."
+	FlagInputFileReset = "Input file that specifies Workflow Executions to reset.\nEach line contains one Workflow Id as the base Run and, optionally, a Run Id."
 	FlagExcludeFileDefinition = "Input file that specifies Workflow Executions to exclude from resetting."
-	FlagInputSeparatorDefinition = "Separator for the input file. The default is a tab (\t)."
+	FlagInputSeparatorDefinition = "Separator for the input file.\nThe default is a tab (\t)."
 	FlagReasonResetBatch = "Reason for resetting the Workflow Executions."
-	FlagParallelismDefinition = "Number of goroutines to run in parallel. Each goroutine processes one line for every second."
+	FlagParallelismDefinition = "Number of goroutines to run in parallel.\nEach goroutine processes one line for every second."
 	FlagSkipCurrentOpenDefinition = "Skip a Workflow Execution if the current Run is open for the same Workflow Id as the base Run."
 	FlagSkipBaseDefinition =  "Skip a Workflow Execution if the base Run is not the current Run."
 	FlagNonDeterministicDefinition = "Reset Workflow Execution only if its last Event is WorkflowTaskFailed with a nondeterministic error."
@@ -84,7 +81,7 @@ const (
 
 
 	// Stack trace query flag definitions
-	FlagInputSTQDefinition = "Optional Query input, in JSON format. For multiple parameters, concatenate them and separate by space."
+	FlagInputSTQDefinition = "Optional Query input, in JSON format.\nFor multiple parameters, concatenate them and separate by space."
 	FlagInputFileSTQDefinition = "Passes optional Query input from a JSON file.\nIf there are multiple JSON, concatenate them and separate by space or newline.\n" + "Input from the command line will overwrite file input."
 	FlagQueryRejectConditionDefinition = "Optional flag for rejecting Queries based on Workflow state. Valid values are \"not_open\" and \"not_completed_cleanly\"."
 

--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -41,12 +41,12 @@ const (
 	"\t│ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday) \n" +
 	"\t│ │ │ │ │ \n" +
 	"\t* * * * *"
-	FlagWorkflowIdReusePolicyDefinition = "Allows the same Workflow Id to be used in a new Workflow Execution.\nOptions: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning."
-	FlagInputDefinition = "Optional JSON input to provide to the Workflow.\nPass \"null\" for null values."
-	FlagInputFileDefinition = "Passes optional input for the Workflow from a JSON file.\nIf there are multiple JSON files, concatenate them and separate by space or newline.\nInput from the command line will overwrite file input."
-	FlagSearchAttributeDefinition = "Passes Search Attribute in key=value format.\nUse valid JSON formats for value."
+	FlagWorkflowIdReusePolicyDefinition = "Allows the same Workflow Id to be used in a new Workflow Execution. Options: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning."
+	FlagInputDefinition = "Optional JSON input to provide to the Workflow. Pass \"null\" for null values."
+	FlagInputFileDefinition = "Passes optional input for the Workflow from a JSON file. If there are multiple JSON files, concatenate them and separate by space or newline. Input from the command line will overwrite file input."
+	FlagSearchAttributeDefinition = "Passes Search Attribute in key=value format. Use valid JSON formats for value."
 	FlagMemoDefinition = "Passes a memo in key=value format.\nUse valid JSON formats for value."
-	FlagMemoFileDefinition = "Passes a memo as file input, with each line following key=value format.\nUse valid JSON formats for value."
+	FlagMemoFileDefinition = "Passes a memo as file input, with each line following key=value format. Use valid JSON formats for value."
 
 	// Other Workflow flags
 	FlagResetPointsUsage = "Only show auto-reset points."
@@ -60,12 +60,12 @@ const (
 	FlagCancelWorkflow = "Cancel Workflow Execution by Id."
 	FlagWorkflowIDTerminate = "Terminate Workflow Execution by Id."
 	FlagQueryTerminate = "Terminate Workflow Executions by List Filter. See https://docs.temporal.io/concepts/what-is-a-list-filter/."
-	FlagEventIDDefinition = "The Event Id for any Event after WorkflowTaskStarted you want to reset to (exclusive).\nIt can be WorkflowTaskCompleted, WorkflowTaskFailed or others."
+	FlagEventIDDefinition = "The Event Id for any Event after WorkflowTaskStarted you want to reset to (exclusive). It can be WorkflowTaskCompleted, WorkflowTaskFailed or others."
 	FlagQueryResetBatch = "Visibility Query of Search Attributes describing the Workflow Executions to reset. See https://docs.temporal.io/docs/tctl/workflow/list#--query."
-	FlagInputFileReset = "Input file that specifies Workflow Executions to reset.\nEach line contains one Workflow Id as the base Run and, optionally, a Run Id."
+	FlagInputFileReset = "Input file that specifies Workflow Executions to reset. Each line contains one Workflow Id as the base Run and, optionally, a Run Id."
 	FlagExcludeFileDefinition = "Input file that specifies Workflow Executions to exclude from resetting."
-	FlagInputSeparatorDefinition = "Separator for the input file.\nThe default is a tab (\t)."
-	FlagParallelismDefinition = "Number of goroutines to run in parallel.\nEach goroutine processes one line for every second."
+	FlagInputSeparatorDefinition = "Separator for the input file. The default is a tab (\t)."
+	FlagParallelismDefinition = "Number of goroutines to run in parallel. Each goroutine processes one line for every second."
 	FlagSkipCurrentOpenDefinition = "Skip a Workflow Execution if the current Run is open for the same Workflow Id as the base Run."
 	FlagSkipBaseDefinition =  "Skip a Workflow Execution if the base Run is not the current Run."
 	FlagNonDeterministicDefinition = "Reset Workflow Execution only if its last Event is WorkflowTaskFailed with a nondeterministic error."
@@ -82,7 +82,7 @@ const (
 
 	// Pagination flag definitions
 	FlagLimitDefinition = "Number of items to print."
-	FlagPagerDefinition = "Sets the pager for Temporal CLI to use.\nOptions: less, more, favoritePager."
+	FlagPagerDefinition = "Sets the pager for Temporal CLI to use. Options: less, more, favoritePager."
 	FlagNoPagerDefinition = "Disables the interactive pager."
 	FlagFieldsDefinition = "Customize fields to print. Set to 'long' to automatically print more of main fields."
 

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -28,7 +28,7 @@ func NewScheduleCommands() []*cli.Command {
 		},
 		&cli.StringSliceFlag{
 			Name:     common.FlagCronSchedule,
-			Usage:    common.FlagCronScheduleShortDefinition,
+			Usage:    common.FlagCronScheduleDefinition,
 			Category: common.CategoryMain,
 		},
 		&cli.StringSliceFlag{
@@ -157,7 +157,7 @@ func NewScheduleCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonScheduleDefinition,
+					Usage:    common.FlagReasonDefinition,
 					Value:    "(no reason provided)",
 					Category: common.CategoryMain,
 				},

--- a/server/commands.go
+++ b/server/commands.go
@@ -53,6 +53,7 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 		{
 			Name:      "start-dev",
 			Usage:     "Start Temporal development server.",
+			UsageText: common.StartDevUsageText,
 			ArgsUsage: " ",
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -133,7 +133,7 @@ func NewWorkflowCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonSignal,
+					Usage:    common.FlagReasonDefinition,
 					Category: common.CategoryMain,
 				},
 				&cli.BoolFlag{
@@ -188,7 +188,7 @@ func NewWorkflowCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonCancel,
+					Usage:    common.FlagReasonDefinition,
 					Category: common.CategoryMain,
 				},
 				&cli.BoolFlag{
@@ -227,7 +227,7 @@ func NewWorkflowCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonTerminate,
+					Usage:    common.FlagReasonDefinition,
 					Category: common.CategoryMain,
 				},
 				&cli.BoolFlag{
@@ -262,7 +262,7 @@ func NewWorkflowCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonReset,
+					Usage:    common.FlagReasonDefinition,
 					Required: true,
 					Category: common.CategoryMain,
 				},
@@ -311,7 +311,7 @@ func NewWorkflowCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     common.FlagReason,
-					Usage:    common.FlagReasonResetBatch,
+					Usage:    common.FlagReasonDefinition,
 					Required: true,
 					Category: common.CategoryMain,
 				},


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Corrections to the CLI text were made.

## Why?
Duplicate front matter was being generated in some files. Index files had no body text.

## Checklist

- [x] Index files
- [x] Front matter duping
- [x] cmd-option duplication/possible overwrite

How was this tested:
Ran 'go run ./cmd/docgen'
Check the following files:
- anything under the 'operator' directory
- index files
- workflow create
- cmd-options/ memo, cron, input-file

Any docs updates needed?
Yes. Docs will be notified, since we're trying to integrate this right now.
