### PR TITLE
Update GoReleaser tag pattern trigger

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Changed goreleaser pipeline trigger to eg `v0.6.0` from `0.6.0`

## Why?
<!-- Tell your future self why have you made these changes -->

tags should be v-prefixed

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Verified that the produced archive asset naming hasn't changed (v-prefix is removed, see https://goreleaser.com/customization/templates/#fn:version-prefix)

- Verified that the version reported with `temporal -h` also has the v-prefix stripped so Temporal server doesn't error out requests. `temporal operator cluster health` still works

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
