### PR TITLE
Fix exit code when Ctrl+C'ing dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 /temporal
+test-temporal
 /temporal-doc-gen
 *.exe
 *.exe~

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,9 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/temporal",
       "cwd": "${workspaceFolder}",
-      "args": [
-        "server",
-        "start-dev",
-      ],
+      "args": ["server", "start-dev"],
       "env": {
-        "CGO_ENABLED": "0",
+        "CGO_ENABLED": "0"
       }
     },
     {
@@ -23,10 +20,23 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/temporal",
       "cwd": "${workspaceFolder}",
-      "args": [
-        "workflow",
-        "list",
-      ]
+      "args": ["workflow", "list"]
+    },
+    {
+      // Make sure to first start dev server process with:
+      // ~/go/bin/dlv --listen=127.0.0.1:2345 --headless=true --api-version=2 exec ./temporal server start-dev
+      // Useful for debugging SIGTERM (aka Ctrl+C) when running dev server
+      "name": "attach to server",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "remotePath": "/cmd/temporal",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "cwd": "${workspaceFolder}",
+      "trace": "verbose",
+      "apiVersion": 2,
+      "showLog": true
     }
-  ],
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 ##### Test #####
 test:
 	@printf $(COLOR) "Running unit tests..."
-	go test ./... -race
+	go test ./... -race -count 1
 
 ##### Misc #####
 

--- a/app/app.go
+++ b/app/app.go
@@ -68,6 +68,8 @@ func HandleError(c *cli.Context, err error) {
 		return
 	}
 
+	cli.HandleExitCoder(err)
+
 	fmt.Fprintf(os.Stderr, "%s %+v\n", color.Red(c, "Error:"), err)
 	if os.Getenv(common.ShowErrorStackEnv) != `` {
 		fmt.Fprintln(os.Stderr, color.Magenta(c, "Stack trace:"))

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -1,0 +1,61 @@
+// The MIT License
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package app_test
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerInterruptRC(t *testing.T) {
+	// build and run the binary, not "go run" as it modifies the exit code
+	build := exec.Command("go", "build", "-o", "./test-temporal", "../cmd/temporal")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	err := build.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove("./test-temporal")
+
+	cmd := exec.Command("./test-temporal", "server", "start-dev", "--headless")
+	err = cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure the dev server process is killed, even if SIGTERM fails
+	defer cmd.Process.Signal(syscall.SIGKILL)
+
+	// Wait for the app to start
+	time.Sleep(time.Second * 2)
+
+	cmd.Process.Signal(syscall.SIGTERM)
+	_ = cmd.Wait()
+
+	assert.Equal(t, 0, cmd.ProcessState.ExitCode())
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Made `Ctrl+C` exit code 0 instead of 1 when running dev server 

## Why?
<!-- Tell your future self why have you made these changes -->

proper RC

address #43 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```
temporal server start-dev
```

Hit `Ctrl+C`

```
echo $?
0
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
