### PR TITLE
Make workflow show output json usable for replay

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -169,7 +169,7 @@ func GetCurrentUserFromEnv() string {
 	return "unknown"
 }
 
-func PrettyPrintJSONObject(o interface{}) {
+func PrettyPrintJSONObject(c *cli.Context, o interface{}) {
 	var b []byte
 	var err error
 	if pb, ok := o.(proto.Message); ok {
@@ -179,12 +179,15 @@ func PrettyPrintJSONObject(o interface{}) {
 		b, err = json.MarshalIndent(o, "", "  ")
 	}
 
+	w := c.App.Writer
+
 	if err != nil {
-		fmt.Printf("Error when try to print pretty: %v", err)
-		fmt.Println(o)
+		fmt.Fprintf(w, "Error when try to print pretty: %v", err)
+		fmt.Fprintln(w, o)
 	}
-	_, _ = os.Stdout.Write(b)
-	fmt.Println()
+
+	_, _ = w.Write(b)
+	fmt.Fprintln(w)
 }
 
 func RequiredFlag(c *cli.Context, optionName string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.2
-	github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727
+	github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0
 	github.com/temporalio/ui-server/v2 v2.13.0
 	github.com/urfave/cli/v2 v2.23.6
 	go.temporal.io/api v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -812,8 +812,8 @@ github.com/temporalio/ringpop-go v0.0.0-20220818230611-30bf23b490b2 h1:QIwUh2HCt
 github.com/temporalio/ringpop-go v0.0.0-20220818230611-30bf23b490b2/go.mod h1:ZEYrWwPO7607ZEaPzK7nWRv55cIrTtH4TeBBu3V532U=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b h1:Fs3LdlF7xbnOWHymbFmvIEuxIEt1dNRCfaDkoajSaZk=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
-github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727 h1:Yrisr5sO+sPzc2ATX4LS8K7iM1L1ww71RIbZk8N240Q=
-github.com/temporalio/tctl-kit v0.0.0-20230104170414-10932650d727/go.mod h1:hk/LJCKZNNmtVSWRKepbdUJme+k/4fb/hPkekXk40sk=
+github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0 h1:E1iAre7/4VvSJri8uOnItKVsMKnP+WEQourm+zVO0cc=
+github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0/go.mod h1:hk/LJCKZNNmtVSWRKepbdUJme+k/4fb/hPkekXk40sk=
 github.com/temporalio/ui-server/v2 v2.13.0 h1:aKurAPeskgkLYG+1GLm2Cb/1qkoL5wg0gjc776FhRw0=
 github.com/temporalio/ui-server/v2 v2.13.0/go.mod h1:8yI8soutsbGEKyOblUZeuo1CPgl4U43+yVYnUrIiNto=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/schedule/schedule_commands.go
+++ b/schedule/schedule_commands.go
@@ -16,7 +16,6 @@ import (
 	"github.com/temporalio/tctl-kit/pkg/output"
 	"github.com/temporalio/tctl-kit/pkg/pager"
 	"github.com/urfave/cli/v2"
-	apicommon "go.temporal.io/api/common/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
@@ -132,7 +131,7 @@ func buildScheduleAction(c *cli.Context) (*schedpb.ScheduleAction, error) {
 
 	newWorkflow := &workflowpb.NewWorkflowExecutionInfo{
 		WorkflowId:               wid,
-		WorkflowType:             &apicommon.WorkflowType{Name: workflowType},
+		WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
 		TaskQueue:                &taskqueue.TaskQueue{Name: taskQueue},
 		Input:                    inputs,
 		WorkflowExecutionTimeout: timestamp.DurationPtr(time.Second * time.Duration(et)),
@@ -202,7 +201,7 @@ func buildSchedule(c *cli.Context) (*schedpb.Schedule, error) {
 	return sched, nil
 }
 
-func getMemoAndSearchAttributesForSchedule(c *cli.Context) (*apicommon.Memo, *apicommon.SearchAttributes, error) {
+func getMemoAndSearchAttributesForSchedule(c *cli.Context) (*commonpb.Memo, *commonpb.SearchAttributes, error) {
 	if memoMap, err := workflow.UnmarshalMemoFromCLI(c); err != nil {
 		return nil, nil, err
 	} else if memo, err := encodeMemo(memoMap); err != nil {
@@ -416,7 +415,7 @@ func DescribeSchedule(c *cli.Context) error {
 	}
 
 	if c.Bool(common.FlagPrintRaw) {
-		common.PrettyPrintJSONObject(resp)
+		common.PrettyPrintJSONObject(c, resp)
 		return nil
 	}
 
@@ -446,7 +445,7 @@ func DescribeSchedule(c *cli.Context) error {
 		// more convenient copies of values from Info
 		NextRunTime       *time.Time
 		LastRunTime       *time.Time
-		LastRunExecution  *apicommon.WorkflowExecution
+		LastRunExecution  *commonpb.WorkflowExecution
 		LastRunActualTime *time.Time
 
 		Memo             map[string]string // json only
@@ -577,7 +576,7 @@ func ListSchedules(c *cli.Context) error {
 				Info struct {
 					NextRunTime       *time.Time
 					LastRunTime       *time.Time
-					LastRunExecution  *apicommon.WorkflowExecution
+					LastRunExecution  *commonpb.WorkflowExecution
 					LastRunActualTime *time.Time
 				}
 			}

--- a/workflow/workflow_commands.go
+++ b/workflow/workflow_commands.go
@@ -303,7 +303,7 @@ func printWorkflowProgress(c *cli.Context, wid, rid string, watch bool) error {
 	go func() {
 		iter := sdkClient.GetWorkflowHistory(tcCtx, wid, rid, watch, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 		if isJSON {
-			printReplayableHistory(iter)
+			printReplayableHistory(c, iter)
 		} else {
 			hIter := &historyTableIter{iter: iter, maxFieldLength: maxFieldLength, lastEvent: &lastEvent}
 			po := &output.PrintOptions{
@@ -353,7 +353,7 @@ func printWorkflowProgress(c *cli.Context, wid, rid string, watch bool) error {
 	}
 }
 
-func printReplayableHistory(iter iterator.Iterator[*historypb.HistoryEvent]) error {
+func printReplayableHistory(c *cli.Context, iter iterator.Iterator[*historypb.HistoryEvent]) error {
 	var events []*historypb.HistoryEvent
 	for iter.HasNext() {
 		event, err := iter.Next()
@@ -367,7 +367,7 @@ func printReplayableHistory(iter iterator.Iterator[*historypb.HistoryEvent]) err
 	history := &historypb.History{}
 	history.Events = events
 
-	common.PrettyPrintJSONObject(history)
+	common.PrettyPrintJSONObject(c, history)
 
 	return nil
 }
@@ -690,9 +690,9 @@ func DescribeWorkflow(c *cli.Context) error {
 	}
 
 	if printRaw {
-		common.PrettyPrintJSONObject(resp)
+		common.PrettyPrintJSONObject(c, resp)
 	} else {
-		common.PrettyPrintJSONObject(convertDescribeWorkflowExecutionResponse(c, resp))
+		common.PrettyPrintJSONObject(c, convertDescribeWorkflowExecutionResponse(c, resp))
 	}
 
 	return nil
@@ -890,7 +890,7 @@ func ResetWorkflow(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("reset failed: %w", err)
 	}
-	common.PrettyPrintJSONObject(resp)
+	common.PrettyPrintJSONObject(c, resp)
 	return nil
 }
 

--- a/workflow/workflow_commands.go
+++ b/workflow/workflow_commands.go
@@ -364,8 +364,7 @@ func printReplayableHistory(c *cli.Context, iter iterator.Iterator[*historypb.Hi
 		events = append(events, event)
 	}
 
-	history := &historypb.History{}
-	history.Events = events
+	history := &historypb.History{Events: events}
 
 	common.PrettyPrintJSONObject(c, history)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Made `workflow show --output json` produce replayable history

Depends on https://github.com/temporalio/tctl-kit/pull/39

## Why?
<!-- Tell your future self why have you made these changes -->

Allows exporting replayable history with syntax

```
workflow show --output json -w workflow_id > ~/history.json
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

E2E test here https://github.com/temporalio/cli/pull/171


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
