### PR TITLE
Fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ EXPOSE 7233
 EXPOSE 8233
 
 # Keep the container running.
-ENTRYPOINT ["/temporal", "server", "start-dev", "-n", "default", "--ip" , "0.0.0.0"]
+ENTRYPOINT ["temporal"]
+CMD ["server", "start-dev", "-n", "default", "--ip" , "0.0.0.0"]


### PR DESCRIPTION
## What was changed
Fixes the Dockerfile entrypoint as the path for the temporal binary was not correct (/temporal instead of temporal).
Also moves the arguments from the ENTRYPOINT to CMD, so there's no need to override the entrypoint to run other commands.

## Why?
To be able to run the image without overriding the entrypoint.

## Checklist
2. How was this tested:

```bash
docker build -t temporal/cli:latest .
docker run docker run --rm -it temporal/cli:latest --help
docker run docker run --rm -it -p 8233:8233 temporal/cli:latest
open http://localhost:8233
```