### PR TITLE
Fix --grpc-meta for direct rpcs

### DIFF
--- a/client/factory.go
+++ b/client/factory.go
@@ -191,6 +191,7 @@ func (b *clientFactory) createGRPCConnection(c *cli.Context) (*grpc.ClientConn, 
 
 	interceptors := []grpc.UnaryClientInterceptor{
 		errorInterceptor(),
+		headersProviderInterceptor(headersprovider.GetCurrent()),
 	}
 
 	dialOpts := []grpc.DialOption{


### PR DESCRIPTION
## What was changed
Actually include headers interceptor

## Why?
So `--grpc-meta` works on direct rpcs, outside sdk

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
manually

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
