### PR TITLE
List env command

### DIFF
--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -64,7 +64,7 @@ const (
 	RemoveDefinition   = "Remove a remote Cluster."
 
 	// Env subcommand definitions
-	ListEnvDefinition = "Prints all environments."
+	ListEnvDefinition = "Prints all local configuration envs."
 	GetDefinition     = "Prints environmental properties."
 	SetDefinition     = "Set environmental properties."
 	DeleteDefinition  = "Delete an environment or environmental property."

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -65,7 +65,7 @@ const (
 
 	// Env subcommand definitions
 	ListEnvDefinition = "Print all local configuration envs."
-	GetDefinition     = "Prints environmental properties."
+	GetDefinition     = "Print environmental properties."
 	SetDefinition     = "Set environmental properties."
 	DeleteDefinition  = "Delete an environment or environmental property."
 

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -64,9 +64,10 @@ const (
 	RemoveDefinition   = "Remove a remote Cluster."
 
 	// Env subcommand definitions
-	GetDefinition    = "Prints environmental properties."
-	SetDefinition    = "Set environmental properties."
-	DeleteDefinition = "Delete an environment or environmental property."
+	ListEnvDefinition = "Prints all environments."
+	GetDefinition     = "Prints environmental properties."
+	SetDefinition     = "Set environmental properties."
+	DeleteDefinition  = "Delete an environment or environmental property."
 
 	// Schedule definitions
 	ScheduleCreateDefinition   = "Create a new Schedule."
@@ -197,7 +198,6 @@ Workflow terminations require a valid [Workflow ID](/concepts/what-is-a-workflow
 
 Use the options listed below to change termination behavior.`
 
-
 const ResetWorkflowUsageText = `The ` + "`" + `temporal workflow reset` + "`" + ` command resets a [Workflow Execution](/concepts/what-is-a-workflow-execution).
 A reset allows the Workflow to resume from a certain point without losing its parameters or [Event History](/concepts/what-is-an-event-history).
 
@@ -313,6 +313,8 @@ const ClusterRemoveUsageText = `The ` + "`" + `temporal operator cluster remove`
 Use the options listed below to change the command's behavior.`
 
 const EnvUsageText = `Environment (or 'env') commands allow the user to configure the properties for the environment in use.`
+
+const EnvListUsageText = `List all environments`
 
 const EnvGetUsageText = `The ` + "`" + `temporal env get` + "`" + ` command prints the environmental properties for the environment in use.
 

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -64,7 +64,7 @@ const (
 	RemoveDefinition   = "Remove a remote Cluster."
 
 	// Env subcommand definitions
-	ListEnvDefinition = "Prints all local configuration envs."
+	ListEnvDefinition = "Print all local configuration envs."
 	GetDefinition     = "Prints environmental properties."
 	SetDefinition     = "Set environmental properties."
 	DeleteDefinition  = "Delete an environment or environmental property."

--- a/common/flags.go
+++ b/common/flags.go
@@ -118,6 +118,8 @@ var (
 	FlagUICodecEndpoint            = "ui-codec-endpoint"
 	FlagUIPort                     = "ui-port"
 	FlagUnpause                    = "unpause"
+	FlagVerbose                    = "verbose"
+	FlagVerboseAlias               = []string{"v"}
 	FlagVisibilityArchivalState    = "visibility-archival-state"
 	FlagVisibilityArchivalURI      = "visibility-uri"
 	FlagWorkflowExecutionTimeout   = "execution-timeout"

--- a/common/flags.go
+++ b/common/flags.go
@@ -118,8 +118,6 @@ var (
 	FlagUICodecEndpoint            = "ui-codec-endpoint"
 	FlagUIPort                     = "ui-port"
 	FlagUnpause                    = "unpause"
-	FlagVerbose                    = "verbose"
-	FlagVerboseAlias               = []string{"v"}
 	FlagVisibilityArchivalState    = "visibility-archival-state"
 	FlagVisibilityArchivalURI      = "visibility-uri"
 	FlagWorkflowExecutionTimeout   = "execution-timeout"

--- a/env/env.go
+++ b/env/env.go
@@ -19,6 +19,16 @@ var (
 func NewEnvCommands() []*cli.Command {
 	return []*cli.Command{
 		{
+			Name:      "list",
+			Usage:     common.ListEnvDefinition,
+			UsageText: common.EnvListUsageText,
+			Flags:     []cli.Flag{},
+			ArgsUsage: "",
+			Action: func(c *cli.Context) error {
+				return ListEnvs(c)
+			},
+		},
+		{
 			Name:      "get",
 			Usage:     common.GetDefinition,
 			UsageText: common.EnvGetUsageText,
@@ -57,6 +67,21 @@ func Init(c *cli.Context) {
 	for _, c := range c.App.Commands {
 		common.AddBeforeHandler(c, loadEnv)
 	}
+}
+
+func ListEnvs(c *cli.Context) error {
+	type envStruct struct {
+		Name string
+	}
+
+	for k := range ClientConfig.Envs {
+		env := envStruct{Name: k}
+		if ClientConfig.CurrentEnv == k {
+			env.Name = "*" + k
+		}
+		output.PrintItems(c, []interface{}{env}, &output.PrintOptions{})
+	}
+	return nil
 }
 
 func EnvProperty(c *cli.Context) error {

--- a/env/env.go
+++ b/env/env.go
@@ -76,15 +76,11 @@ func Init(c *cli.Context) {
 	}
 }
 
-type Env struct {
-	Name string
-}
-
 func ListEnvs(c *cli.Context) error {
 	envs := make([]interface{}, 0, len(ClientConfig.Envs))
 
 	for name := range ClientConfig.Envs {
-		envs = append(envs, Env{Name: name})
+		envs = append(envs, struct{ Name string }{Name: name})
 	}
 
 	return output.PrintItems(c, envs, &output.PrintOptions{

--- a/env/env.go
+++ b/env/env.go
@@ -29,12 +29,6 @@ func NewEnvCommands() []*cli.Command {
 					Value:    string(output.Table),
 					Category: common.CategoryDisplay,
 				},
-				&cli.BoolFlag{
-					Name:     common.FlagVerbose,
-					Aliases:  common.FlagVerboseAlias,
-					Usage:    "List envs in verbose mode",
-					Category: common.CategoryDisplay,
-				},
 			},
 			ArgsUsage: "",
 			Action: func(c *cli.Context) error {
@@ -82,43 +76,21 @@ func Init(c *cli.Context) {
 	}
 }
 
-type Data map[string]string
-
-func (d Data) String() string {
-	var sb strings.Builder
-	for k, v := range d {
-		sb.WriteString(fmt.Sprintf("\n%s=%s", k, v))
-	}
-	return sb.String()
-}
-
 type Env struct {
 	Name string
-	Data Data
 }
 
 func ListEnvs(c *cli.Context) error {
 	envs := make([]interface{}, 0, len(ClientConfig.Envs))
 
-	for name, data := range ClientConfig.Envs {
-		envs = append(envs, Env{Name: name, Data: data})
+	for name := range ClientConfig.Envs {
+		envs = append(envs, Env{Name: name})
 	}
-	if c.Bool(common.FlagVerbose) {
-		err := output.PrintItems(c, envs, &output.PrintOptions{
-			OutputFormat: output.Table,
-			Separator:    "",
-			NoHeader:     false,
-			ForceFields:  true,
-			Fields:       []string{"Name", "Data"},
-		})
-		return err
-	} else {
-		err := output.PrintItems(c, envs, &output.PrintOptions{
-			NoHeader: true,
-			Fields:   []string{"Name"},
-		})
-		return err
-	}
+
+	return output.PrintItems(c, envs, &output.PrintOptions{
+		NoHeader: true,
+		Fields:   []string{"Name"},
+	})
 }
 
 func EnvProperty(c *cli.Context) error {


### PR DESCRIPTION
## What was changed

Adds `temporal env list` cmd to display a list of available local config envs.


1. Closes #193

2. How was this tested:

Locally only if there are any good hints on how to test this properly please let me know.

3. Any docs updates needed?

**Output:**

```
❯ ./temporal env list
default*
dev
local


❯ ./temporal env list -v
default*
dev
  address  other
  tls          1
local
  address  127.0.0.1:7233
  test     some

```
