### PR TITLE
Don't prompt when creating search attribute

### DIFF
--- a/searchattribute/search_attribute.go
+++ b/searchattribute/search_attribute.go
@@ -12,8 +12,8 @@ import (
 func NewSearchAttributeCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:  "create",
-			Usage: common.CreateSearchAttributeDefinition,
+			Name:      "create",
+			Usage:     common.CreateSearchAttributeDefinition,
 			UsageText: common.SearchAttributeCreateUsageText,
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{
@@ -28,20 +28,14 @@ func NewSearchAttributeCommands() []*cli.Command {
 					Usage:    fmt.Sprintf("Search attribute type: %v", common.AllowedEnumValues(enumspb.IndexedValueType_name)),
 					Category: common.CategoryMain,
 				},
-				&cli.BoolFlag{
-					Name:     common.FlagYes,
-					Aliases:  common.FlagYesAlias,
-					Usage:    common.FlagYesDefinition,
-					Category: common.CategoryMain,
-				},
 			},
 			Action: func(c *cli.Context) error {
 				return AddSearchAttributes(c)
 			},
 		},
 		{
-			Name:  "list",
-			Usage: common.ListSearchAttributesDefinition,
+			Name:      "list",
+			Usage:     common.ListSearchAttributesDefinition,
 			UsageText: common.SearchAttributeListUsageText,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -57,8 +51,8 @@ func NewSearchAttributeCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:  "remove",
-			Usage: common.RemoveSearchAttributesDefinition,
+			Name:      "remove",
+			Usage:     common.RemoveSearchAttributesDefinition,
 			UsageText: common.SearchAttributeRemoveUsageText,
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{

--- a/searchattribute/search_attribute_commands.go
+++ b/searchattribute/search_attribute_commands.go
@@ -3,7 +3,6 @@ package searchattribute
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/temporalio/cli/client"
@@ -105,14 +104,6 @@ func AddSearchAttributes(c *cli.Context) error {
 
 	if len(searchAttributes) == 0 {
 		fmt.Println(color.Yellow(c, "Search attributes already exist"))
-		return nil
-	}
-
-	promptMsg := fmt.Sprintf(
-		"You are about to add search attributes %s. Continue? Y/N",
-		color.Yellow(c, strings.TrimLeft(fmt.Sprintf("%v", searchAttributes), "map")),
-	)
-	if !common.PromptYes(promptMsg, c.Bool(common.FlagYes)) {
 		return nil
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed the prompt for `temporal operator search-attribute create`

## Why?
<!-- Tell your future self why have you made these changes -->

The prompt was rather unnecessary since the operation doesn't break/mutate existing data

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

manually

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
