### PR TITLE
Fix examples in the usage text of namespace create

### DIFF
--- a/common/defs-cmds.go
+++ b/common/defs-cmds.go
@@ -390,14 +390,14 @@ Use the options listed below to change the command's output.`
 
 const NamespaceCreateUsageText = `The ` + "`" + `temporal operator namespace create` + "`" + ` command creates a new [Namespace](/concepts/what-is-a-namespace) on the [Server](/concepts/what-is-a-frontend-service).
 Namespaces can be created on the active [Cluster](/concepts/what-is-a-temporal-cluster), or any named Cluster.
-` + "`" + `temporal operator namespace --cluster=MyCluster` + "`" + `
+` + "`" + `temporal operator namespace --cluster=MyCluster example-1` + "`" + `
 
 Global Namespaces can also be created.
-` + "`" + `temporal operator namespace create --global` + "`" + `
+` + "`" + `temporal operator namespace create --global example-2` + "`" + `
 
 Other settings, such as [retention](/concepts/what-is-a-retention-period) and [Visibility Archival State](/concepts/what-is-visibility), can be configured as needed.
 For example, the Visibility Archive can be set on a separate URI.
-` + "`" + `temporal operator namespace create --retention=RetentionMyWorkflow --visibility-archival-state="enabled" --visibility-uri="some-uri"` + "`" + `
+` + "`" + `temporal operator namespace create --retention=RetentionMyWorkflow --visibility-archival-state="enabled" --visibility-uri="some-uri" example-3` + "`" + `
 
 Use the options listed below to change the command's behavior.`
 


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixed examples of "temporal operator namespace create" to include the missing namespace argument.

## Why?
<!-- Tell your future self why have you made these changes -->
The examples were incorrect and would fail if used. The namespace argument is not documented anywhere. 
