### PR TITLE
Time elapse -> time elapsed

### DIFF
--- a/workflow/workflow_commands.go
+++ b/workflow/workflow_commands.go
@@ -285,8 +285,8 @@ func printWorkflowProgress(c *cli.Context, wid, rid string, watch bool) error {
 	defer cancel()
 
 	doneChan := make(chan bool)
-	timeElapse := 1
-	isTimeElapseExist := false
+	timeElapsed := 1
+	timeElapsedExists := false
 	ticker := time.NewTicker(time.Second).C
 	if !isJSON {
 		fmt.Println(color.Magenta(c, "Progress:"))
@@ -320,19 +320,19 @@ func printWorkflowProgress(c *cli.Context, wid, rid string, watch bool) error {
 			}
 
 			if !isJSON {
-				if isTimeElapseExist {
+				if timeElapsedExists {
 					removePrevious2LinesFromTerminal()
 				}
-				fmt.Printf("\nTime elapse: %ds\n", timeElapse)
+				fmt.Printf("\nTime elapsed: %ds\n", timeElapsed)
 			}
 
-			isTimeElapseExist = true
-			timeElapse++
+			timeElapsedExists = true
+			timeElapsed++
 		case <-doneChan: // print result of this run
 			if !isJSON {
 				fmt.Println(color.Magenta(c, "\nResult:"))
 				if watch {
-					fmt.Printf("  Run Time: %d seconds\n", timeElapse)
+					fmt.Printf("  Run Time: %d seconds\n", timeElapsed)
 				}
 				printRunStatus(c, &lastEvent)
 			}


### PR DESCRIPTION
Small grammar change I noticed when executing a `wf run` command.

<img width="818" alt="Screen Shot 2023-02-16 at 11 06 29 PM" src="https://user-images.githubusercontent.com/15153943/219573617-39edc340-92d0-4ca4-99ae-4bf04fb3b3a5.png">
