### PR TITLE
Replace custom bool conversion with urfave Bool

### DIFF
--- a/client/factory.go
+++ b/client/factory.go
@@ -5,12 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -231,17 +229,8 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	certPath := c.String(common.FlagTLSCertPath)
 	keyPath := c.String(common.FlagTLSKeyPath)
 	caPath := c.String(common.FlagTLSCaPath)
-	disableHostNameVerificationS := c.String(common.FlagTLSDisableHostVerification)
-	disableHostNameVerification, err := strconv.ParseBool(disableHostNameVerificationS)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read TLS disable host verification flag: %w", err)
-	}
-	enableTLSS := c.String(common.FlagTLS)
-	enableTLS, err := strconv.ParseBool(enableTLSS)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read TLS flag: %w", err)
-	}
-
+	disableHostNameVerification := c.Bool(common.FlagTLSDisableHostVerification)
+	enableTLS := c.Bool(common.FlagTLS)
 	serverName := c.String(common.FlagTLSServerName)
 
 	var host string

--- a/namespace/namespace_commands.go
+++ b/namespace/namespace_commands.go
@@ -3,7 +3,6 @@ package namespace
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	cliclient "github.com/temporalio/cli/client"
 	"github.com/temporalio/cli/common"
@@ -41,10 +40,7 @@ func createNamespace(c *cli.Context) error {
 
 	var isGlobalNamespace bool
 	if c.IsSet(common.FlagIsGlobalNamespace) {
-		isGlobalNamespace, err = strconv.ParseBool(c.String(common.FlagIsGlobalNamespace))
-		if err != nil {
-			return fmt.Errorf("option %s format is invalid: %w", common.FlagIsGlobalNamespace, err)
-		}
+		isGlobalNamespace = c.Bool(common.FlagIsGlobalNamespace)
 	}
 
 	data := map[string]string{}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Replaced `strconv.ParseBool` for TLS flags with urfave's `c.Bool`

## Why?
<!-- Tell your future self why have you made these changes -->

Consistency with other Bool flags

related https://github.com/temporalio/cli/pull/210/files#r1180775765

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Manually verified the same conversion. Backwards compatible since `c.Bool` does strconv.ParseBool internally. Also  previously something like `temporal workflow list --tls-disable-host-verification 0` would result in a string value to be equal to `true` because this flag is defined as `cli.BoolFlag`.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
