### PR TITLE
Refactor release process to first build assets

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,9 +1,10 @@
 name: goreleaser
+
 on:
-  release:
-    types:
-      - released
-      - prereleased
+  push:
+    tags:
+      - "^\d+\.\d+\.\d+$"
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -40,7 +41,7 @@ jobs:
         run: echo "::set-output name=go::$(go version | cut -d ' ' -f 3)"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,35 +3,51 @@ before:
     - go mod download
     - go run ./cmd/docgen
 
-archives:
-  - id: temporal
-    builds:
-      - temporal
-    name_template: "temporal_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        format: zip
+release:
+  prerelease: auto
+  draft: false
+  name_template: "v{{.Version}}"
 
-  - id: temporal-doc-gen
-    builds: []
-    name_template: "temporal_cli_documentation_{{ .Version }}"
-    wrap_in_directory: false
+archives:
+  - <<: &archive_defaults
+      name_template: "temporal_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: nix
+    builds:
+      - nix
+    format: tar.gz
     files:
-      - docs/*
+      - LICENSE
+
+  - <<: *archive_defaults
+    id: windows
+    builds:
+      - windows
+    format: zip
+    files:
+      - LICENSE
 
 builds:
-  - id: temporal
-    dir: cmd/temporal
-    binary: temporal
-    env:
-      - CGO_ENABLED=0
+  - <<: &build_defaults
+      dir: cmd/temporal
+      binary: temporal
+      ldflags:
+        - -s -w -X github.com/temporalio/cli/headers.Version={{.Version}}
+      goarch:
+        - amd64
+        - arm64
+      env:
+        - CGO_ENABLED=0
+    id: nix
     goos:
       - linux
       - darwin
+
+  - <<: *build_defaults
+    id: windows
+    goos:
       - windows
-    goarch:
-      - amd64
-      - arm64
+    hooks:
+      post: # TODO sign Windows release
 
 checksum:
   name_template: "checksums.txt"

--- a/app/app.go
+++ b/app/app.go
@@ -27,16 +27,14 @@ import (
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite" // load sqlite storage driver
 )
 
-func BuildApp(version string) *cli.App {
+func BuildApp() *cli.App {
 	defaultCfg, _ := sconfig.NewDefaultConfig()
 
 	app := cli.NewApp()
 	app.Name = "temporal"
 	app.Usage = "Temporal command-line interface and development server"
-	if version == "" {
-		version = headers.CLIVersion
-	}
-	app.Version = fmt.Sprintf("%s (server %s) (ui %s)", version, sheaders.ServerVersion, uiversion.UIVersion)
+	app.Version = fmt.Sprintf("%s (server %s) (ui %s)", headers.Version,
+		sheaders.ServerVersion, uiversion.UIVersion)
 	app.Suggest = true
 	app.EnableBashCompletion = true
 	app.DisableSliceFlagSeparator = true
@@ -58,8 +56,9 @@ func SetFactory(factory client.ClientFactory) {
 }
 
 func configureCLI(ctx *cli.Context) error {
-	env.Build(ctx)
-	client.Build(ctx)
+	env.Init(ctx)
+	client.Init(ctx)
+	headers.Init()
 
 	return nil
 }
@@ -99,25 +98,25 @@ var clientCommands = []*cli.Command{
 	{
 		Name:        "workflow",
 		Usage:       common.WorkflowDefinition,
-		UsageText:   common.WorkflowUsageText,	
+		UsageText:   common.WorkflowUsageText,
 		Subcommands: workflow.NewWorkflowCommands(),
 	},
 	{
 		Name:        "activity",
 		Usage:       common.ActivityDefinition,
-		UsageText: 	 common.ActivityUsageText,
+		UsageText:   common.ActivityUsageText,
 		Subcommands: activity.NewActivityCommands(),
 	},
 	{
 		Name:        "task-queue",
 		Usage:       common.TaskQueueDefinition,
-		UsageText: common.TaskQueueUsageText,
+		UsageText:   common.TaskQueueUsageText,
 		Subcommands: taskqueue.NewTaskQueueCommands(),
 	},
 	{
 		Name:        "schedule",
 		Usage:       common.ScheduleDefinition,
-		UsageText: common.ScheduleUsageText,
+		UsageText:   common.ScheduleUsageText,
 		Subcommands: schedule.NewScheduleCommands(),
 	},
 	{
@@ -127,8 +126,8 @@ var clientCommands = []*cli.Command{
 		Subcommands: batch.NewBatchCommands(),
 	},
 	{
-		Name:  "operator",
-		Usage: common.OperatorDefinition,
+		Name:      "operator",
+		Usage:     common.OperatorDefinition,
 		UsageText: common.OperatorUsageText,
 		Subcommands: []*cli.Command{
 			{
@@ -154,7 +153,7 @@ var clientCommands = []*cli.Command{
 	{
 		Name:        "env",
 		Usage:       common.EnvDefinition,
-		UsageText: common.EnvUsageText,
+		UsageText:   common.EnvUsageText,
 		Subcommands: env.NewEnvCommands(),
 	},
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -81,7 +81,7 @@ func TestCLIAppSuite(t *testing.T) {
 }
 
 func (s *cliAppSuite) SetupSuite() {
-	s.app = app.BuildApp("")
+	s.app = app.BuildApp()
 }
 
 func (s *cliAppSuite) SetupTest() {
@@ -320,7 +320,7 @@ func assertServerHealth(t *testing.T, ctx context.Context, opts client.Options) 
 }
 
 func TestCreateDataDirectory_MissingDirectory(t *testing.T) {
-	temporalCLI := app.BuildApp("")
+	temporalCLI := app.BuildApp()
 	// Don't call os.Exit
 	temporalCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
 
@@ -344,7 +344,7 @@ func TestCreateDataDirectory_MissingDirectory(t *testing.T) {
 }
 
 func TestCreateDataDirectory_ExistingDirectory(t *testing.T) {
-	temporalCLI := app.BuildApp("")
+	temporalCLI := app.BuildApp()
 	// Don't call os.Exit
 	temporalCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
 

--- a/app/mtls_test.go
+++ b/app/mtls_test.go
@@ -76,7 +76,7 @@ func TestMTLSConfig(t *testing.T) {
 		"--ui-port", strconv.Itoa(webUIPort),
 	}
 	go func() {
-		temporalCLI := app.BuildApp("")
+		temporalCLI := app.BuildApp()
 		// Don't call os.Exit
 		temporalCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
 

--- a/client/factory.go
+++ b/client/factory.go
@@ -62,7 +62,7 @@ type ClientFactory interface {
 	HealthClient(c *cli.Context) healthpb.HealthClient
 }
 
-func Build(c *cli.Context) {
+func Init(c *cli.Context) {
 	for _, c := range c.App.Commands {
 		common.AddBeforeHandler(c, configureSDK)
 	}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -43,7 +43,7 @@ var currentHeaderFile, currentOptionFile *os.File
 func main() {
 	deleteExistingFolder()
 
-	doc, err := app.BuildApp("").ToMarkdown()
+	doc, err := app.BuildApp().ToMarkdown()
 	if err != nil {
 		log.Fatalf("Error when trying to build app: %s", err)
 	}
@@ -111,12 +111,10 @@ func main() {
 			}
 
 			writeLine(currentOptionFile, strings.TrimSpace(definition))
-			
-			
 		} else if strings.Contains(line, ">") {
 			writeLine(currentHeaderFile, strings.Trim(line, ">"))
-		}  else {
-			if(createdFiles[path] == currentOptionFile) || strings.Contains(line, "┌") || strings.Contains(line , "|") {
+		} else {
+			if (createdFiles[path] == currentOptionFile) || strings.Contains(line, "┌") || strings.Contains(line, "|") {
 				writeLine(currentOptionFile, strings.TrimSpace(line))
 			} else {
 				writeLine(currentHeaderFile, strings.TrimSpace(line))
@@ -156,7 +154,7 @@ func makeFile(path string, isIndex bool, isOptions bool, scanner *bufio.Scanner,
 		if !strings.Contains(path, "operator") {
 			writeFrontMatter(strings.Trim(indexFile, ".md"), currentHeader, scanner, true, currentHeaderFile)
 		} else {
-			writeFrontMatter(strings.Trim(indexFile, ".md"), currentHeader + " " + fileName, scanner, true, currentHeaderFile)
+			writeFrontMatter(strings.Trim(indexFile, ".md"), currentHeader+" "+fileName, scanner, true, currentHeaderFile)
 		}
 	} else {
 		// check if we already created the file

--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -10,11 +10,8 @@ import (
 	"github.com/temporalio/cli/app"
 )
 
-// These variables are set by GoReleaser using ldflags
-var version string
-
 func main() {
-	if err := app.BuildApp(version).Run(os.Args); err != nil {
+	if err := app.BuildApp().Run(os.Args); err != nil {
 		goLog.Fatal(err)
 	}
 }

--- a/env/env.go
+++ b/env/env.go
@@ -51,7 +51,7 @@ func NewEnvCommands() []*cli.Command {
 	}
 }
 
-func Build(c *cli.Context) {
+func Init(c *cli.Context) {
 	ClientConfig, _ = NewClientConfig()
 
 	for _, c := range c.App.Commands {

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -2,6 +2,7 @@ package headers
 
 import (
 	"context"
+	"runtime/debug"
 
 	"google.golang.org/grpc/metadata"
 )
@@ -14,10 +15,11 @@ const (
 	SupportedFeaturesHeaderDelim      = ","
 )
 
+// Set by GoReleaser using ldflags
+var Version = "DEV"
+
 const (
 	ClientNameCLI = "temporal-cli"
-
-	CLIVersion = "0.5.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"
@@ -38,12 +40,20 @@ var (
 
 	cliVersionHeaders = metadata.New(map[string]string{
 		ClientNameHeaderName:              ClientNameCLI,
-		ClientVersionHeaderName:           CLIVersion,
+		ClientVersionHeaderName:           Version,
 		SupportedServerVersionsHeaderName: SupportedServerVersions,
 		// TODO: This should include SupportedFeaturesHeaderName with a value that's taken
 		// from the Go SDK (since the cli uses the Go SDK for most operations).
 	})
 )
+
+func Init() {
+	if Version == "DEV" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+}
 
 // GetValues returns header values for passed header names.
 // It always returns slice of the same size as number of passed header names.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Refactored the goreleaser pipeline so it:

- On a new tag (eg. `0.5.0`) will start GoReleaser pipeline, build assets and then cut a new Github Release
- Set version using `ldtags` instead of hardcoded value

## Why?
<!-- Tell your future self why have you made these changes -->

- Address potential CDN issue where the Github Release was cut while the assets were not yet build which can result in downloads failure

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```
goreleaser --skip-publish --snapshot --rm-dist
```
^ and verified the locally built files. Didn't verify GoReleaser actually cutting a Github release 

```
go build -ldflags "-s -w -X github.com/temporalio/cli/headers.Version=0.9.0" ./cmd/temporal

./temporal -h
...
VERSION:
   0.9.0 (server 1.20.0) (ui 2.10.3)
```



3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
