### PR TITLE
Add trace WorkflowExecutionUpdate and its worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/temporalio/cli
 go 1.19
 
 require (
+	github.com/alitto/pond v1.8.3
 	github.com/fatih/color v1.15.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alitto/pond v1.8.3 h1:ydIqygCLVPqIX/USe5EaV/aSRXTRXDEI9JwuDdu+/xs=
+github.com/alitto/pond v1.8.3/go.mod h1:CmvIIGd5jKLasGI3D87qDkQxjzChdKMmnXMg3fG6M6Q=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=

--- a/trace/execution_state.go
+++ b/trace/execution_state.go
@@ -177,6 +177,8 @@ func (state *WorkflowExecutionState) newChildWorkflowFromEvent(event *history.Hi
 	attrs := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
 	childWorkflowState := NewWorkflowExecutionState(attrs.GetWorkflowId(), "")
 	childWorkflowState.Type = attrs.GetWorkflowType()
+	// Set parent workflow execution since child events don't contain that info.
+	childWorkflowState.ParentWorkflowExecution = state.Execution
 
 	state.childWorkflowMap[event.EventId] = childWorkflowState
 	state.ChildStates = append(state.ChildStates, childWorkflowState)

--- a/trace/execution_state.go
+++ b/trace/execution_state.go
@@ -215,7 +215,7 @@ func (state *WorkflowExecutionState) updateTimer(startedId int64, event *history
 // IsClosed returns true when the Workflow Execution is closed. A Closed status means that the Workflow Execution cannot make further progress.
 func (state *WorkflowExecutionState) IsClosed() (bool, error) {
 	if state.Status == enums.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED {
-		return false, fmt.Errorf("workflow status in an unspecified state")
+		return false, fmt.Errorf("workflow execution status is in an unspecified state, cannot determine if it's closed")
 	}
 	return state.Status != enums.WORKFLOW_EXECUTION_STATUS_RUNNING, nil
 }

--- a/trace/execution_state_test.go
+++ b/trace/execution_state_test.go
@@ -532,6 +532,9 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 					Execution: &common.WorkflowExecution{
 						WorkflowId: "childWfId", RunId: "",
 					},
+					ParentWorkflowExecution: &common.WorkflowExecution{
+						WorkflowId: "foo",
+					},
 				},
 			},
 		},
@@ -547,6 +550,9 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 					Status: enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
 					Execution: &common.WorkflowExecution{
 						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+					ParentWorkflowExecution: &common.WorkflowExecution{
+						WorkflowId: "foo",
 					},
 				},
 			},
@@ -565,6 +571,9 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 					Execution: &common.WorkflowExecution{
 						WorkflowId: "childWfId", RunId: "childRunId",
 					},
+					ParentWorkflowExecution: &common.WorkflowExecution{
+						WorkflowId: "foo",
+					},
 				},
 			},
 		},
@@ -581,6 +590,9 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 					Status: enums.WORKFLOW_EXECUTION_STATUS_FAILED,
 					Execution: &common.WorkflowExecution{
 						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+					ParentWorkflowExecution: &common.WorkflowExecution{
+						WorkflowId: "foo",
 					},
 					Failure: &failure.Failure{
 						Message: "This child failed us",
@@ -602,6 +614,9 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 					Status: enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
 					Execution: &common.WorkflowExecution{
 						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+					ParentWorkflowExecution: &common.WorkflowExecution{
+						WorkflowId: "foo",
 					},
 				},
 			},

--- a/trace/execution_state_test.go
+++ b/trace/execution_state_test.go
@@ -1,15 +1,38 @@
-package sundial
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
 
 import (
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/history/v1"
+	"testing"
+	"time"
 )
 
 var events = map[string]*history.HistoryEvent{
@@ -219,6 +242,31 @@ var events = map[string]*history.HistoryEvent{
 			WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
 				WorkflowType: &common.WorkflowType{Name: "baz"},
 				Attempt:      1,
+			},
+		},
+	},
+	"child workflow initiated child": { // Child workflow has a child workflow
+		EventId:   50,
+		EventType: enums.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+		Attributes: &history.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{
+			StartChildWorkflowExecutionInitiatedEventAttributes: &history.StartChildWorkflowExecutionInitiatedEventAttributes{
+				Namespace:    "default",
+				WorkflowId:   "depth2child",
+				WorkflowType: &common.WorkflowType{Name: "baz"},
+			},
+		},
+	},
+	"child workflow started child": {
+		EventId:   52,
+		EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &history.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{
+			ChildWorkflowExecutionStartedEventAttributes: &history.ChildWorkflowExecutionStartedEventAttributes{
+				Namespace:        "default",
+				InitiatedEventId: 50,
+				WorkflowExecution: &common.WorkflowExecution{
+					WorkflowId: "depth2child", RunId: "depth2childRunId",
+				},
+				WorkflowType: &common.WorkflowType{Name: "baz"},
 			},
 		},
 	},

--- a/trace/trace_commands.go
+++ b/trace/trace_commands.go
@@ -1,0 +1,150 @@
+package trace
+
+import (
+	"fmt"
+	"github.com/temporalio/cli/client"
+	"github.com/temporalio/cli/common"
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/api/enums/v1"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func GetFoldStatus(c *cli.Context) ([]enums.WorkflowExecutionStatus, error) {
+	values := []enums.WorkflowExecutionStatus{}
+	flagFold := c.String(common.FlagFold)
+	for _, v := range strings.Split(flagFold, ",") {
+		var status enums.WorkflowExecutionStatus
+		switch strings.ToLower(v) {
+		case "running":
+			status = enums.WORKFLOW_EXECUTION_STATUS_RUNNING
+		case "completed":
+			status = enums.WORKFLOW_EXECUTION_STATUS_COMPLETED
+		case "failed":
+			status = enums.WORKFLOW_EXECUTION_STATUS_FAILED
+		case "canceled":
+			status = enums.WORKFLOW_EXECUTION_STATUS_CANCELED
+		case "terminated":
+			status = enums.WORKFLOW_EXECUTION_STATUS_TERMINATED
+		case "timedout":
+			status = enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+		case "continueasnew":
+			status = enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+		default:
+			return nil, fmt.Errorf("fold status \"%s\" not recognized", v)
+		}
+
+		values = append(values, status)
+	}
+	return values, nil
+}
+
+// printWorkflowTrace prints and updates a workflow trace following printWorkflowProgress pattern
+func printWorkflowTrace(c *cli.Context, wid, rid string) (int, error) {
+	childsDepth := c.Int(common.FlagDepth)
+	concurrency := c.Int(common.FlagConcurrency)
+	allFlag := c.Bool(common.FlagNoFold)
+
+	foldStatus, err := GetFoldStatus(c)
+	if err != nil {
+		return 1, err
+	}
+
+	sdkClient, err := client.GetSDKClient(c)
+	//sdkClient, err := temporal.NewClientFromEnv()
+	if err != nil {
+		return 1, err
+	}
+
+	tcCtx, cancel := common.NewIndefiniteContext(c)
+	//tcCtx, cancel := context.WithCancel(c.Context)
+	defer cancel()
+
+	doneChan := make(chan bool)
+	errChan := make(chan error)
+	ticker := time.NewTicker(time.Second).C
+
+	// Capture interrupt signals to do a last print
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+
+	// Start update fetching
+	var update *WorkflowExecutionUpdate
+	go func() {
+		iter, err := GetWorkflowExecutionUpdates(tcCtx, sdkClient, wid, rid, allFlag, foldStatus, childsDepth, concurrency)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		for iter.HasNext() {
+			if update, err = iter.Next(); err != nil {
+				errChan <- err
+			}
+		}
+		doneChan <- true
+	}()
+
+	//var printedRows int
+	//var prevString string
+	var currentEvents int64
+	var totalEvents int64
+	var isUpToDate bool
+	//fmt.Println(style.Title("Progress:"))
+	for {
+		select {
+		case <-ticker:
+			state := update.GetState()
+			if state == nil {
+				printProgress(currentEvents, totalEvents)
+				continue
+			}
+
+			if !isUpToDate {
+				currentEvents, totalEvents = state.GetNumberOfEvents()
+				isUpToDate = currentEvents >= totalEvents && !state.IsArchived
+			}
+
+			if isUpToDate {
+				//printedRows, prevString = updateWorkflow(state, printedRows, prevString, allFlag, true)
+			} else {
+				printProgress(currentEvents, totalEvents)
+			}
+		case <-doneChan:
+		case <-sigChan:
+			// Print last execution state available, this one doesn't need to be trimmed.
+			//updateWorkflow(update.GetState(), printedRows, prevString, allFlag, false)
+			return GetExitCode(update.GetState()), nil
+		case err = <-errChan:
+			//fmt.Println(style.Danger("Error:"), err)
+			return 1, err
+		}
+	}
+}
+
+func printProgress(currentEvents int64, totalEvents int64) {
+	//if totalEvents == 0 {
+	//	fmt.Printf("%sProcessing HistoryEvents (%d)\r", output.CLEAR_LINE, currentEvents)
+	//} else {
+	//	fmt.Printf("%sProcessing HistoryEvents (%d/%d)\r", output.CLEAR_LINE, currentEvents, totalEvents)
+	//}
+}
+
+// GetExitCode returns the exit code for a given workflow execution status.
+func GetExitCode(exec *WorkflowExecutionState) int {
+	if exec == nil {
+		// Don't panic if the state is missing.
+		return 0
+	}
+	switch exec.Status {
+	case enums.WORKFLOW_EXECUTION_STATUS_FAILED:
+		return 2
+	case enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+		return 3
+	case enums.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED:
+		return 4
+	}
+	return 0
+}

--- a/trace/workflow_execution_update.go
+++ b/trace/workflow_execution_update.go
@@ -1,0 +1,115 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"github.com/alitto/pond"
+	sdkclient "go.temporal.io/sdk/client"
+)
+
+type WorkflowExecutionUpdate struct {
+	State *WorkflowExecutionState
+}
+
+// WorkflowExecutionUpdateIterator is the interface the provides iterative updates, analogous to the HistoryEventIterator interface.
+type WorkflowExecutionUpdateIterator interface {
+	HasNext() bool
+	Next() (*WorkflowExecutionUpdate, error)
+}
+
+// WorkflowExecutionUpdateIteratorImpl implements the iterator interface. Keeps information about the last processed update and
+// receives new updates through the updateChan channel.
+type WorkflowExecutionUpdateIteratorImpl struct {
+	updated    bool
+	nextUpdate *WorkflowExecutionUpdate
+	state      *WorkflowExecutionState
+	err        error
+	updateChan <-chan struct{}
+	doneChan   <-chan struct{}
+	errorChan  <-chan error
+}
+
+// GetWorkflowExecutionUpdates gets workflow execution updates for a particular workflow
+// - workflow ID of the workflow
+// - runID can be default (empty string)
+// - depth of child workflows to request updates for (-1 for unlimited depth)
+// - concurrency of requests (non-zero positive integer)
+// Returns iterator (see client.GetWorkflowHistory) that provides updated WorkflowExecutionState snapshots.
+// Example:
+// To print a workflow's state whenever there's updates
+//
+//	iter := GetWorkflowExecutionUpdates(ctx, client, wfId, runId, -1, 5)
+//	var state *WorkflowExecutionState
+//	for iter.HasNext() {
+//		update = iter.Next()
+//		PrintWorkflowState(update.State)
+//	}
+func GetWorkflowExecutionUpdates(ctx context.Context, client sdkclient.Client, wfId, runId string, fetchAll bool, depth int, concurrency int) (WorkflowExecutionUpdateIterator, error) {
+	if concurrency < 1 {
+		return nil, fmt.Errorf("invalid value for concurrency (expected non-zero positive integer, got %d)", concurrency)
+	}
+
+	pool := pond.New(concurrency, 1000)
+
+	// Using a GroupContext we can use pond's error handling and context cancelling.
+	group, poolCtx := pool.GroupContext(ctx)
+	updateChan := make(chan struct{})
+	doneChan := make(chan struct{})
+	errorChan := make(chan error)
+
+	state := NewWorkflowExecutionState(wfId, runId)
+	job, err := NewWorkflowStateJob(poolCtx, client, state, fetchAll, depth, updateChan)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		group.Submit(job.Run(group))
+		// Wait for all tasks to complete and signal done
+		if err = group.Wait(); err != nil {
+			errorChan <- err
+		} else {
+			doneChan <- struct{}{}
+		}
+	}()
+
+	return &WorkflowExecutionUpdateIteratorImpl{
+		updateChan: updateChan,
+		doneChan:   doneChan,
+		errorChan:  errorChan,
+		state:      state,
+	}, nil
+}
+
+// HasNext checks if there's any more updates in the updateChan channel. Returns false if the channel has been closed.
+func (iter *WorkflowExecutionUpdateIteratorImpl) HasNext() bool {
+	iter.updated = true
+	select {
+	case <-iter.updateChan:
+		iter.nextUpdate = &WorkflowExecutionUpdate{State: iter.state}
+		return true
+	case <-iter.doneChan:
+		return false
+	case err := <-iter.errorChan:
+		iter.err = err
+		return true
+	}
+}
+
+// Next return the last processed execution update. HasNext has to be called first (following the HasNext/Next pattern).
+func (iter *WorkflowExecutionUpdateIteratorImpl) Next() (*WorkflowExecutionUpdate, error) {
+	// Make sure HasNext() has been called first.
+	if !iter.updated {
+		return nil, fmt.Errorf("please call HasNext() first")
+	}
+	iter.updated = false
+
+	if err := iter.err; err != nil {
+		iter.err = nil
+		return nil, err
+	}
+
+	update := iter.nextUpdate
+	iter.nextUpdate = nil
+	return update, nil
+}

--- a/trace/workflow_execution_update_test.go
+++ b/trace/workflow_execution_update_test.go
@@ -1,0 +1,263 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	"go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/mocks"
+)
+
+type WorkflowExecutionUpdateSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestWorkflowExecutionUpdateSuite(t *testing.T) {
+	suite.Run(t, new(WorkflowExecutionUpdateSuite))
+}
+
+func (s *WorkflowExecutionUpdateSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// SetDescribeWorkflowMocks mocks DescribeWorkflowExecution to return a list of events for a wfId/runId.
+// This is used in the WorkflowStateJob.Run method to retrieve the history length.
+func (s *WorkflowExecutionUpdateSuite) SetDescribeWorkflowMocks(client *mocks.Client, wfId, runId string, events []*history.HistoryEvent) {
+	var historyLength int64
+	if len(events) > 0 {
+		historyLength = events[len(events)-1].EventId // Get last event id
+	}
+	client.On("DescribeWorkflowExecution", mock.Anything, wfId, runId).Return(
+		&workflowservice.DescribeWorkflowExecutionResponse{
+			WorkflowExecutionInfo: &workflow.WorkflowExecutionInfo{
+				HistoryLength: historyLength,
+			},
+		}, nil)
+}
+
+// SetDescribeWorkflowErrorMocks mocks DescribeWorkflowExecution to return an error.
+func (s *WorkflowExecutionUpdateSuite) SetDescribeWorkflowErrorMocks(client *mocks.Client, wfId, runId string, err error) {
+	client.On("DescribeWorkflowExecution", mock.Anything, wfId, runId).Return(nil, err)
+}
+
+// SetWorkflowHistoryMocks mocks GetWorkflowHistory to return an iterator that will return each event in succession.
+func (s *WorkflowExecutionUpdateSuite) SetWorkflowHistoryMocks(client *mocks.Client, wfId, runId string, events []*history.HistoryEvent) {
+	mockIterator := &mocks.HistoryEventIterator{}
+	for _, event := range events {
+		mockIterator.On("HasNext").Return(true).Once()
+		mockIterator.On("Next").Return(event, nil).Once()
+	}
+	mockIterator.On("HasNext").Return(false)
+	mockIterator.On("Next").Return(nil, fmt.Errorf("no more events available"))
+	client.On("GetWorkflowHistory", mock.Anything, wfId, runId, mock.Anything, mock.Anything).Return(mockIterator)
+}
+
+// RemoveStateMaps removes caching data from WorkflowExecutionState (i.e. activityMap and childWfMap) so it can be easily asserted upon
+func RemoveStateMaps(state *WorkflowExecutionState) *WorkflowExecutionState {
+	state.childWfMap = nil
+	state.activityMap = nil
+	state.timerMap = nil
+	return state
+}
+
+func (s *WorkflowExecutionUpdateSuite) Test_ParametersAreValid() {
+	type args struct {
+		concurrency int
+	}
+	tests := map[string]struct {
+		args        args
+		assertError assert.ErrorAssertionFunc
+	}{
+		"sanity": {
+			args:        args{concurrency: 1},
+			assertError: assert.NoError,
+		},
+		"zero concurrency": {
+			args:        args{concurrency: 0},
+			assertError: assert.Error,
+		},
+		"negative concurrency": {
+			args:        args{concurrency: -1},
+			assertError: assert.Error,
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			client := &mocks.Client{}
+			// Setup mocks since valid parameters will start WorkflowStateJobs
+			s.SetDescribeWorkflowMocks(client, "foo", "bar", nil)
+			s.SetWorkflowHistoryMocks(client, "foo", "bar", nil)
+			iter, err := GetWorkflowExecutionUpdates(s.ctx, client, "foo", "bar", true, -1, tt.args.concurrency)
+
+			tt.assertError(s.T(), err)
+
+			// Iterate through all the events to make sure we have no issues due to the assertion coming before errors in the started jobs
+			if iter != nil {
+				for iter.HasNext() {
+					_, err = iter.Next()
+					s.NoError(err)
+				}
+			}
+		})
+	}
+}
+
+func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdates() {
+	tests := map[string]struct {
+		depth         int
+		initialState  *WorkflowExecutionState
+		rootEvents    []*history.HistoryEvent
+		childEvents   []*history.HistoryEvent
+		expectedState *WorkflowExecutionState
+	}{
+		"sanity": {
+			depth:        -1,
+			initialState: NewWorkflowExecutionState("foo", "bar"),
+			rootEvents: []*history.HistoryEvent{
+				events["started"],
+			},
+			childEvents: []*history.HistoryEvent{},
+			expectedState: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       1,
+				LastEventId:   1,
+				HistoryLength: 1,
+			},
+		},
+		"child workflow started": {
+			depth:        -1,
+			initialState: NewWorkflowExecutionState("foo", "bar"),
+			rootEvents: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+			},
+			childEvents: []*history.HistoryEvent{
+				events["workflow started child"],
+			},
+			expectedState: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       1,
+				LastEventId:   52,
+				HistoryLength: 52,
+				ChildStates: []ExecutionState{
+					&WorkflowExecutionState{
+						LastEventId:   1, // Child workflow has its own events
+						HistoryLength: 1,
+						Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						Type: &common.WorkflowType{
+							Name: "baz",
+						},
+						Execution: &common.WorkflowExecution{
+							WorkflowId: "childWfId",
+							RunId:      "childRunId",
+						},
+						Attempt: 1,
+					},
+				},
+			},
+		},
+		"not enough depth for child": {
+			depth:        0,
+			initialState: NewWorkflowExecutionState("foo", "bar"),
+			rootEvents: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+			},
+			childEvents: []*history.HistoryEvent{
+				events["workflow started child"],
+			},
+			expectedState: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       1,
+				LastEventId:   52,
+				HistoryLength: 52,
+				ChildStates: []ExecutionState{
+					&WorkflowExecutionState{
+						// Child workflow doesn't have its own events (no LastEventId)
+						Status: enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						Type: &common.WorkflowType{
+							Name: "baz",
+						},
+						Execution: &common.WorkflowExecution{
+							WorkflowId: "childWfId",
+							RunId:      "childRunId",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			client := &mocks.Client{}
+
+			// Setup HistoryEventIterator mocks
+			exec := tt.initialState.Execution
+			s.SetWorkflowHistoryMocks(client, exec.GetWorkflowId(), exec.GetRunId(), tt.rootEvents)
+			s.SetWorkflowHistoryMocks(client, "childWfId", "childRunId", tt.childEvents)
+
+			// Setup DescribeWorkflowExecution mocks
+			s.SetDescribeWorkflowMocks(client, exec.GetWorkflowId(), exec.GetRunId(), tt.rootEvents)
+			s.SetDescribeWorkflowMocks(client, "childWfId", "childRunId", tt.childEvents)
+
+			// Execute what we're testing
+			iter, _ := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, tt.depth, 5)
+
+			// Iterate over all the updates to get the final state
+			var update *WorkflowExecutionUpdate
+			for iter.HasNext() {
+				update, _ = iter.Next()
+				// Update should never be nil
+				if update == nil {
+					assert.FailNow(s.T(), "Update cannot be nil")
+				}
+			}
+			// Remove helper maps to make comparison easier
+			// TODO: Find a way to make this comparison clearer and not depend on some adhoc cleanup (maybe using state.Equal?)
+			cleanState := RemoveStateMaps(update.State)
+
+			assert.Equal(s.T(), tt.expectedState, cleanState)
+		})
+	}
+}
+
+func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdatesErrors() {
+	client := &mocks.Client{}
+
+	exec := NewWorkflowExecutionState("foo", "bar").Execution
+	s.SetWorkflowHistoryMocks(client, exec.GetWorkflowId(), exec.GetRunId(), []*history.HistoryEvent{events["started"]})
+
+	// Setup DescribeWorkflowExecution mocks
+	s.SetDescribeWorkflowErrorMocks(client, exec.GetWorkflowId(), exec.GetRunId(), fmt.Errorf("hey, I'm an error"))
+
+	// Execute what we're testing
+	iter, updateErr := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, 0, 5)
+	require.NoError(s.T(), updateErr)
+
+	// Only call once since we only want to check on the first error.
+	iter.HasNext()
+	update, err := iter.Next()
+
+	require.Nil(s.T(), update)
+	require.Error(s.T(), err)
+}

--- a/trace/workflow_execution_update_test.go
+++ b/trace/workflow_execution_update_test.go
@@ -201,6 +201,10 @@ func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdates() {
 							WorkflowId: "childWfId",
 							RunId:      "childRunId",
 						},
+						ParentWorkflowExecution: &common.WorkflowExecution{
+							WorkflowId: "foo",
+							RunId:      "bar",
+						},
 					},
 				},
 			},

--- a/trace/workflow_execution_update_test.go
+++ b/trace/workflow_execution_update_test.go
@@ -62,9 +62,9 @@ func (s *WorkflowExecutionUpdateSuite) SetWorkflowHistoryMocks(client *mocks.Cli
 	client.On("GetWorkflowHistory", mock.Anything, wfId, runId, mock.Anything, mock.Anything).Return(mockIterator)
 }
 
-// RemoveStateMaps removes caching data from WorkflowExecutionState (i.e. activityMap and childWfMap) so it can be easily asserted upon
+// RemoveStateMaps removes caching data from WorkflowExecutionState (i.e. activityMap and childWorkflowMap) so it can be easily asserted upon
 func RemoveStateMaps(state *WorkflowExecutionState) *WorkflowExecutionState {
-	state.childWfMap = nil
+	state.childWorkflowMap = nil
 	state.activityMap = nil
 	state.timerMap = nil
 	return state

--- a/trace/workflow_execution_update_test.go
+++ b/trace/workflow_execution_update_test.go
@@ -98,7 +98,7 @@ func (s *WorkflowExecutionUpdateSuite) Test_ParametersAreValid() {
 			// Setup mocks since valid parameters will start WorkflowStateJobs
 			s.SetDescribeWorkflowMocks(client, "foo", "bar", nil)
 			s.SetWorkflowHistoryMocks(client, "foo", "bar", nil)
-			iter, err := GetWorkflowExecutionUpdates(s.ctx, client, "foo", "bar", true, -1, tt.args.concurrency)
+			iter, err := GetWorkflowExecutionUpdates(s.ctx, client, "foo", "bar", true, nil, -1, tt.args.concurrency)
 
 			tt.assertError(s.T(), err)
 
@@ -221,7 +221,7 @@ func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdates() {
 			s.SetDescribeWorkflowMocks(client, "childWfId", "childRunId", tt.childEvents)
 
 			// Execute what we're testing
-			iter, _ := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, tt.depth, 5)
+			iter, _ := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, nil, tt.depth, 5)
 
 			// Iterate over all the updates to get the final state
 			var update *WorkflowExecutionUpdate
@@ -243,7 +243,6 @@ func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdates() {
 
 func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdatesErrors() {
 	// We're testing the following:
-	// - If DescribeWorkflow returns an error, GetWorkflowExecutionUpdate returns no error (since it's a nice-to-have).
 	// - If the update iterator errors, it's available in Next().
 	client := &mocks.Client{}
 
@@ -251,10 +250,10 @@ func (s *WorkflowExecutionUpdateSuite) Test_GetWorkflowExecutionUpdatesErrors() 
 	s.SetWorkflowHistoryMocks(client, exec.GetWorkflowId(), exec.GetRunId(), []*history.HistoryEvent{events["started"]})
 
 	// Setup DescribeWorkflowExecution mocks
-	s.SetDescribeWorkflowErrorMocks(client, exec.GetWorkflowId(), exec.GetRunId(), fmt.Errorf("hey, I'm an error"))
+	s.SetDescribeWorkflowMocks(client, exec.GetWorkflowId(), exec.GetRunId(), []*history.HistoryEvent{events["started"]})
 
 	// Call function under testing.
-	iter, updateErr := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, 0, 5)
+	iter, updateErr := GetWorkflowExecutionUpdates(s.ctx, client, exec.GetWorkflowId(), exec.GetRunId(), true, nil, 0, 5)
 	require.NoError(s.T(), updateErr)
 
 	// First Next returns the "started" event.

--- a/trace/workflow_state_worker.go
+++ b/trace/workflow_state_worker.go
@@ -1,0 +1,138 @@
+package trace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/alitto/pond"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	sdkclient "go.temporal.io/sdk/client"
+)
+
+// WorkflowStateJob implements a WorkerJob to retrieve updates for a WorkflowExecutionState and its child workflows.
+type WorkflowStateJob struct {
+	ctx    context.Context
+	client sdkclient.Client
+
+	state      *WorkflowExecutionState
+	depth      int
+	fetchAll   bool
+	childJobs  []*WorkflowStateJob
+	isUpToDate bool
+
+	updateChan chan struct{}
+}
+
+// NewWorkflowStateJob returns a new WorkflowStateJob. It requires an updateChan to signal when there's updates.
+func NewWorkflowStateJob(ctx context.Context, client sdkclient.Client, state *WorkflowExecutionState, fetchAll bool, depth int, updateChan chan struct{}) (*WorkflowStateJob, error) {
+	if state == nil {
+		return nil, errors.New("workflow state cannot be nil for a workflow state job")
+	}
+	if updateChan == nil {
+		return nil, errors.New("updateChan cannot be nil for a workflow state job")
+	}
+
+	return &WorkflowStateJob{
+		ctx:        ctx,
+		client:     client,
+		state:      state,
+		depth:      depth,
+		fetchAll:   fetchAll,
+		updateChan: updateChan,
+		childJobs:  []*WorkflowStateJob{},
+	}, nil
+}
+
+// Run starts the WorkflowStateJob, which retrieves the workflow's events and spawns new jobs for the child workflows once it's up-to-date.
+// New jobs are submitted to the pool when the job is up-to-date to reduce the amount of unnecessary history fetches (e.g. when the child workflow is already completed).
+func (job *WorkflowStateJob) Run(group *pond.TaskGroupWithContext) func() error {
+	return func() error {
+		state := job.state
+		wfId := state.Execution.GetWorkflowId()
+		runId := state.Execution.GetRunId()
+
+		// Get workflow's history length, so we know when we're up-to-date.
+		if execInfo, err := GetWorkflowExecutionInfo(job.ctx, job.client, state.Execution.GetWorkflowId(), state.Execution.GetRunId()); err != nil {
+			return err
+		} else {
+			state.HistoryLength = execInfo.HistoryLength
+			state.IsArchived = execInfo.HistoryLength == 0 // TODO: Find a better way to identify archived workflows
+		}
+
+		// Make sure to not long poll archived workflows since GetWorkflowHistory fails under those circumstances.
+		isLongPoll := !state.IsArchived
+		historyIterator := job.client.GetWorkflowHistory(job.ctx, wfId, runId, isLongPoll, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+
+		for historyIterator.HasNext() {
+			event, err := historyIterator.Next()
+			if err != nil {
+				return err
+			}
+			if event == nil {
+				continue
+			}
+
+			// Update state with new event and signal
+			job.state.Update(event)
+			job.updateChan <- struct{}{}
+
+			// Create child jobs if we're on a child workflow execution started event and we haven't hit depth 0.
+			if event.EventType == enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED && job.depth != 0 {
+				childJob, err := job.GetChildJob(event)
+				if err != nil {
+					// TODO: Consider if we want to error out if a child workflow cannot be updated by itself.
+					return err
+				}
+				job.childJobs = append(job.childJobs, childJob)
+
+				if job.isUpToDate {
+					group.Submit(childJob.Run(group))
+				}
+			}
+
+			// Start child jobs when we're up-to-date
+			if !job.isUpToDate && event.EventId >= state.HistoryLength {
+				job.isUpToDate = true
+				for _, childJob := range job.childJobs {
+					if childJob.ShouldStart() {
+						group.Submit(childJob.Run(group))
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+// GetChildJob gets a new child job and appends it to the list of childJobs. These jobs don't start until the parent is catched up.
+func (job *WorkflowStateJob) GetChildJob(event *history.HistoryEvent) (*WorkflowStateJob, error) {
+	// Retrieve child workflow from parent and create a new job to fetch events for it
+	childAttrs := event.GetChildWorkflowExecutionStartedEventAttributes()
+	wf, ok := job.state.GetChildWorkflowByEventId(childAttrs.GetInitiatedEventId())
+	if !ok {
+		exec := childAttrs.GetWorkflowExecution()
+		return nil, fmt.Errorf("child workflow (%s, %s) initiated in event %d not found in parent workflow's events", exec.GetWorkflowId(), exec.GetRunId(), childAttrs.GetInitiatedEventId())
+	}
+
+	// Create child job
+	childJob, err := NewWorkflowStateJob(job.ctx, job.client, wf, job.fetchAll, job.depth-1, job.updateChan)
+	if err != nil {
+		return nil, err
+	}
+	return childJob, nil
+}
+
+// ShouldStart will return true if the state is in a status that requires requesting its event history.
+// This will help reduce the amount of event histories requested when they're not needed.
+func (job *WorkflowStateJob) ShouldStart() bool {
+	switch job.state.Status {
+	case enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+		enums.WORKFLOW_EXECUTION_STATUS_FAILED:
+		return true
+	default:
+		return job.fetchAll
+	}
+}

--- a/trace/workflow_state_worker.go
+++ b/trace/workflow_state_worker.go
@@ -35,9 +35,8 @@ func NewWorkflowStateJob(ctx context.Context, client sdkclient.Client, state *Wo
 
 	// Get workflow execution's description, so we can know if we're up-to-date. Doing this synchronously will allow us to correctly
 	// assess how many events need to be processed (otherwise only the ones from the root workflow will be counted).
-	if description, err := client.DescribeWorkflowExecution(ctx, state.Execution.GetWorkflowId(), state.Execution.GetRunId()); err != nil {
-		return nil, err
-	} else {
+	// We don't mind if this fails, since HistoryLength is used only to display event processing progress.
+	if description, err := client.DescribeWorkflowExecution(ctx, state.Execution.GetWorkflowId(), state.Execution.GetRunId()); err == nil {
 		execInfo := description.GetWorkflowExecutionInfo()
 		state.HistoryLength = execInfo.HistoryLength
 		state.IsArchived = execInfo.HistoryLength == 0 // TODO: Find a better way to identify archived workflows

--- a/trace/workflow_state_worker.go
+++ b/trace/workflow_state_worker.go
@@ -53,9 +53,10 @@ func (job *WorkflowStateJob) Run(group *pond.TaskGroupWithContext) func() error 
 		runId := state.Execution.GetRunId()
 
 		// Get workflow's history length, so we know when we're up-to-date.
-		if execInfo, err := GetWorkflowExecutionInfo(job.ctx, job.client, state.Execution.GetWorkflowId(), state.Execution.GetRunId()); err != nil {
+		if description, err := job.client.DescribeWorkflowExecution(job.ctx, state.Execution.GetWorkflowId(), state.Execution.GetRunId()); err != nil {
 			return err
 		} else {
+			execInfo := description.GetWorkflowExecutionInfo()
 			state.HistoryLength = execInfo.HistoryLength
 			state.IsArchived = execInfo.HistoryLength == 0 // TODO: Find a better way to identify archived workflows
 		}


### PR DESCRIPTION
## What was changed
Add `GetWorkflowExecutionUpdates` function that uses `GetWorkflowHistory` to aggregate the workflow execution state. New updates can be retrieved using the HasNext()/Next() pattern, I hope I implemented this correctly.

This uses a workerpool to spawn new aggregation jobs for child workflows. I decided to use `pond` due to being able to easily wait for all jobs to complete (instead of closing and waiting as other workerpools do) and to easily propagate contexts and errors. Let me know if there's any problem with this.

This also includes adding a mutex lock to the `WorkflowExecutionState` maps storing the child workflows/activity/timers to avoid concurrent read/writes.

## Why?
This is the main engine of the workflow tracing. 

Next step will be the frontend, which uses `GetWorkflowExecutionUpdates` to get the latest `WorkflowExecutionState` and display it.

## Checklist

There are tests for `GetWorkflowExecutionUpdates` which cover the whole functionality. Let me know if you'd like more specific tests for the different components.
