### PR TITLE
Set caller-type header

### DIFF
--- a/headers/headers.go
+++ b/headers/headers.go
@@ -13,6 +13,7 @@ const (
 	SupportedServerVersionsHeaderName = "supported-server-versions"
 	SupportedFeaturesHeaderName       = "supported-features"
 	SupportedFeaturesHeaderDelim      = ","
+	CallerTypeHeaderName              = "caller-type"
 )
 
 const DEV_VERSION = "0.0.0-DEV"
@@ -21,7 +22,8 @@ const DEV_VERSION = "0.0.0-DEV"
 var Version = DEV_VERSION
 
 const (
-	ClientNameCLI = "temporal-cli"
+	ClientNameCLI       = "temporal-cli"
+	CallerTypeHeaderCLI = "operator"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"
@@ -32,6 +34,7 @@ var (
 		ClientNameHeaderName:              ClientNameCLI,
 		ClientVersionHeaderName:           Version,
 		SupportedServerVersionsHeaderName: SupportedServerVersions,
+		CallerTypeHeaderName:              CallerTypeHeaderCLI,
 		// TODO: This should include SupportedFeaturesHeaderName with a value that's taken
 		// from the Go SDK (since the cli uses the Go SDK for most operations).
 	})

--- a/headersprovider/headers_provider.go
+++ b/headersprovider/headers_provider.go
@@ -2,6 +2,8 @@ package headersprovider
 
 import (
 	"context"
+
+	h "github.com/temporalio/cli/headers"
 )
 
 type HeadersProvider interface {
@@ -16,12 +18,18 @@ type grpcHeaderProvider struct {
 	headers map[string]string
 }
 
+func newGrpcHeaderProvider(headers map[string]string) *grpcHeaderProvider {
+	provider := &grpcHeaderProvider{headers}
+	provider.headers[h.CallerTypeHeaderName] = h.CallerTypeHeaderCLI
+	return provider
+}
+
 func (a grpcHeaderProvider) GetHeaders(ctx context.Context) (map[string]string, error) {
 	return a.headers, nil
 }
 
 func SetGRPCHeadersProvider(headers map[string]string) {
-	headersProvider = &grpcHeaderProvider{headers}
+	headersProvider = newGrpcHeaderProvider(headers)
 }
 
 func SetCurrent(hp HeadersProvider) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Set the new `caller-type` header to `operator` for all requests.

## Why?
<!-- Tell your future self why have you made these changes -->
To improve developer debug experience, requests coming from cli will be prioritized higher
See https://github.com/temporalio/temporal/pull/4623

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
