### PR TITLE
Print version when installing CLI with curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,10 @@ main() {
         esac
     done
 
-    say "Downloading Temporal CLI" >&2
+    local _version
+    _version="$(ensure get_version "$@")"
+
+    say "Downloading Temporal CLI $_version" >&2
 
     local _temp
     if ! _temp="$(ensure mktemp -d)"; then
@@ -124,8 +127,6 @@ main() {
         ;;
     esac
 
-    local _version
-    _version="$(ensure get_version "$@")"
     local _url
     _url="https://temporal.download/cli/archive/${_version}?platform=${_platform}&arch=${_arch}"
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Started printing version when installing CLI with install.sh

```
temporal: Downloading Temporal CLI v0.3.0
temporal: Temporal CLI installed at ./temp/bin/temporal
temporal: For convenience, we recommend adding it to your PATH
temporal: If using bash, run echo export PATH="\$PATH:./temp/bin" >> ~/.bashrc
```

## Why?
<!-- Tell your future self why have you made these changes -->

logging version when building docker image etc

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
