### PR TITLE
Restore showing subcommand list

### DIFF
--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -590,9 +590,11 @@ DESCRIPTION:
    {{template "descriptionTemplate" .}}{{end}}{{if .UsageText}}
 
 USAGE:
-   {{wrap .UsageText 3 | markdown2Text}}{{end}}{{if .VisibleFlagCategories}}
-   {{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+   {{wrap .UsageText 3 | markdown2Text | trimSpace}}{{end}}{{if .VisibleCommands}}
 
-DISPLAY OPTIONS:
-   {{template "visibleFlagTemplate" .}}{{end}}
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 `

--- a/helpprinter/helpprinter.go
+++ b/helpprinter/helpprinter.go
@@ -21,6 +21,7 @@ func HelpPrinter() func(w io.Writer, templ string, data interface{}, customFunc 
 	return func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{}) {
 		cfs := template.FuncMap{
 			"markdown2Text": MarkdownToText,
+			"trimSpace":     strings.TrimSpace,
 		}
 
 		_helpPrinterOrig(w, templ, data, cfs)

--- a/tests/help_test.go
+++ b/tests/help_test.go
@@ -1,0 +1,84 @@
+package tests
+
+func (s *e2eSuite) TestHelp_PrintsCommands() {
+	s.T().Skip("Skipped because downloaded dev server has old update implementation")
+	s.T().Parallel()
+
+	testserver, app, writer := s.setUpTestEnvironment()
+	defer func() {
+		_ = testserver.Stop()
+	}()
+
+	err := app.Run([]string{"", "--help"})
+	s.NoError(err)
+
+	tests := []struct {
+		want string
+	}{
+		{"workflow"},
+		{"Operations performed on Workflows"},
+		{"schedule"},
+		{"Operations performed on Schedules"},
+	}
+
+	for _, tt := range tests {
+		s.Contains(writer.GetContent(), tt.want)
+	}
+}
+
+func (s *e2eSuite) TestHelp_PrintsSubcommands() {
+	s.T().Skip("Skipped because downloaded dev server has old update implementation")
+	s.T().Parallel()
+
+	testserver, app, writer := s.setUpTestEnvironment()
+	defer func() {
+		_ = testserver.Stop()
+	}()
+
+	err := app.Run([]string{"", "workflow", "--help"})
+	s.NoError(err)
+
+	tests := []struct {
+		want string
+	}{
+		{"start"},
+		{"Starts a new Workflow Execution"},
+		{"list"},
+		{"List Workflow Executions based on a Query"},
+	}
+
+	for _, tt := range tests {
+		s.Contains(writer.GetContent(), tt.want)
+	}
+}
+
+func (s *e2eSuite) TestHelp_PrintsFlags() {
+	s.T().Skip("Skipped because downloaded dev server has old update implementation")
+	s.T().Parallel()
+
+	testserver, app, writer := s.setUpTestEnvironment()
+	defer func() {
+		_ = testserver.Stop()
+	}()
+
+	err := app.Run([]string{"", "workflow", "list", "--help"})
+	s.NoError(err)
+
+	tests := []struct {
+		want string
+	}{
+		{"Command Options:"},
+		{"--query"},
+		{"Filter results using an SQL-like query"},
+		{"Display Options:"},
+		{"--limit"},
+		{"Number of items to print"},
+		{"Shared Options:"},
+		{"--address"},
+		{"The host and port"},
+	}
+
+	for _, tt := range tests {
+		s.Contains(writer.GetContent(), tt.want)
+	}
+}


### PR DESCRIPTION
## What was changed
Fix help output to show list of subcommands again. This was broken by #280 by something in the cli update.

## Why?
Self-documentation

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
manually + unit tests (skipped for now)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
