### PR TITLE
Support custom version in installation via .sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -337,7 +337,7 @@ get_install_dir() {
     local _dir
     _dir="$(get_default_install_dir)"
 
-    while [[ $# -gt 0 ]]; do
+    while [ $# -gt 0 ]; do
         case "$1" in
         --dir)
             _dir="$2"
@@ -359,7 +359,7 @@ get_version() {
     local _version
     _version="latest"
 
-    while [[ $# -gt 0 ]]; do
+    while [ $# -gt 0 ]; do
         case "$1" in
         --version)
             _version="$2"
@@ -371,9 +371,10 @@ get_version() {
         esac
     done
 
-    if [[ $_version == [0-9]* ]]; then
+    if [ "$(echo "$_version" | grep -E '^[0-9]+')" ]; then
         _version="v$_version"
     fi
+
     printf %s "$_version"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -337,16 +337,16 @@ get_install_dir() {
     local _dir
     _dir="$(get_default_install_dir)"
 
-    while [ $# -gt 0 ]; do
+    while [[ $# -gt 0 ]]; do
         case "$1" in
         --dir)
             _dir="$2"
+            shift 2
+            ;;
+        *)
             shift
             ;;
-        *) ;;
-
         esac
-        shift
     done
 
     printf %s "$_dir"

--- a/install.sh
+++ b/install.sh
@@ -371,11 +371,10 @@ get_version() {
         esac
     done
 
-    if [[ $_version == v* ]] || [[ $_version == "latest" ]]; then
-        printf %s "$_version"
-    else
-        printf 'v%s' "$_version"
+    if [[ $_version == [0-9]* ]]; then
+        _version="v$_version"
     fi
+    printf %s "$_version"
 }
 
 prompt_for_path() {

--- a/install.sh
+++ b/install.sh
@@ -330,6 +330,9 @@ get_default_install_dir() {
     printf %s "${HOME}/.temporalio"
 }
 
+# Retrieves the installation directory from the command-line arguments
+# Accepts flag: --dir /tmp/temporalio
+# Default: $HOME/.temporalio
 get_install_dir() {
     local _dir
     _dir="$(get_default_install_dir)"
@@ -349,16 +352,18 @@ get_install_dir() {
     printf %s "$_dir"
 }
 
-# Function to retrieve the version from the command-line arguments
+# Retrieve the version from the command-line arguments
+# Accepts flag: --version 1.1.0, --version v1.1.0, --version latest
+# Default: latest
 get_version() {
     local _version
-    _dir="latest"
+    _version="latest"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --version)
-            --version="$2"
-            return
+            _version="$2"
+            shift 2
             ;;
         *)
             shift
@@ -366,7 +371,11 @@ get_version() {
         esac
     done
 
-    printf %s "$_dir"
+    if [[ $_version == v* ]] || [[ $_version == "latest" ]]; then
+        printf %s "$_version"
+    else
+        printf 'v%s' "$_version"
+    fi
 }
 
 prompt_for_path() {

--- a/install.sh
+++ b/install.sh
@@ -124,11 +124,13 @@ main() {
         ;;
     esac
 
+    local _version
+    _version="$(ensure get_version "$@")"
+    local _url
+    _url="https://temporal.download/cli/archive/${_version}?platform=${_platform}&arch=${_arch}"
+
     local _archive_path
     _archive_path="${_temp}/temporal_cli_latest${_ext}"
-    local _url
-    _url="https://temporal.download/cli/archive/latest?platform=${_platform}&arch=${_arch}"
-
     ensure downloader "$_url" "$_archive_path" "$_arch"
     ensure unzip "$_archive_path" "$_temp"
     local _dir
@@ -342,6 +344,26 @@ get_install_dir() {
 
         esac
         shift
+    done
+
+    printf %s "$_dir"
+}
+
+# Function to retrieve the version from the command-line arguments
+get_version() {
+    local _version
+    _dir="latest"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --version)
+            --version="$2"
+            return
+            ;;
+        *)
+            shift
+            ;;
+        esac
     done
 
     printf %s "$_dir"

--- a/install.sh
+++ b/install.sh
@@ -371,7 +371,7 @@ get_version() {
         esac
     done
 
-    if [ "$(echo "$_version" | grep -E '^[0-9]+')" ]; then
+    if echo "$_version" | grep -qE '^[0-9]+'; then
         _version="v$_version"
     fi
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added support for CLI version in insall.sh

## Why?
<!-- Tell your future self why have you made these changes -->

Used by https://github.com/temporalio/docker-builds/pull/112

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Manually so far. There is an install.test.sh file for testing, i'd prefer to have testing with a proper language (not done).

```
sh -c "$(cat ./install.sh)" -- --dir ./temp
(cd ./temp/bin && ./temporal -h)
...
VERSION:
   0.9.0 (server 1.20.2) (ui 2.15.0)
```

```
sh -c "$(cat ./install.sh)" -- --dir ./temp --version v0.3.0
(cd ./temp/bin && ./temporal -h)
...
VERSION:
   0.3.0 (server 1.19.1) (ui 2.9.1)
```

```
sh -c "$(cat ./install.sh)" -- --dir ./temp --version 0.3.0
(cd ./temp/bin && ./temporal -h)
...
VERSION:
   0.3.0 (server 1.19.1) (ui 2.9.1)
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
