### PR TITLE
Process markdown in --help

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/temporalio/cli/completion"
 	"github.com/temporalio/cli/env"
 	"github.com/temporalio/cli/headers"
+	"github.com/temporalio/cli/helpprinter"
 	"github.com/temporalio/cli/namespace"
 	"github.com/temporalio/cli/schedule"
 	"github.com/temporalio/cli/searchattribute"
@@ -38,10 +39,9 @@ func BuildApp() *cli.App {
 	app.Suggest = true
 	app.EnableBashCompletion = true
 	app.DisableSliceFlagSeparator = true
-	app.Commands = commands(defaultCfg)
+	app.Commands = helpprinter.WithHelpTemplate(commands(defaultCfg), common.CustomTemplateHelpCLI)
 	app.Before = configureCLI
 	app.ExitErrHandler = HandleError
-	app.CustomAppHelpTemplate = common.CustomTemplateHelpCLI
 
 	// set builder if not customized
 	if client.CFactory == nil {
@@ -60,6 +60,7 @@ func configureCLI(ctx *cli.Context) error {
 	env.Init(ctx)
 	client.Init(ctx)
 	headers.Init()
+	cli.HelpPrinterCustom = helpprinter.HelpPrinter()
 
 	return nil
 }
@@ -83,7 +84,13 @@ func HandleError(c *cli.Context, err error) {
 }
 
 func commands(defaultCfg *sconfig.Config) []*cli.Command {
-	return append(append(serverCommands(defaultCfg), common.WithFlags(clientCommands, common.SharedFlags)...), completionCommands...)
+	return append(
+		append(
+			serverCommands(defaultCfg),
+			common.WithFlags(clientCommands, common.SharedFlags)...,
+		),
+		completionCommands...,
+	)
 }
 
 func serverCommands(defaultCfg *sconfig.Config) []*cli.Command {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -80,8 +80,7 @@ var commands = []string{
 var cliTestNamespace = "cli-test-namespace"
 
 func TestCLIAppSuite(t *testing.T) {
-	s := new(cliAppSuite)
-	suite.Run(t, s)
+	suite.Run(t, new(cliAppSuite))
 }
 
 func (s *cliAppSuite) SetupSuite() {

--- a/app/helpprinter_test.go
+++ b/app/helpprinter_test.go
@@ -1,0 +1,31 @@
+package app_test
+
+import (
+	"github.com/temporalio/cli/helpprinter"
+)
+
+func (s *cliAppSuite) TestMarkdownToText() {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input: `The ` + "`" + `temporal workflow describe` + "`" + ` command shows information about a given [Workflow Execution](/concepts/what-is-a-workflow-execution).
+	This information can be used to locate Workflow Executions that weren't able to run successfully.
+
+	Use the command options listed below to change the information returned by this command.
+	Make sure to write the command in this format:
+	` + "`" + `temporal workflow describe [command options]` + "`" + ``,
+			expected: `The ` + "`" + `temporal workflow describe` + "`" + ` command shows information about a given Workflow Execution.
+	This information can be used to locate Workflow Executions that weren't able to run successfully.
+
+	Use the command options listed below to change the information returned by this command.
+	Make sure to write the command in this format:
+	` + "`" + `temporal workflow describe [command options]` + "`" + ``,
+		},
+	}
+
+	for _, test := range tests {
+		s.Equal(test.expected, helpprinter.MarkdownToText(test.input))
+	}
+}

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -475,7 +475,7 @@ The index schema is not modified.
 
 Use the options listed below to change the command's behavior.
 Make sure to write the command as follows:
-`+ "`" +`temporal operator search-attribute remove [command options]`+ "`" +`
+` + "`" + `temporal operator search-attribute remove [command options]` + "`" + `
 
 `
 const TaskQueueListPartitionUsageText = `The ` + "`" + `temporal task-queue list-partition` + "`" + ` command displays the partitions of a [Task Queue](/concepts/what-is-a-task-queue), along with the matching node they are assigned to.
@@ -541,12 +541,18 @@ The results of any command run on the Server can be viewed at http://localhost:7
 `
 
 const CustomTemplateHelpCLI = `NAME:
-{{template "helpNameTemplate" .}}
+   {{template "helpNameTemplate" .}}
+
 USAGE:
-{{if .VisibleCommands}}command [command options] {{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
+   {{if .UsageText}}{{wrap .UsageText 3 | markdown2Text}}{{end}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
 DESCRIPTION:
-{{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
-COMMANDS:{{template "visibleCommandTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
 OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
 OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 `

--- a/helpprinter/helpprinter.go
+++ b/helpprinter/helpprinter.go
@@ -1,0 +1,39 @@
+package helpprinter
+
+import (
+	"html/template"
+	"io"
+	"regexp"
+
+	"github.com/urfave/cli/v2"
+)
+
+func HelpPrinter() func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{}) {
+	_helpPrinterOrig := cli.HelpPrinterCustom
+	return func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{}) {
+		cfs := template.FuncMap{
+			"markdown2Text": MarkdownToText,
+		}
+
+		_helpPrinterOrig(w, templ, data, cfs)
+	}
+}
+
+func WithHelpTemplate(commands []*cli.Command, template string) []*cli.Command {
+	for _, cmd := range commands {
+		cmd.CustomHelpTemplate = template
+
+		WithHelpTemplate(cmd.Subcommands, template)
+	}
+
+	return commands
+}
+
+func MarkdownToText(input string) string {
+	return removeLinks(input)
+}
+
+func removeLinks(input string) string {
+	linkPattern := regexp.MustCompile(`\[(.*?)\]\((.*?)\)`)
+	return linkPattern.ReplaceAllString(input, "$1")
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Transformed markdown links such as `[Workflow Execution](/concepts/what-is-a-workflow-execution)` to `Workflow Execution` when outputting in `--help`
- Highlighted code blocks

![Screenshot_20230323_005342](https://user-images.githubusercontent.com/11838981/227106850-1722e361-5de3-44e2-acb9-f3b171051f98.png)

**Additional context**:
Also considered https://github.com/gomarkdown/markdown however it's a bit complicated to get the desired output. E.g. with the external package it would remove texts such as ``temporal workflow describe [command options]``

## Why?
<!-- Tell your future self why have you made these changes -->

Readability of --help

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added a test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
