### PR TITLE
Allow obtaining the "env" via the TEMPORAL_ENV env var

### DIFF
--- a/common/flags.go
+++ b/common/flags.go
@@ -147,6 +147,7 @@ var SharedFlags = []cli.Flag{
 		Name:     FlagEnv,
 		Value:    config.DefaultEnv,
 		Usage:    FlagEnvDefinition,
+		EnvVars:  []string{"TEMPORAL_ENV"},
 		Category: CategoryGlobal,
 	},
 	&cli.StringFlag{


### PR DESCRIPTION
Based on my experience using the CLI it's quite painful to provide the `--env` for different commands because the limited capabilities of `urfave` don't allow passing `--env` as an option to the top level command.

This makes the `env` feature a bit nicer to use.

Eventually I think we should switch to a more powerful arg parser but that's a bigger lift.