### PR TITLE
Fix parsing dynamic config numbers

### DIFF
--- a/server/commands_test.go
+++ b/server/commands_test.go
@@ -59,9 +59,9 @@ func TestGetDynamicConfigValues(t *testing.T) {
 	assertBadVal("foo=bar")
 	assertBadVal("foo=123a")
 
-	assertGoodVals(v{"foo": {123.0}}, "foo=123")
+	assertGoodVals(v{"foo": {123}}, "foo=123")
 	assertGoodVals(
-		v{"foo": {123.0, []interface{}{"123", false}}, "bar": {"baz"}, "qux": {true}},
+		v{"foo": {123, []interface{}{"123", false}}, "bar": {"baz"}, "qux": {true}},
 		"foo=123", `bar="baz"`, "qux=true", `foo=["123", false]`,
 	)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Parse dynamic config numbers correctly: use `json.Number`, and then tries to parse to int, and then to float.

## Why?
<!-- Tell your future self why have you made these changes -->
Without using `json.Decoder`, all number are parsed to `float64` which is not read correctly by dynamic config expecting `int` type value.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Started Temporal Server via CLI tool:
```
$ ./temporal server start-dev --dynamic-config-value frontend.searchAttributesSizeOfValueLimit=20480 --dynamic-config-value frontend.searchAttributesTotalSizeLimit=40480
```
Run search attribute sample workflow with very large values.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
