### PR TITLE
Add port for the Frontend service.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /etc/temporal
 COPY --from=temporal-cli-builder /home/temporal-cli-builder/temporal /usr/local/bin
 
 EXPOSE 7233
+EXPOSE 8233
 
 # Keep the container running.
 ENTRYPOINT ["/temporal", "server", "start-dev", "-n", "default", "--ip" , "0.0.0.0"]


### PR DESCRIPTION
## What was changed
Add port for the Frontend service.

## Why?
The change is necessary to allow the service running in the container to be accessible externally.

## Checklist
2. How was this tested:

```bash
docker build -t temporal:latest . 
docker run -p 127.0.0.1:8233:8233 --rm -it temporal:latest
```

then open http://localhost:8233