### PR TITLE
Remove tests skip as server is now built locally

### DIFF
--- a/tests/help_test.go
+++ b/tests/help_test.go
@@ -1,7 +1,6 @@
 package tests
 
 func (s *e2eSuite) TestHelp_PrintsCommands() {
-	s.T().Skip("Skipped because downloaded dev server has old update implementation")
 	s.T().Parallel()
 
 	testserver, app, writer := s.setUpTestEnvironment()
@@ -27,7 +26,6 @@ func (s *e2eSuite) TestHelp_PrintsCommands() {
 }
 
 func (s *e2eSuite) TestHelp_PrintsSubcommands() {
-	s.T().Skip("Skipped because downloaded dev server has old update implementation")
 	s.T().Parallel()
 
 	testserver, app, writer := s.setUpTestEnvironment()
@@ -53,7 +51,6 @@ func (s *e2eSuite) TestHelp_PrintsSubcommands() {
 }
 
 func (s *e2eSuite) TestHelp_PrintsFlags() {
-	s.T().Skip("Skipped because downloaded dev server has old update implementation")
 	s.T().Parallel()
 
 	testserver, app, writer := s.setUpTestEnvironment()

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -68,7 +68,6 @@ func (s *e2eSuite) TestWorkflowShow_ReplayableHistory() {
 }
 
 func (s *e2eSuite) TestWorkflowUpdate() {
-	s.T().Skip("Skipped because downloaded dev server has old update implementation")
 	s.T().Parallel()
 
 	testserver, app, writer := s.setUpTestEnvironment()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Stopped skipping e2e tests

## Why?
<!-- Tell your future self why have you made these changes -->

e2e tests no longer download dev server and instead build locally. No need to skip anymore 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

e2e

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
