### PR TITLE
Add frontend to trace command

### DIFF
--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -95,7 +95,7 @@ There are three types of Batch Jobs:
 	- Terminate: terminates the Workflow Executions specified by the List Filter.
 
 A successfully started Batch job will return a Job ID.
-Use this Job ID to execute other actions on the Batch job.
+Use this Job ID to execute other actions on the Batch job. 
 
 Use the command options below to change the information returned by this command.
 `
@@ -107,13 +107,13 @@ Pass a valid Job ID to return a Batch Job's information.
 
 Use the command options below to change the information returned by this command.`
 
-const ListBatchUsageText = `The ` + "`" + `temporal batch list` + "`" + ` command returns all Batch jobs.
+const ListBatchUsageText = `The ` + "`" + `temporal batch list` + "`" + ` command returns all Batch jobs. 
 Batch Jobs can be returned for an entire Cluster or a single Namespace.
 ` + "`" + `temporal batch list --namespace=MyNamespace` + "`" + `
 
 Use the command options below to change the information returned by this command.`
 
-const TerminateBatchUsageText = `The ` + "`" + `temporal batch terminate` + "`" + ` command terminates a Batch job with the provided Job ID.
+const TerminateBatchUsageText = `The ` + "`" + `temporal batch terminate` + "`" + ` command terminates a Batch job with the provided Job ID. 
 For future reference, provide a reason for terminating the Batch Job.
 
 ` + "`" + `temporal batch terminate --job-id=MyJobId --reason=JobReason` + "`" + `
@@ -267,7 +267,7 @@ Use the options listed below to change the behavior of this command.`
 
 const FailActivityUsageText = `The ` + "`" + `temporal activity fail` + "`" + ` command fails an [Activity Execution](/concepts/what-is-an-activity-execution).
 The Activity must be running on a valid [Workflow](/concepts/what-is-a-workflow).
-` + "`" + `temporal fail --workflow-id=meaningful-business-id --activity-id=MyActivity` + "`" + `
+` + "`" + `temporal fail --workflow-id=meaningful-business-id --activity-id=MyActivity` + "`" + ` 
 
 Use the options listed below to change the behavior of this command.`
 
@@ -323,10 +323,10 @@ Passing the 'local' [Namespace](/concepts/what-is-a-namespace) returns the name,
 ` + "`" + `temporal env get local` + "`" + `
 ` + "`" + `
 Output:
-tls-cert-path  /home/my-user/certs/cluster.cert
-tls-key-path   /home/my-user/certs/cluster.key
-address        127.0.0.1:7233
-namespace      someNamespace
+tls-cert-path  /home/my-user/certs/cluster.cert  
+tls-key-path   /home/my-user/certs/cluster.key   
+address        127.0.0.1:7233                    
+namespace      someNamespace 
 ` + "`" + `
 
 Output can be narrowed down to a specific environmental property.
@@ -412,7 +412,7 @@ temporal schedule create \
 		--cron '3 11 * * Fri' \
 		--wid 'your-workflow-id' \
 		--tq 'your-task-queue' \
-		--type 'YourWorkflowType'
+		--type 'YourWorkflowType' 
 ` + "`" + `` + "`" + `` + "`" + `
 
 Any combination of ` + "`" + `--cal` + "`" + `, ` + "`" + `--interval` + "`" + `, and ` + "`" + `--cron` + "`" + ` is supported.
@@ -429,17 +429,17 @@ temporal schedule update 			\
 		--cron '3 11 * * Fri' 		\
 		--wid 'your-workflow-id' 	\
 		--tq 'your-task-queue' 		\
-		--type 'YourWorkflowType'
+		--type 'YourWorkflowType' 
 ` + "`" + `` + "`" + `` + "`" + `
 
-Updating a Schedule takes the given options and replaces the entire configuration of the Schedule with what's provided.
+Updating a Schedule takes the given options and replaces the entire configuration of the Schedule with what's provided. 
 If you only change one value of the Schedule, be sure to provide the other unchanged fields to prevent them from being overwritten.
 
 Use the command options below to change the information returned by this command.`
 
 const ScheduleToggleUsageText = `The ` + "`" + `temporal schedule toggle` + "`" + ` command can pause and unpause a [Schedule](/concepts/what-is-a-schedule).
 
-Toggling a Schedule requires a reason.
+Toggling a Schedule requires a reason. 
 Use ` + "`" + `--reason` + "`" + ` to note the issue leading to the pause or unpause.
 
 Schedule toggles follow this syntax:
@@ -453,15 +453,15 @@ By default, this action is subject to the Overlap Policy of the Schedule.
 
 Schedule triggers follow this syntax:
 ` + "`" + `temporal schedule trigger` + "`" + ` can be used to start a Workflow Run immediately.
-` + "`" + `temporal schedule trigger --sid 'your-schedule-id'` + "`" + `
+` + "`" + `temporal schedule trigger --sid 'your-schedule-id'` + "`" + ` 
 
 The Overlap Policy of the Schedule can be overridden as well.
 ` + "`" + `temporal schedule trigger --sid 'your-schedule-id' --overlap-policy 'AllowAll'` + "`" + `
 
 Use the options provided below to change this command's behavior.`
 
-const ScheduleBackfillUsageText = `The ` + "`" + `temporal schedule backfill` + "`" + ` command executes Actions ahead of their specified time range.
-Backfilling can fill in [Workflow Runs](/concepts/what-is-a-run-id) from a time period when the Schedule was paused, or from before the Schedule was created.
+const ScheduleBackfillUsageText = `The ` + "`" + `temporal schedule backfill` + "`" + ` command executes Actions ahead of their specified time range. 
+Backfilling can fill in [Workflow Runs](/concepts/what-is-a-run-id) from a time period when the Schedule was paused, or from before the Schedule was created. 
 
 Schedule backfills require a valid Schedule ID, along with the time in which to run the Schedule and a change to the overlap policy.
 ` + "`" + `` + "`" + `` + "`" + `
@@ -556,7 +556,7 @@ Use the options listed below to change the command's behavior.`
 
 const ServerUsageText = `Server commands allow you to start and manage the [Temporal Server](/concepts/what-is-the-temporal-server) from the command line.
 
-Currently, ` + "`" + `cli` + "`" + ` server functionality extends to starting the Server.
+Currently, ` + "`" + `cli` + "`" + ` server functionality extends to starting the Server. 
 
 Server commands follow this syntax:
 ` + "`" + `temporal server COMMAND` + "`" + `

--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -95,7 +95,7 @@ There are three types of Batch Jobs:
 	- Terminate: terminates the Workflow Executions specified by the List Filter.
 
 A successfully started Batch job will return a Job ID.
-Use this Job ID to execute other actions on the Batch job. 
+Use this Job ID to execute other actions on the Batch job.
 
 Use the command options below to change the information returned by this command.
 `
@@ -107,13 +107,13 @@ Pass a valid Job ID to return a Batch Job's information.
 
 Use the command options below to change the information returned by this command.`
 
-const ListBatchUsageText = `The ` + "`" + `temporal batch list` + "`" + ` command returns all Batch jobs. 
+const ListBatchUsageText = `The ` + "`" + `temporal batch list` + "`" + ` command returns all Batch jobs.
 Batch Jobs can be returned for an entire Cluster or a single Namespace.
 ` + "`" + `temporal batch list --namespace=MyNamespace` + "`" + `
 
 Use the command options below to change the information returned by this command.`
 
-const TerminateBatchUsageText = `The ` + "`" + `temporal batch terminate` + "`" + ` command terminates a Batch job with the provided Job ID. 
+const TerminateBatchUsageText = `The ` + "`" + `temporal batch terminate` + "`" + ` command terminates a Batch job with the provided Job ID.
 For future reference, provide a reason for terminating the Batch Job.
 
 ` + "`" + `temporal batch terminate --job-id=MyJobId --reason=JobReason` + "`" + `
@@ -267,7 +267,7 @@ Use the options listed below to change the behavior of this command.`
 
 const FailActivityUsageText = `The ` + "`" + `temporal activity fail` + "`" + ` command fails an [Activity Execution](/concepts/what-is-an-activity-execution).
 The Activity must be running on a valid [Workflow](/concepts/what-is-a-workflow).
-` + "`" + `temporal fail --workflow-id=meaningful-business-id --activity-id=MyActivity` + "`" + ` 
+` + "`" + `temporal fail --workflow-id=meaningful-business-id --activity-id=MyActivity` + "`" + `
 
 Use the options listed below to change the behavior of this command.`
 
@@ -323,10 +323,10 @@ Passing the 'local' [Namespace](/concepts/what-is-a-namespace) returns the name,
 ` + "`" + `temporal env get local` + "`" + `
 ` + "`" + `
 Output:
-tls-cert-path  /home/my-user/certs/cluster.cert  
-tls-key-path   /home/my-user/certs/cluster.key   
-address        127.0.0.1:7233                    
-namespace      someNamespace 
+tls-cert-path  /home/my-user/certs/cluster.cert
+tls-key-path   /home/my-user/certs/cluster.key
+address        127.0.0.1:7233
+namespace      someNamespace
 ` + "`" + `
 
 Output can be narrowed down to a specific environmental property.
@@ -412,7 +412,7 @@ temporal schedule create \
 		--cron '3 11 * * Fri' \
 		--wid 'your-workflow-id' \
 		--tq 'your-task-queue' \
-		--type 'YourWorkflowType' 
+		--type 'YourWorkflowType'
 ` + "`" + `` + "`" + `` + "`" + `
 
 Any combination of ` + "`" + `--cal` + "`" + `, ` + "`" + `--interval` + "`" + `, and ` + "`" + `--cron` + "`" + ` is supported.
@@ -429,17 +429,17 @@ temporal schedule update 			\
 		--cron '3 11 * * Fri' 		\
 		--wid 'your-workflow-id' 	\
 		--tq 'your-task-queue' 		\
-		--type 'YourWorkflowType' 
+		--type 'YourWorkflowType'
 ` + "`" + `` + "`" + `` + "`" + `
 
-Updating a Schedule takes the given options and replaces the entire configuration of the Schedule with what's provided. 
+Updating a Schedule takes the given options and replaces the entire configuration of the Schedule with what's provided.
 If you only change one value of the Schedule, be sure to provide the other unchanged fields to prevent them from being overwritten.
 
 Use the command options below to change the information returned by this command.`
 
 const ScheduleToggleUsageText = `The ` + "`" + `temporal schedule toggle` + "`" + ` command can pause and unpause a [Schedule](/concepts/what-is-a-schedule).
 
-Toggling a Schedule requires a reason. 
+Toggling a Schedule requires a reason.
 Use ` + "`" + `--reason` + "`" + ` to note the issue leading to the pause or unpause.
 
 Schedule toggles follow this syntax:
@@ -453,15 +453,15 @@ By default, this action is subject to the Overlap Policy of the Schedule.
 
 Schedule triggers follow this syntax:
 ` + "`" + `temporal schedule trigger` + "`" + ` can be used to start a Workflow Run immediately.
-` + "`" + `temporal schedule trigger --sid 'your-schedule-id'` + "`" + ` 
+` + "`" + `temporal schedule trigger --sid 'your-schedule-id'` + "`" + `
 
 The Overlap Policy of the Schedule can be overridden as well.
 ` + "`" + `temporal schedule trigger --sid 'your-schedule-id' --overlap-policy 'AllowAll'` + "`" + `
 
 Use the options provided below to change this command's behavior.`
 
-const ScheduleBackfillUsageText = `The ` + "`" + `temporal schedule backfill` + "`" + ` command executes Actions ahead of their specified time range. 
-Backfilling can fill in [Workflow Runs](/concepts/what-is-a-run-id) from a time period when the Schedule was paused, or from before the Schedule was created. 
+const ScheduleBackfillUsageText = `The ` + "`" + `temporal schedule backfill` + "`" + ` command executes Actions ahead of their specified time range.
+Backfilling can fill in [Workflow Runs](/concepts/what-is-a-run-id) from a time period when the Schedule was paused, or from before the Schedule was created.
 
 Schedule backfills require a valid Schedule ID, along with the time in which to run the Schedule and a change to the overlap policy.
 ` + "`" + `` + "`" + `` + "`" + `
@@ -546,7 +546,7 @@ const WorkflowDeleteUsageText = `The ` + "`" + `temporal workflow delete` + "`" 
 
 Use the options listed below to change the command's behavior.`
 
-const WorkflowTraceUsageText = `The ` + "`" + `temporal workflow trace` + "`" + ` command tracks the progress of a [Workflow Execution](/concepts/what-is-a-workflow-execution) and any  [Child Workflows](/concepts/what-is-a-child-workflow-execution) it generates.
+const WorkflowTraceUsageText = `The ` + "`" + `temporal workflow trace` + "`" + ` command tracks the progress of a [Workflow Execution](/concepts/what-is-a-workflow-execution) and any [Child Workflows](/concepts/what-is-a-child-workflow-execution) it generates.
 
 Use the options listed below to change the command's behavior.`
 
@@ -556,7 +556,7 @@ Use the options listed below to change the command's behavior.`
 
 const ServerUsageText = `Server commands allow you to start and manage the [Temporal Server](/concepts/what-is-the-temporal-server) from the command line.
 
-Currently, ` + "`" + `cli` + "`" + ` server functionality extends to starting the Server. 
+Currently, ` + "`" + `cli` + "`" + ` server functionality extends to starting the Server.
 
 Server commands follow this syntax:
 ` + "`" + `temporal server COMMAND` + "`" + `

--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -75,7 +75,7 @@ const (
 	FlagSkipBaseDefinition         = "Skip a Workflow Execution if the base Run is not the current Workflow Run."
 	FlagNonDeterministicDefinition = "Reset Workflow Execution if its last Event is `WorkflowTaskFailed` with a nondeterministic error."
 	FlagDryRunDefinition           = "Simulate reset without resetting any Workflow Executions."
-	FlagDepthDefinition            = "Number of Child Workflows to expand. Use -1 to expand all Child Workflows."
+	FlagDepthDefinition            = "Depth of child workflows to fetch. Use -1 to fetch child workflows at any depth."
 	FlagConcurrencyDefinition      = "Request concurrency."
 	FlagNoFoldDefinition           = "Disable folding. All Child Workflows within the set depth will be fetched and displayed."
 

--- a/trace/execution_icons.go
+++ b/trace/execution_icons.go
@@ -1,0 +1,102 @@
+package trace
+
+import (
+	"github.com/fatih/color"
+	"go.temporal.io/api/enums/v1"
+)
+
+var (
+	StatusRunning              string = color.BlueString("▷")
+	StatusCompleted            string = color.GreenString("✓")
+	StatusTerminated           string = color.RedString("x")
+	StatusCanceled             string = color.YellowString("x")
+	StatusFailed               string = color.RedString("!")
+	StatusContinueAsNew        string = color.GreenString("»")
+	StatusTimedOut             string = color.RedString("⏱")
+	StatusUnspecifiedScheduled string = "•"
+	StatusCancelRequested      string = color.YellowString("▷")
+	StatusTimerWaiting         string = color.BlueString("⧖")
+	StatusTimerFired           string = color.GreenString("⧖")
+	StatusTimerCanceled        string = color.YellowString("⧖")
+)
+
+var workflowIcons = map[enums.WorkflowExecutionStatus]string{
+	enums.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED:      StatusUnspecifiedScheduled,
+	enums.WORKFLOW_EXECUTION_STATUS_RUNNING:          StatusRunning,
+	enums.WORKFLOW_EXECUTION_STATUS_COMPLETED:        StatusCompleted,
+	enums.WORKFLOW_EXECUTION_STATUS_TERMINATED:       StatusTerminated,
+	enums.WORKFLOW_EXECUTION_STATUS_CANCELED:         StatusCanceled,
+	enums.WORKFLOW_EXECUTION_STATUS_FAILED:           StatusFailed,
+	enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW: StatusContinueAsNew,
+	enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:        StatusTimedOut,
+}
+var activityIcons = map[ActivityExecutionStatus]string{
+	ACTIVITY_EXECUTION_STATUS_UNSPECIFIED:      StatusUnspecifiedScheduled,
+	ACTIVITY_EXECUTION_STATUS_SCHEDULED:        StatusUnspecifiedScheduled,
+	ACTIVITY_EXECUTION_STATUS_RUNNING:          StatusRunning,
+	ACTIVITY_EXECUTION_STATUS_COMPLETED:        StatusCompleted,
+	ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED: StatusCancelRequested,
+	ACTIVITY_EXECUTION_STATUS_CANCELED:         StatusCanceled,
+	ACTIVITY_EXECUTION_STATUS_FAILED:           StatusFailed,
+	ACTIVITY_EXECUTION_STATUS_TIMED_OUT:        StatusTimedOut,
+}
+var timerIcons = map[TimerExecutionStatus]string{
+	TIMER_STATUS_WAITING:  StatusTimerWaiting,
+	TIMER_STATUS_FIRED:    StatusTimerFired,
+	TIMER_STATUS_CANCELED: StatusTimerCanceled,
+}
+
+// ExecutionStatus returns the icon (with color) for a given ExecutionState's status.
+func ExecutionStatus(exec ExecutionState) string {
+	switch e := exec.(type) {
+	case *WorkflowExecutionState:
+		if icon, ok := workflowIcons[e.Status]; ok {
+			return icon
+		}
+	case *ActivityExecutionState:
+		if icon, ok := activityIcons[e.Status]; ok {
+			return icon
+		}
+	case *TimerExecutionState:
+		if icon, ok := timerIcons[e.Status]; ok {
+			return icon
+		}
+	}
+	return "?"
+}
+
+// StatusIcon has names for each status (useful for help messages).
+type StatusIcon struct {
+	Name string
+	Icon string
+}
+
+var StatusIconsLegend = []StatusIcon{
+	{
+		Name: "Unspecified or Scheduled", Icon: StatusUnspecifiedScheduled,
+	},
+	{
+		Name: "Running", Icon: StatusRunning,
+	},
+	{
+		Name: "Completed", Icon: StatusCompleted,
+	},
+	{
+		Name: "Continue As New", Icon: StatusContinueAsNew,
+	},
+	{
+		Name: "Failed", Icon: StatusFailed,
+	},
+	{
+		Name: "Timed Out", Icon: StatusTimedOut,
+	},
+	{
+		Name: "Cancel Requested", Icon: StatusCancelRequested,
+	},
+	{
+		Name: "Canceled", Icon: StatusCanceled,
+	},
+	{
+		Name: "Terminated", Icon: StatusTerminated,
+	},
+}

--- a/trace/execution_state.go
+++ b/trace/execution_state.go
@@ -246,6 +246,9 @@ func (state *WorkflowExecutionState) Update(event *history.HistoryEvent) {
 		state.StartTime = event.EventTime
 		state.Attempt = attrs.GetAttempt()
 		state.Type = attrs.GetWorkflowType()
+		if state.Execution.GetRunId() == "" {
+			state.Execution.RunId = attrs.GetOriginalExecutionRunId()
+		}
 
 		state.ParentWorkflowExecution = attrs.ParentWorkflowExecution
 

--- a/trace/execution_state.go
+++ b/trace/execution_state.go
@@ -395,14 +395,13 @@ func (state *WorkflowExecutionState) Update(event *history.HistoryEvent) {
 // This method iteratively sums the LastEventId (the sequential id of the last event processed) and the HistoryLength for all child workflows
 func (state *WorkflowExecutionState) GetNumberOfEvents() (int64, int64) {
 	var current, total int64
-	if state.ChildStates == nil {
-		return 0, 0
-	}
-	for _, child := range state.ChildStates {
-		if childWf, ok := child.(*WorkflowExecutionState); ok {
-			c, t := childWf.GetNumberOfEvents()
-			current += c
-			total += t
+	if state.ChildStates != nil {
+		for _, child := range state.ChildStates {
+			if childWf, ok := child.(*WorkflowExecutionState); ok {
+				c, t := childWf.GetNumberOfEvents()
+				current += c
+				total += t
+			}
 		}
 	}
 	return current + state.LastEventId, total + state.HistoryLength

--- a/trace/execution_state_test.go
+++ b/trace/execution_state_test.go
@@ -26,13 +26,14 @@ package trace
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/history/v1"
-	"testing"
-	"time"
 )
 
 var events = map[string]*history.HistoryEvent{
@@ -781,7 +782,7 @@ func TestWorkflowExecutionState_GetNumberOfEvents(t *testing.T) {
 		wantCurrent int64
 		wantTotal   int64
 	}{
-		"no childs": {
+		"no children": {
 			state: &WorkflowExecutionState{
 				LastEventId:   1,
 				HistoryLength: 5,
@@ -803,7 +804,7 @@ func TestWorkflowExecutionState_GetNumberOfEvents(t *testing.T) {
 			wantCurrent: 6,
 			wantTotal:   13,
 		},
-		"multiple childs": {
+		"multiple children": {
 			state: &WorkflowExecutionState{
 				LastEventId:   5,
 				HistoryLength: 10,

--- a/trace/execution_state_test.go
+++ b/trace/execution_state_test.go
@@ -393,12 +393,12 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 
 func TestExecutionState_UpdateActivities(t *testing.T) {
 	tests := map[string]struct {
-		events         []*history.HistoryEvent
-		expectedChilds []ExecutionState
+		events           []*history.HistoryEvent
+		expectedChildren []ExecutionState
 	}{
 		"activity scheduled": {
 			events: []*history.HistoryEvent{events["started"], events["activity scheduled"]},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -412,7 +412,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["activity scheduled"],
 				events["activity started"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -428,7 +428,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["activity started"],
 				events["activity failed"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -445,7 +445,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["activity started"],
 				events["activity completed"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -461,7 +461,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["second activity scheduled"],
 				events["activity started"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -482,7 +482,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["activity started"],
 				events["activity cancel requested"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -499,7 +499,7 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 				events["activity cancel requested"],
 				events["activity canceled"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&ActivityExecutionState{
 					ActivityId: "abc",
 					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
@@ -515,19 +515,19 @@ func TestExecutionState_UpdateActivities(t *testing.T) {
 			for _, event := range tt.events {
 				state.Update(event)
 			}
-			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+			assert.Equal(t, tt.expectedChildren, state.ChildStates)
 		})
 	}
 }
 
 func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 	tests := map[string]struct {
-		events         []*history.HistoryEvent
-		expectedChilds []ExecutionState
+		events           []*history.HistoryEvent
+		expectedChildren []ExecutionState
 	}{
 		"child workflow initiated": {
 			events: []*history.HistoryEvent{events["started"], events["child workflow initiated"]},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&WorkflowExecutionState{
 					Type: &common.WorkflowType{Name: "baz"},
 					Execution: &common.WorkflowExecution{
@@ -545,7 +545,7 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 				events["child workflow initiated"],
 				events["child workflow started"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&WorkflowExecutionState{
 					Type:   &common.WorkflowType{Name: "baz"},
 					Status: enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
@@ -565,7 +565,7 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 				events["child workflow started"],
 				events["child workflow completed"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&WorkflowExecutionState{
 					Type:   &common.WorkflowType{Name: "baz"},
 					Status: enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
@@ -585,7 +585,7 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 				events["child workflow started"],
 				events["child workflow failed"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&WorkflowExecutionState{
 					Type:   &common.WorkflowType{Name: "baz"},
 					Status: enums.WORKFLOW_EXECUTION_STATUS_FAILED,
@@ -609,7 +609,7 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 				events["child workflow started"],
 				events["child workflow canceled"],
 			},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&WorkflowExecutionState{
 					Type:   &common.WorkflowType{Name: "baz"},
 					Status: enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
@@ -629,19 +629,19 @@ func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
 			for _, event := range tt.events {
 				state.Update(event)
 			}
-			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+			assert.Equal(t, tt.expectedChildren, state.ChildStates)
 		})
 	}
 }
 
 func TestExecutionState_UpdateTimers(t *testing.T) {
 	tests := map[string]struct {
-		events         []*history.HistoryEvent
-		expectedChilds []ExecutionState
+		events           []*history.HistoryEvent
+		expectedChildren []ExecutionState
 	}{
 		"timer started": {
 			events: []*history.HistoryEvent{events["started"], events["timer started"]},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&TimerExecutionState{
 					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
@@ -652,7 +652,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 		},
 		"timer fired": {
 			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer fired"]},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&TimerExecutionState{
 					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
@@ -663,7 +663,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 		},
 		"timer canceled": {
 			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer canceled"]},
-			expectedChilds: []ExecutionState{
+			expectedChildren: []ExecutionState{
 				&TimerExecutionState{
 					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
@@ -680,7 +680,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 			for _, event := range tt.events {
 				state.Update(event)
 			}
-			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+			assert.Equal(t, tt.expectedChildren, state.ChildStates)
 		})
 	}
 }

--- a/trace/execution_test.go
+++ b/trace/execution_test.go
@@ -1,0 +1,199 @@
+package trace
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/api/enums/v1"
+)
+
+var foldStatus = []enums.WorkflowExecutionStatus{
+	enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+	enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
+	enums.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+	enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+}
+
+func GetRelativeTime(d time.Duration) *time.Time {
+	startTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	if d > 0 {
+		startTime = startTime.Add(d)
+	}
+	return &startTime
+}
+
+func GetDuration(d time.Duration) *time.Duration {
+	return &d
+}
+
+func TestExecuteWorkflowTemplate(t *testing.T) {
+	tests := map[string]struct {
+		state ExecutionState
+		depth int
+		want  string
+	}{
+		"simple wf": {
+			state: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       1,
+				LastEventId:   52,
+				HistoryLength: 52,
+				ChildStates:   []ExecutionState{},
+			},
+			depth: 0,
+			want: " ╪ ▷ foo \n" +
+				" │   wfId: foo, runId: bar\n",
+		},
+		"extras": {
+			state: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       10,
+				LastEventId:   52,
+				HistoryLength: 52,
+				ChildStates:   []ExecutionState{},
+				StartTime:     GetRelativeTime(0),
+				CloseTime:     GetRelativeTime(time.Hour),
+			},
+			depth: 0,
+			want: " ╪ ✓ foo (1h0m0s, 10 attempts)\n" +
+				" │   wfId: foo, runId: bar\n",
+		},
+		"child wf": {
+			state: &WorkflowExecutionState{
+				Execution:     &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Status:        enums.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+				Type:          &common.WorkflowType{Name: "foo"},
+				Attempt:       1,
+				LastEventId:   52,
+				HistoryLength: 52,
+				ChildStates: []ExecutionState{
+					&WorkflowExecutionState{
+						LastEventId:   1, // Child workflow has its own events
+						HistoryLength: 1,
+						Status:        enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						Type: &common.WorkflowType{
+							Name: "baz",
+						},
+						Execution: &common.WorkflowExecution{
+							WorkflowId: "childWfId",
+							RunId:      "childRunId",
+						},
+						Attempt: 1,
+					},
+				},
+			},
+			depth: 0,
+			want: " ╪ x foo \n" +
+				" │   wfId: foo, runId: bar\n" +
+				" │   ╪ ▷ baz \n" +
+				" │   │   wfId: childWfId, runId: childRunId\n",
+		},
+		"activity": {
+			state: &ActivityExecutionState{
+				ActivityId: "1",
+				Status:     ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				Type:       &common.ActivityType{Name: "foobar"},
+				Attempt:    0,
+				RetryState: 0,
+				StartTime:  GetRelativeTime(0),
+				CloseTime:  GetRelativeTime(10 * time.Second),
+			},
+			want: " ┼ ✓ foobar (10s)\n",
+		},
+		"timer": {
+			state: &TimerExecutionState{
+				StartToFireTimeout: GetDuration(time.Hour),
+				Status:             TIMER_STATUS_CANCELED,
+				Name:               "Timer (1h0m0s)",
+				StartTime:          GetRelativeTime(0),
+				CloseTime:          GetRelativeTime(10 * time.Minute),
+			},
+			want: " ┼ ⧖ Timer (1h0m0s) (10m0s)\n",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := new(bytes.Buffer)
+			tmpl, err := NewExecutionTemplate(b, foldStatus, false)
+			require.NoError(t, err)
+
+			require.NoError(t, tmpl.Execute(tt.state, tt.depth))
+
+			assert.Equal(t, tt.want, b.String())
+		})
+	}
+}
+
+func TestShouldFold(t *testing.T) {
+	tests := map[string]struct {
+		displayAll   bool
+		currentDepth int
+		state        *WorkflowExecutionState
+		want         bool
+	}{
+		"running": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			},
+			displayAll:   false,
+			currentDepth: 1,
+			want:         false,
+		},
+		"completed": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			displayAll:   false,
+			currentDepth: 1,
+			want:         true,
+		},
+		"canceled": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
+			},
+			displayAll:   false,
+			currentDepth: 1,
+			want:         true,
+		},
+		"terminate": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+			},
+			displayAll:   false,
+			currentDepth: 1,
+			want:         true,
+		},
+		"not deep enough": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			displayAll:   false,
+			currentDepth: 0,
+			want:         false,
+		},
+		"infinite depth": {
+			state: &WorkflowExecutionState{
+				Status: enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			displayAll:   true,
+			currentDepth: 10,
+			want:         false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := ShouldFoldStatus(foldStatus, tt.displayAll)(tt.state, tt.currentDepth)
+
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}

--- a/trace/execution_tmpls.go
+++ b/trace/execution_tmpls.go
@@ -1,0 +1,153 @@
+package trace
+
+import (
+	"embed"
+	"fmt"
+	"github.com/fatih/color"
+	"go.temporal.io/api/enums/v1"
+	"io"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const (
+	MinFoldingDepth = 1
+)
+
+//go:embed templates/*.tmpl
+var templatesFS embed.FS
+
+var (
+	faint = color.New(color.Faint).SprintFunc()
+)
+
+// ExecutionTemplate contains the necessary templates and utilities to render WorkflowExecutionState and its child states.
+type ExecutionTemplate struct {
+	w          io.Writer
+	tmpl       *template.Template
+	shouldFold func(*WorkflowExecutionState, int) bool
+}
+
+// NewExecutionTemplate initializes the templates with the necessary functions.
+func NewExecutionTemplate(w io.Writer, foldStatus []enums.WorkflowExecutionStatus, noFold bool) (*ExecutionTemplate, error) {
+	shouldFold := ShouldFoldStatus(foldStatus, noFold)
+	templateFunctions := template.FuncMap{
+		"statusIcon": ExecutionStatus,
+		"blue":       color.BlueString,
+		"yellow":     color.YellowString,
+		"red":        color.RedString,
+		"faint":      faint,
+		"shouldFold": shouldFold,
+		"indent": func(depths ...int) string {
+			var sum int
+			for _, d := range depths {
+				sum += d
+			}
+			return faint(strings.Repeat(" │  ", sum))
+		},
+		"splitLines": func(str string) []string {
+			return strings.Split(str, "\n")
+		},
+		"duration": DiffDuration,
+	}
+
+	tmpl, err := template.New("output").Funcs(templateFunctions).ParseFS(templatesFS, "templates/*.tmpl")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExecutionTemplate{
+		w:          w,
+		tmpl:       tmpl,
+		shouldFold: shouldFold,
+	}, nil
+}
+
+type StateTemplate struct {
+	State ExecutionState
+	Depth int
+}
+
+// Execute executes the templates for a given Execution state and writes it into the ExecutionTemplate's writer.
+func (t *ExecutionTemplate) Execute(state ExecutionState, depth int) error {
+	if state == nil {
+		return nil
+	}
+
+	var templateName string
+	switch state.(type) {
+	case *WorkflowExecutionState:
+		templateName = "workflow.tmpl"
+	case *ActivityExecutionState:
+		templateName = "activity.tmpl"
+	case *TimerExecutionState:
+		templateName = "timer.tmpl"
+	default:
+		return fmt.Errorf("no template available for %s", state)
+	}
+
+	if err := t.tmpl.ExecuteTemplate(t.w, templateName, &StateTemplate{
+		State: state,
+		Depth: depth,
+	}); err != nil {
+		return err
+	}
+
+	if workflow, isWorkflow := state.(*WorkflowExecutionState); isWorkflow && !t.shouldFold(workflow, depth) {
+		for _, child := range workflow.ChildStates {
+			if err := t.Execute(child, depth+1); err != nil {
+				return err
+			}
+
+		}
+	}
+
+	return nil
+}
+
+// ShouldFoldStatus returns a predicate that will return true when the workflow status can be folded for a given depth.
+// NOTE: Depth starts at 0 (i.e. the root workflow will be at depth 0).
+func ShouldFoldStatus(foldStatus []enums.WorkflowExecutionStatus, noFold bool) func(*WorkflowExecutionState, int) bool {
+	return func(state *WorkflowExecutionState, currentDepth int) bool {
+		if noFold || currentDepth < MinFoldingDepth {
+			return false
+		}
+		for _, s := range foldStatus {
+			if s == state.Status {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// DiffDuration returns a string representing the difference it time between start and close (or start and now).
+func DiffDuration(start *time.Time, close *time.Time) string {
+	if start == nil {
+		return ""
+	}
+	if close != nil {
+		return FmtDuration(close.Sub(*start))
+	}
+	return fmt.Sprintf("%s ago", FmtDuration(time.Now().Sub(*start)))
+}
+
+// FmtDuration produces a string for a given duration, rounding to the most reasonable timeframe.
+func FmtDuration(duration time.Duration) string {
+	if duration < time.Second {
+		return duration.Round(time.Millisecond).String()
+	} else if duration < time.Hour {
+		return duration.Round(time.Second).String()
+	} else if duration < 24*time.Hour {
+		return duration.Round(time.Minute).String()
+	} else if duration < 7*24*time.Hour {
+		days := int(duration.Hours() / 24)
+		hours := int(duration.Hours()) - days*24 // % doesn't work for float
+		return fmt.Sprintf("%dd%dh", days, hours)
+	} else {
+		days := int(duration.Hours() / 24)
+		weeks := int(duration.Hours() / (7 * 24))
+		return fmt.Sprintf("%dw%dd", weeks, days)
+	}
+}

--- a/trace/tail_buffer.go
+++ b/trace/tail_buffer.go
@@ -1,0 +1,58 @@
+package trace
+
+import (
+	"bytes"
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+// StripBytesAnsi removes all ansi codes from a byte array.
+func StripBytesAnsi(b []byte) []byte {
+	return re.ReplaceAllLiteral(b, []byte{})
+}
+
+// CountBytesPrintWidth counts the number of printed characters a byte array will take.
+func CountBytesPrintWidth(b []byte) int {
+	return len(bytes.Runes(StripBytesAnsi(b)))
+}
+
+// LineHeight returns the number of lines a string is going to take
+func LineHeight(line []byte, maxWidth int) int {
+	return 1 + (CountBytesPrintWidth(line)-1)/maxWidth
+}
+
+func ReverseLinesBuffer(buf *bytes.Buffer) [][]byte {
+	lines := bytes.Split(buf.Bytes(), []byte("\n"))
+	revBuf := make([][]byte, len(lines))
+
+	j := 0
+	// TODO: we can probably stop sooner since we're definitely not going to do more than maxLines lines
+	for i := len(lines) - 1; i >= 0; i-- {
+		revBuf[j] = lines[i]
+		j++
+	}
+	return revBuf
+}
+
+// NewTailBoxBoundBuffer returns trims a buffer to fit into the box defined by maxLines and maxWidth and the number of lines printing the buffer will take.
+// For no limit on lines, use maxLines = 0.
+// NOTE: This is a best guess. It'll take ansi codes into account but some other chars might throw this off.
+func NewTailBoxBoundBuffer(buf *bytes.Buffer, maxLines int, maxWidth int) (*bytes.Buffer, int) {
+	res := make([][]byte, 0)
+	lines := 0
+
+	for _, line := range ReverseLinesBuffer(buf) {
+		lineHeight := LineHeight(line, maxWidth)
+		if lineHeight+lines > maxLines && maxLines > 0 {
+			break
+		} else {
+			res = append([][]byte{line}, res...)
+			lines += lineHeight
+		}
+	}
+
+	return bytes.NewBuffer(bytes.Join(res, []byte{'\n'})), lines
+}

--- a/trace/tail_buffer_test.go
+++ b/trace/tail_buffer_test.go
@@ -1,0 +1,159 @@
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripBytesAnsi(t *testing.T) {
+	tests := map[string]struct {
+		b    []byte
+		want []byte
+	}{
+		"no ansi": {
+			b:    []byte("foo"),
+			want: []byte("foo"),
+		},
+		"moving cursor": {
+			b:    []byte(fmt.Sprintf("%sfoo", MoveCursorUp(2))),
+			want: []byte("foo"),
+		},
+		"start of line": {
+			b:    []byte(fmt.Sprintf("%sfoo", AnsiMoveCursorStartLine)),
+			want: []byte("foo"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, StripBytesAnsi(tt.b), "StripBytesAnsi(%v)", tt.b)
+		})
+	}
+}
+
+func TestGetBufferPrintWidth(t *testing.T) {
+	tests := map[string]struct {
+		b    []byte
+		want int
+	}{
+		"sanity": {
+			b:    []byte("test"),
+			want: 4,
+		},
+		"utf8 char": {
+			b:    []byte("a界c"),
+			want: 3,
+		},
+		"ansi codes": {
+			b:    []byte(color.RedString("red")),
+			want: 3,
+		},
+		"actual output": {
+			b:    []byte("\x1b[2m ╪\x1b[0m \x1b[34m▷\x1b[0m \x1b[2mcnab.CNAB_\x1b[0mRunTask \x1b[2m(5m47s ago)\x1b[0m"),
+			want: 34,
+		},
+		"many pipes": {
+			b:    []byte(" │   │   │   │   │   │   ┼ ✓ cnab.BundleExecutor_PullBundleActionWorker (119ms)"),
+			want: 79,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, CountBytesPrintWidth(tt.b), "CountBytesPrintWidth(%q)", tt.b)
+		})
+	}
+}
+
+func TestNewTailBoxBoundBuffer(t *testing.T) {
+	type args struct {
+		buf      *bytes.Buffer
+		maxLines int
+		maxWidth int
+	}
+	tests := map[string]struct {
+		args      args
+		wantBuf   *bytes.Buffer
+		wantLines int
+	}{
+		"sanity": {
+			args: args{
+				buf:      bytes.NewBufferString("foo\nbar\nbaz"),
+				maxLines: 100,
+				maxWidth: 100,
+			},
+			wantBuf:   bytes.NewBufferString("foo\nbar\nbaz"),
+			wantLines: 3,
+		},
+		"zero max lines": {
+			args: args{
+				buf:      bytes.NewBufferString("foo\nbar\nbaz"),
+				maxLines: 0,
+				maxWidth: 100,
+			},
+			wantBuf:   bytes.NewBufferString("foo\nbar\nbaz"),
+			wantLines: 3,
+		},
+		"too many lines": {
+			args: args{
+				buf:      bytes.NewBufferString("foo\nbar\nbaz"),
+				maxLines: 2,
+				maxWidth: 100,
+			},
+			wantBuf:   bytes.NewBufferString("bar\nbaz"),
+			wantLines: 2,
+		},
+		"too wide": {
+			args: args{
+				buf:      bytes.NewBufferString("foo\nbar\nbaz"),
+				maxLines: 100,
+				maxWidth: 2,
+			},
+			wantBuf:   bytes.NewBufferString("foo\nbar\nbaz"),
+			wantLines: 6,
+		},
+		"dont print unfinished lines": {
+			// Since foo takes two lines and would be cut in half, we won't return it (since it might mangle some ansi codes).
+			args: args{
+				buf:      bytes.NewBufferString("foo\nbar\nbaz"),
+				maxLines: 5,
+				maxWidth: 2,
+			},
+			wantBuf:   bytes.NewBufferString("bar\nbaz"),
+			wantLines: 4,
+		},
+		"actual output": {
+			// TODO: consider using snapshots for these tests
+			args: args{
+				// 5 lines shorter than 70, 2 lines longer than 70:
+				// │   ┼ ✓ cnab.bundleexecutor_experimentsisenabled (9ms)
+				// │   ┼ ✓ cnab.bundleexecutor_experimentsisenabled (9ms)
+				// │   ┼ ✓ cnab.bundleexecutor_experimentsisenabled (8ms)
+				// │   ╪ ▷ cnab.cnabinternal_scheduleworkflowcleanup (15s ago)
+				// │   │   wfid: becc1b71-1fed-4831-9ca6-05f4b212f602_51, runid: a248024d-1728-47b7-a877-ce6721aca5f7
+				// │   ╪ ▷ cnab.cnab_checkworkflowauthorization (15s ago)
+				// │   │   wfid: becc1b71-1fed-4831-9ca6-05f4b212f602_56, runid: 570863ad-4f66-4a03-9756-bb007eb7d3fa
+				buf:      bytes.NewBufferString("\x1b[2m │   ┼\x1b[0m \x1b[32m✓\x1b[0m \x1b[2mcnab.bundleexecutor_\x1b[0mexperimentsisenabled \x1b[2m(9ms)\x1b[0m\n\x1b[2m │   ┼\x1b[0m \x1b[32m✓\x1b[0m \x1b[2mcnab.bundleexecutor_\x1b[0mexperimentsisenabled \x1b[2m(9ms)\x1b[0m\n\x1b[2m │   ┼\x1b[0m \x1b[32m✓\x1b[0m \x1b[2mcnab.bundleexecutor_\x1b[0mexperimentsisenabled \x1b[2m(8ms)\x1b[0m\n\x1b[2m │   ╪\x1b[0m \x1b[34m▷\x1b[0m \x1b[2mcnab.cnabinternal_\x1b[0mscheduleworkflowcleanup \x1b[2m(15s ago)\x1b[0m\n\x1b[2m │   │\x1b[0m   \x1b[2mwfid:\x1b[0m \x1b[34mbecc1b71-1fed-4831-9ca6-05f4b212f602_51\x1b[0m\x1b[2m, \x1b[0m\x1b[2mrunid:\x1b[0m \x1b[34ma248024d-1728-47b7-a877-ce6721aca5f7\x1b[0m\n\x1b[2m │   ╪\x1b[0m \x1b[34m▷\x1b[0m \x1b[2mcnab.cnab_\x1b[0mcheckworkflowauthorization \x1b[2m(15s ago)\x1b[0m\n\x1b[2m │   │\x1b[0m   \x1b[2mwfid:\x1b[0m \x1b[34mbecc1b71-1fed-4831-9ca6-05f4b212f602_56\x1b[0m\x1b[2m, \x1b[0m\x1b[2mrunid:\x1b[0m \x1b[34m570863ad-4f66-4a03-9756-bb007eb7d3fa\x1b[0m"),
+				maxLines: 6,
+				maxWidth: 70, // This should only trigger newlines on the long lines but none of the others
+			},
+			// Expected:
+			// │   ╪ ▷ cnab.cnabinternal_scheduleworkflowcleanup (15s ago)
+			// │   │   wfid: becc1b71-1fed-4831-9ca6-05f4b212f602_51, runid: a248024d-1728-47b7-a877-ce6721aca5f7
+			// │   ╪ ▷ cnab.cnab_checkworkflowauthorization (15s ago)
+			// │   │   wfid: becc1b71-1fed-4831-9ca6-05f4b212f602_56, runid: 570863ad-4f66-4a03-9756-bb007eb7d3fa
+			wantBuf:   bytes.NewBufferString("\x1b[2m │   ╪\x1b[0m \x1b[34m▷\x1b[0m \x1b[2mcnab.cnabinternal_\x1b[0mscheduleworkflowcleanup \x1b[2m(15s ago)\x1b[0m\n\x1b[2m │   │\x1b[0m   \x1b[2mwfid:\x1b[0m \x1b[34mbecc1b71-1fed-4831-9ca6-05f4b212f602_51\x1b[0m\x1b[2m, \x1b[0m\x1b[2mrunid:\x1b[0m \x1b[34ma248024d-1728-47b7-a877-ce6721aca5f7\x1b[0m\n\x1b[2m │   ╪\x1b[0m \x1b[34m▷\x1b[0m \x1b[2mcnab.cnab_\x1b[0mcheckworkflowauthorization \x1b[2m(15s ago)\x1b[0m\n\x1b[2m │   │\x1b[0m   \x1b[2mwfid:\x1b[0m \x1b[34mbecc1b71-1fed-4831-9ca6-05f4b212f602_56\x1b[0m\x1b[2m, \x1b[0m\x1b[2mrunid:\x1b[0m \x1b[34m570863ad-4f66-4a03-9756-bb007eb7d3fa\x1b[0m"),
+			wantLines: 6,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, got1 := NewTailBoxBoundBuffer(tt.args.buf, tt.args.maxLines, tt.args.maxWidth)
+			assert.Equalf(t, tt.wantBuf, got, "NewTailBoxBoundBuffer(%q, %v, %v)", tt.args.buf.String(), tt.args.maxLines, tt.args.maxWidth)
+			// This one helps identify mismatches
+			assert.Equalf(t, tt.wantBuf.String(), got.String(), "NewTailBoxBoundBuffer(%q, %v, %v)", tt.args.buf.String(), tt.args.maxLines, tt.args.maxWidth)
+			assert.Equalf(t, tt.wantLines, got1, "NewTailBoxBoundBuffer(%q, %v, %v)", tt.args.buf.String(), tt.args.maxLines, tt.args.maxWidth)
+		})
+	}
+}

--- a/trace/templates/activity.tmpl
+++ b/trace/templates/activity.tmpl
@@ -1,0 +1,3 @@
+{{ indent .Depth }} {{ faint "┼" }} {{ statusIcon .State }} {{ .State.GetName }} {{ template "extras" . }}
+{{ template "failure" . -}}
+{{ template "retry" . -}}

--- a/trace/templates/common.tmpl
+++ b/trace/templates/common.tmpl
@@ -1,0 +1,23 @@
+{{ define "extras" }}
+{{- if .State.StartTime }}{{ faint "(" }}{{ duration .State.StartTime .State.CloseTime | faint }}
+    {{- if gt (.State.GetAttempt) 1 }}{{ printf ", %d attempts" .State.GetAttempt | faint }}{{end}}
+{{- faint ")"}}{{ end }}
+{{- end }}
+
+{{ define "failure" }}
+{{- with .State.GetFailure }}
+{{- $lines := splitLines .Message }}
+{{- /* Print first error line with title */}}
+{{- indent $.Depth 1 }} {{ red "Failure:" }} {{ index $lines 0 | faint }}
+{{- /* Print other error lines, add extra 4 spaces to indent so it looks like it's part of the failure message */}}
+{{range $line := slice $lines 1 }}
+    {{- indent $.Depth 1 }}     {{ faint $line }}
+{{ end }}
+{{- end }}
+{{- end }}
+
+{{ define "retry" }}
+{{- with .State.RetryState }}
+{{- indent $.Depth 1 }} {{ red "Retry state:" }} {{ faint . }}
+{{ end }}
+{{- end }}

--- a/trace/templates/timer.tmpl
+++ b/trace/templates/timer.tmpl
@@ -1,0 +1,1 @@
+{{ indent .Depth }} {{ faint "┼" }} {{ statusIcon .State }} {{ .State.GetName }} {{ template "extras" . }}

--- a/trace/templates/workflow.tmpl
+++ b/trace/templates/workflow.tmpl
@@ -1,0 +1,27 @@
+{{ indent .Depth }} {{ faint "╪" }} {{ statusIcon .State }} {{ .State.GetName }} {{ template "extras" . }}
+{{ indent .Depth 1 }} {{ with .State.Execution }}{{ faint "wfId:" }} {{ .WorkflowId |  blue }} {{- faint ", runId:" }} {{ .RunId | blue }}{{ end }}
+{{ template "failure" . }}{{ template "retry" . }}
+
+{{- /* Termination Request */}}
+{{- with .State.Termination -}}
+{{ with .Reason }}
+    {{- indent $.Depth 1 }} {{ "Termination reason:" | yellow }} {{ . | faint }}
+{{ end -}}
+{{ with .Identity }}
+    {{- indent $.Depth 1 }} {{ "Termination request id:" | yellow }} {{ . | faint }}
+{{ end -}}
+{{ end -}}
+
+{{- /* Cancel Request */}}
+{{- with .State.CancelRequest -}}
+{{ with .Cause }}
+    {{- indent $.Depth 1 }} {{ "Cancel cause:" | yellow }} {{ . | faint }}
+{{ end -}}
+{{ with .Identity }}
+    {{- indent $.Depth 1 }} {{ "Cancel request id:" | yellow }} {{ . | faint }}
+{{ end -}}
+{{ end -}}
+
+{{- /* Folding */}}
+{{- if shouldFold .State .Depth }}{{ indent $.Depth 1 }} {{ faint "↳ execution folded" }}
+{{ end -}}

--- a/trace/term_writer.go
+++ b/trace/term_writer.go
@@ -103,10 +103,10 @@ func (w *TermWriter) clearLines() error {
 	}
 	b := bytes.NewBuffer([]byte{})
 	if w.lineCount > 1 {
-		b.Write([]byte(MoveCursorUp(w.lineCount - 1)))
+		_, _ = b.Write([]byte(MoveCursorUp(w.lineCount - 1)))
 	}
-	b.Write([]byte(AnsiMoveCursorStartLine))
-	b.Write([]byte(AnsiEraseToEnd))
+	_, _ = b.Write([]byte(AnsiMoveCursorStartLine))
+	_, _ = b.Write([]byte(AnsiEraseToEnd))
 	_, err := w.out.Write(b.Bytes())
 	return err
 }

--- a/trace/term_writer.go
+++ b/trace/term_writer.go
@@ -1,0 +1,146 @@
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	AnsiMoveCursorUp        = "\x1b[%dA"
+	AnsiMoveCursorStartLine = "\x1b[0G"
+	AnsiEraseToEnd          = "\x1b[0J"
+)
+
+func MoveCursorUp(lines int) string {
+	return fmt.Sprintf(AnsiMoveCursorUp, lines)
+}
+
+type TermWriter struct {
+	// out is the writer to write to
+	out io.Writer
+
+	buf       *bytes.Buffer
+	mtx       sync.Mutex
+	lineCount int
+
+	termWidth  int
+	termHeight int
+}
+
+// NewTermWriter returns a new TermWriter set to output to Stdout.
+// TermWriter is a stateful writer designed to print into a terminal window by limiting the number of lines printed what fits and clearing them on new outputs.
+func NewTermWriter() *TermWriter {
+	w := &TermWriter{buf: new(bytes.Buffer)}
+	return w.WithWriter(io.Writer(os.Stdout))
+}
+
+// WithWriter sets the writer for TermWriter.
+func (w *TermWriter) WithWriter(out io.Writer) *TermWriter {
+	w.out = out
+	return w
+}
+
+// WithSize sets the size of TermWriter to the desired width and height.
+func (w *TermWriter) WithSize(width, height int) *TermWriter {
+	if width <= 0 {
+		panic(fmt.Errorf("TermWriter cannot have width %d", width))
+	}
+	if height <= 0 {
+		panic(fmt.Errorf("TermWriter cannot have height %d", width))
+	}
+	w.termHeight = height
+	w.termWidth = width
+	return w
+}
+
+func (w *TermWriter) GetSize() (int, int) {
+	return w.termWidth, w.termHeight
+}
+
+// WithTerminalSize sets the size of TermWriter to that of the terminal.
+func (w *TermWriter) WithTerminalSize() *TermWriter {
+	termWidth, termHeight := getTerminalSize()
+	return w.WithSize(termWidth, termHeight)
+}
+
+// getTerminalSize returns the current number of columns and rows in the active console window.
+// The return value of this function is in the order of cols, rows.
+// Copied from https://github.com/nathan-fiscaletti/consolesize-go/blob/master/consolesize_unix.go
+func getTerminalSize() (int, int) {
+	var size struct {
+		rows    uint16
+		cols    uint16
+		xpixels uint16
+		ypixels uint16
+	}
+	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(syscall.Stdout), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&size)))
+	return int(size.cols), int(size.rows)
+}
+
+// Write save the contents of buf to the writer b. The only errors returned are ones encountered while writing to the underlying buffer.
+// TODO: Consider merging it into Flush since we might always want to write and flush. Alternatively, we can pass the writer to the Sprint functions and write (but we might run into issues if the normal writing is interrupted and the interrupt writing starts).
+func (w *TermWriter) Write(buf []byte) (n int, err error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	return w.buf.Write(buf)
+}
+
+// WriteString writes a string into TermWriter.
+func (w *TermWriter) WriteString(s string) (n int, err error) {
+	return w.Write([]byte(s))
+}
+
+// clearLines prints the ansi codes to clear a given number of lines.
+func (w *TermWriter) clearLines() error {
+	if w.lineCount == 0 {
+		return nil
+	}
+	b := bytes.NewBuffer([]byte{})
+	if w.lineCount > 1 {
+		b.Write([]byte(MoveCursorUp(w.lineCount - 1)))
+	}
+	b.Write([]byte(AnsiMoveCursorStartLine))
+	b.Write([]byte(AnsiEraseToEnd))
+	_, err := w.out.Write(b.Bytes())
+	return err
+}
+
+// Flush writes to the out and resets the buffer. It should be called after the last call to Write to ensure that any data buffered in the TermWriter is written to output.
+// Any incomplete escape sequence at the end is considered complete for formatting purposes.
+// An error is returned if the contents of the buffer cannot be written to the underlying output stream.
+func (w *TermWriter) Flush(trim bool) error {
+	if w.termWidth <= 0 {
+		return fmt.Errorf("TermWriter cannot flush without a valid width (current: %d)", w.termWidth)
+	}
+
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	// Do nothing if buffer is empty.
+	if len(w.buf.Bytes()) == 0 {
+		return nil
+	}
+
+	maxLines := 0
+	if trim {
+		maxLines = w.termHeight
+	}
+	// Tail the buffer (if necessary) and count the number of lines
+	r, lines := NewTailBoxBoundBuffer(w.buf, maxLines, w.termWidth)
+
+	// Clear the last printed lines and store the new amount of lines that are going to be printed.
+	if err := w.clearLines(); err != nil {
+		return err
+	}
+	w.lineCount = lines
+
+	_, err := w.out.Write(r.Bytes())
+	w.buf.Reset()
+	return err
+}

--- a/trace/term_writer_test.go
+++ b/trace/term_writer_test.go
@@ -1,0 +1,112 @@
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTermWriter_OneFlush(t *testing.T) {
+	tests := map[string]struct {
+		width   int
+		height  int
+		trim    bool
+		content string
+		want    string
+	}{
+		"sanity": {
+			width:   10,
+			height:  10,
+			trim:    true,
+			content: "foobarbaz",
+			want:    "foobarbaz",
+		},
+		"tail trimmed content": {
+			width:   10,
+			height:  1,
+			trim:    true,
+			content: "foo\nbar",
+			want:    "bar",
+		},
+		"trim wide content": {
+			width:   3,
+			height:  2,
+			trim:    true,
+			content: "foo\nbarbaz",
+			want:    "barbaz",
+		},
+		"trimmed content doesn't cut through a line": {
+			width:   3,
+			height:  2,
+			trim:    true,
+			content: "foobarbaz",
+			want:    "",
+		},
+		"no trimming": {
+			width:   3,
+			height:  2,
+			trim:    false,
+			content: "foobarbaz",
+			want:    "foobarbaz",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := bytes.NewBufferString("") // Start with an empty string so we can test no content being written
+			w := NewTermWriter().WithWriter(b).WithSize(tt.width, tt.height)
+
+			_, err := w.WriteString(tt.content)
+			err = w.Flush(tt.trim)
+
+			require.NoError(t, err)
+			require.Equalf(t, b, bytes.NewBufferString(tt.want), "flushed message doesn't match expected message")
+		})
+	}
+}
+
+func TestTermWriter_MultipleFlushes(t *testing.T) {
+	tests := map[string]struct {
+		width   int
+		height  int
+		trim    bool
+		content []string
+		want    string
+	}{
+		"sanity": {
+			width:   10,
+			height:  10,
+			trim:    true,
+			content: []string{"foobarbaz"},
+			want:    "foobarbaz",
+		},
+		"write two single lines": {
+			width:   10,
+			height:  10,
+			trim:    true,
+			content: []string{"foo", "bar"},
+			want:    fmt.Sprintf("foo%s%sbar", AnsiMoveCursorStartLine, AnsiEraseToEnd),
+		},
+		"write two double lines": {
+			width:   10,
+			height:  10,
+			trim:    true,
+			content: []string{"foo\nfoo", "bar\nbar"},
+			want:    fmt.Sprintf("foo\nfoo%s%s%sbar\nbar", MoveCursorUp(1), AnsiMoveCursorStartLine, AnsiEraseToEnd),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := bytes.NewBufferString("") // Start with an empty string so we can test no content being written
+			w := NewTermWriter().WithWriter(b).WithSize(tt.width, tt.height)
+
+			for _, s := range tt.content {
+				_, err := w.WriteString(s)
+				err = w.Flush(tt.trim)
+				require.NoError(t, err)
+			}
+
+			require.Equalf(t, b, bytes.NewBufferString(tt.want), "flushed message doesn't match expected message")
+		})
+	}
+}

--- a/trace/trace_commands.go
+++ b/trace/trace_commands.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"fmt"
+	"github.com/fatih/color"
 	"github.com/temporalio/cli/client"
 	"github.com/temporalio/cli/common"
 	"github.com/urfave/cli/v2"
@@ -13,8 +14,12 @@ import (
 	"time"
 )
 
+var (
+	title = color.New(color.FgMagenta).SprintFunc()
+)
+
 func GetFoldStatus(c *cli.Context) ([]enums.WorkflowExecutionStatus, error) {
-	values := []enums.WorkflowExecutionStatus{}
+	var values []enums.WorkflowExecutionStatus
 	flagFold := c.String(common.FlagFold)
 	for _, v := range strings.Split(flagFold, ",") {
 		var status enums.WorkflowExecutionStatus
@@ -42,25 +47,18 @@ func GetFoldStatus(c *cli.Context) ([]enums.WorkflowExecutionStatus, error) {
 	return values, nil
 }
 
-// printWorkflowTrace prints and updates a workflow trace following printWorkflowProgress pattern
-func printWorkflowTrace(c *cli.Context, wid, rid string) (int, error) {
+// PrintWorkflowTrace prints and updates a workflow trace following printWorkflowProgress pattern
+func PrintWorkflowTrace(c *cli.Context, wid, rid string, foldStatus []enums.WorkflowExecutionStatus) (int, error) {
 	childsDepth := c.Int(common.FlagDepth)
 	concurrency := c.Int(common.FlagConcurrency)
-	allFlag := c.Bool(common.FlagNoFold)
-
-	foldStatus, err := GetFoldStatus(c)
-	if err != nil {
-		return 1, err
-	}
+	noFold := c.Bool(common.FlagNoFold)
 
 	sdkClient, err := client.GetSDKClient(c)
-	//sdkClient, err := temporal.NewClientFromEnv()
 	if err != nil {
 		return 1, err
 	}
 
 	tcCtx, cancel := common.NewIndefiniteContext(c)
-	//tcCtx, cancel := context.WithCancel(c.Context)
 	defer cancel()
 
 	doneChan := make(chan bool)
@@ -74,7 +72,7 @@ func printWorkflowTrace(c *cli.Context, wid, rid string) (int, error) {
 	// Start update fetching
 	var update *WorkflowExecutionUpdate
 	go func() {
-		iter, err := GetWorkflowExecutionUpdates(tcCtx, sdkClient, wid, rid, allFlag, foldStatus, childsDepth, concurrency)
+		iter, err := GetWorkflowExecutionUpdates(tcCtx, sdkClient, wid, rid, noFold, foldStatus, childsDepth, concurrency)
 		if err != nil {
 			errChan <- err
 			return
@@ -87,49 +85,72 @@ func printWorkflowTrace(c *cli.Context, wid, rid string) (int, error) {
 		doneChan <- true
 	}()
 
-	//var printedRows int
-	//var prevString string
 	var currentEvents int64
 	var totalEvents int64
 	var isUpToDate bool
-	//fmt.Println(style.Title("Progress:"))
+
+	// Load templates
+	writer := NewTermWriter().WithTerminalSize()
+	tmpl, err := NewExecutionTemplate(writer, foldStatus, noFold)
+	if err != nil {
+		return 1, err
+	}
+
+	fmt.Println(title("Progress:"))
 	for {
 		select {
 		case <-ticker:
 			state := update.GetState()
 			if state == nil {
-				printProgress(currentEvents, totalEvents)
+				writer.WriteString(ProgressString(currentEvents, totalEvents))
+				writer.Flush(true)
 				continue
 			}
 
 			if !isUpToDate {
 				currentEvents, totalEvents = state.GetNumberOfEvents()
-				isUpToDate = currentEvents >= totalEvents && !state.IsArchived
+				isUpToDate = totalEvents > 0 && currentEvents >= totalEvents && !state.IsArchived
 			}
 
 			if isUpToDate {
-				//printedRows, prevString = updateWorkflow(state, printedRows, prevString, allFlag, true)
+				if err := tmpl.Execute(update.GetState(), 0); err != nil {
+					writer.WriteString(fmt.Sprintf("%s %s", color.RedString("Error:"), err.Error()))
+				}
 			} else {
-				printProgress(currentEvents, totalEvents)
+				writer.WriteString(ProgressString(currentEvents, totalEvents))
+			}
+			if err := writer.Flush(true); err != nil {
+				return 1, err
 			}
 		case <-doneChan:
+			return PrintAndExit(writer, tmpl, update)
 		case <-sigChan:
-			// Print last execution state available, this one doesn't need to be trimmed.
-			//updateWorkflow(update.GetState(), printedRows, prevString, allFlag, false)
-			return GetExitCode(update.GetState()), nil
+			return PrintAndExit(writer, tmpl, update)
 		case err = <-errChan:
-			//fmt.Println(style.Danger("Error:"), err)
 			return 1, err
 		}
 	}
 }
 
-func printProgress(currentEvents int64, totalEvents int64) {
-	//if totalEvents == 0 {
-	//	fmt.Printf("%sProcessing HistoryEvents (%d)\r", output.CLEAR_LINE, currentEvents)
-	//} else {
-	//	fmt.Printf("%sProcessing HistoryEvents (%d/%d)\r", output.CLEAR_LINE, currentEvents, totalEvents)
-	//}
+func ProgressString(currentEvents int64, totalEvents int64) string {
+	if totalEvents == 0 {
+		if currentEvents == 0 {
+			return "Processing HistoryEvents"
+		}
+		return fmt.Sprintf("Processing HistoryEvents (%d)", currentEvents)
+	} else {
+		return fmt.Sprintf("Processing HistoryEvents (%d/%d)", currentEvents, totalEvents)
+	}
+}
+
+func PrintAndExit(writer *TermWriter, tmpl *ExecutionTemplate, update *WorkflowExecutionUpdate) (int, error) {
+	if err := tmpl.Execute(update.GetState(), 0); err != nil {
+		return 1, err
+	}
+	if err := writer.Flush(false); err != nil {
+		return 1, err
+	}
+	return GetExitCode(update.GetState()), nil
 }
 
 // GetExitCode returns the exit code for a given workflow execution status.

--- a/trace/trace_commands.go
+++ b/trace/trace_commands.go
@@ -97,7 +97,7 @@ func PrintWorkflowTrace(c *cli.Context, wid, rid string, foldStatus []enums.Work
 		return 1, err
 	}
 
-	fmt.Println(title("Progress:"))
+	_, _ = fmt.Println(title("Progress:"))
 	for {
 		select {
 		case <-ticker:

--- a/trace/workflow_state_worker.go
+++ b/trace/workflow_state_worker.go
@@ -96,8 +96,8 @@ func (job *WorkflowStateJob) Run(group *pond.TaskGroupWithContext) func() error 
 				}
 			}
 
-			// Start child jobs when we're up-to-date
-			if !job.isUpToDate && event.EventId >= state.HistoryLength {
+			// Start child jobs when we're up-to-date and if we haven't reached max depth.
+			if !job.isUpToDate && event.EventId >= state.HistoryLength && job.depth != 0 {
 				job.isUpToDate = true
 				for _, childJob := range job.childJobs {
 					if childJob.ShouldStart() {

--- a/workflow/workflow_commands.go
+++ b/workflow/workflow_commands.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/temporalio/cli/trace"
 	"math/rand"
 	"os"
 	"reflect"
@@ -1437,12 +1438,14 @@ func listArchivedWorkflows(c *cli.Context, sdkClient sdkclient.Client, npt []byt
 }
 
 func TraceWorkflow(c *cli.Context) error {
-	_, err := ParseFoldStatusList(c.String(common.FlagFold))
+	foldStatus, err := ParseFoldStatusList(c.String(common.FlagFold))
 	if err != nil {
 		return err
 	}
-	fmt.Println("Trace hasn't been implemented yet.")
-	return nil
+	wid := c.String(common.FlagWorkflowID)
+	rid := c.String(common.FlagRunID)
+	_, err = trace.PrintWorkflowTrace(c, wid, rid, foldStatus)
+	return err
 }
 
 func UpdateWorkflow(c *cli.Context) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added the frontend to the trace command. This includes the following:

1. `TermWriter`: a way to manage printing/clearing the terminal. This is not Windows-compliant.
2. `ExecutionTemplate`: takes care of rendering the display for ExecutionStatus.
3. Tied everything together so the command words correctly.

### Example

This is an example outlining the different workflow and activity status:
![Screenshot 2023-05-10 at 17 40 26](https://github.com/temporalio/cli/assets/3642110/4b5e9692-8e24-43ef-82ce-d4973eb34b07)

You can see the following (in order)

- Root workflow fails due to a non-retryable error from an activity
- First activity run completes successfully
- First child workflow completes successfully (folded)
- Second child workflow times out 
- 5s timer (fired successfully)
- Failing activity (that fails the root workflow)

## Why?

These changes complete the upstream of the trace functionality that has been used in DataDog for the last year.

## Checklist
<!--- add/delete as needed --->

1. Closes `trace` upstream.

4. Used extensively at DataDog + unit tests and running it against well-known examples (see Example)

5. Any docs updates needed?
Probably those related to the temporal cli regarding how to watch workflow executions.