### PR TITLE
Fix batch signal's processing of input values

### DIFF
--- a/batch/batch_commands.go
+++ b/batch/batch_commands.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/api/batch/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/collection"
-	"go.temporal.io/server/common/payloads"
 )
 
 // DescribeBatchJob describe the status of the batch job
@@ -114,12 +113,10 @@ func BatchCancel(c *cli.Context) error {
 // BatchSignal send a signal to a list of workflows
 func BatchSignal(c *cli.Context) error {
 	signalName := c.String(common.FlagName)
-	input := c.String(common.FlagInput)
 	operator := common.GetCurrentUserFromEnv()
-
-	inputP, err := payloads.Encode(input)
+	input, err := common.ProcessJSONInput(c)
 	if err != nil {
-		return fmt.Errorf("unable to serialize signal input: %w", err)
+		return err
 	}
 
 	req := workflowservice.StartBatchOperationRequest{
@@ -127,7 +124,7 @@ func BatchSignal(c *cli.Context) error {
 			SignalOperation: &batch.BatchOperationSignal{
 				Signal:   signalName,
 				Identity: operator,
-				Input:    inputP,
+				Input:    input,
 			},
 		},
 	}

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -207,7 +207,8 @@ func (s *e2eSuite) TestWorkflowSignal_Batch() {
 		return len(wfs.GetExecutions()) == 3
 	}, 10*time.Second, time.Second)
 
-	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--input", "\"input1\"", "--query", "WorkflowId = '1' OR WorkflowId = '2'", "--reason", "test", "--yes", "--namespace", testNamespace})
+	i1 := "\"" + awaitsignal.Input1 + "\""
+	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--input", i1, "--query", "WorkflowId = '1' OR WorkflowId = '2'", "--reason", "test", "--yes", "--namespace", testNamespace})
 	s.NoError(err)
 
 	awaitTaskQueuePoller(s, c, testTq)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -181,10 +181,9 @@ func (s *e2eSuite) TestWorkflowSignal_Batch() {
 		_ = testserver.Stop()
 	}()
 
-	w := s.newWorker(testserver, testTq, func(r worker.Registry) {
+	defer s.newWorker(testserver, testTq, func(r worker.Registry) {
 		r.RegisterWorkflow(awaitsignal.Workflow)
-	})
-	defer w.Stop()
+	}).Stop()
 
 	c := testserver.Client()
 
@@ -208,7 +207,7 @@ func (s *e2eSuite) TestWorkflowSignal_Batch() {
 		return len(wfs.GetExecutions()) == 3
 	}, 10*time.Second, time.Second)
 
-	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--query", "WorkflowId = '1' OR WorkflowId = '2'", "--reason", "test", "--yes", "--namespace", testNamespace})
+	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--input", "\"input1\"", "--query", "WorkflowId = '1' OR WorkflowId = '2'", "--reason", "test", "--yes", "--namespace", testNamespace})
 	s.NoError(err)
 
 	awaitTaskQueuePoller(s, c, testTq)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -208,7 +208,8 @@ func (s *e2eSuite) TestWorkflowSignal_Batch() {
 	}, 10*time.Second, time.Second)
 
 	i1 := "\"" + awaitsignal.Input1 + "\""
-	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--input", i1, "--query", "WorkflowId = '1' OR WorkflowId = '2'", "--reason", "test", "--yes", "--namespace", testNamespace})
+	q := "WorkflowId = '1' OR WorkflowId = '2'"
+	err := app.Run([]string{"", "workflow", "signal", "--name", awaitsignal.Done, "--input", i1, "--query", q, "--reason", "test", "--yes", "--namespace", testNamespace})
 	s.NoError(err)
 
 	awaitTaskQueuePoller(s, c, testTq)

--- a/tests/workflows/awaitsignal/awaitsignal.go
+++ b/tests/workflows/awaitsignal/awaitsignal.go
@@ -1,14 +1,23 @@
 package awaitsignal
 
 import (
+	"fmt"
+
 	"go.temporal.io/sdk/workflow"
 )
 
 const (
-	Done = "done"
+	Done   = "done"
+	input1 = "input1"
 )
 
 func Workflow(ctx workflow.Context) error {
-	_ = workflow.GetSignalChannel(ctx, Done).Receive(ctx, nil)
-	return nil
+	var v string
+	_ = workflow.GetSignalChannel(ctx, Done).Receive(ctx, &v)
+
+	if v == input1 {
+		return nil
+	}
+
+	return fmt.Errorf("expected %s, received %s", input1, v)
 }

--- a/tests/workflows/awaitsignal/awaitsignal.go
+++ b/tests/workflows/awaitsignal/awaitsignal.go
@@ -8,16 +8,16 @@ import (
 
 const (
 	Done   = "done"
-	input1 = "input1"
+	Input1 = "input1"
 )
 
 func Workflow(ctx workflow.Context) error {
 	var v string
 	_ = workflow.GetSignalChannel(ctx, Done).Receive(ctx, &v)
 
-	if v == input1 {
+	if v == Input1 {
 		return nil
 	}
 
-	return fmt.Errorf("expected %s, received %s", input1, v)
+	return fmt.Errorf("expected %s, received %s", Input1, v)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixed processing of `--input` in batch signal command

## Why?
<!-- Tell your future self why have you made these changes -->

```
 temporal workflow signal \
    --query 'WorkflowType="LongRunningWorkflow"' \
    --name migrateIt \
    --reason 'migration' \
    --input \"finalvalue\"
And the error in my worker (Java SDK) is:
json/plain"\"finalvalue\""" into following types: [class java.lang.String]
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

updated e2e test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
