### PR TITLE
Remove double setting of caller-type header

### DIFF
--- a/headersprovider/headers_provider.go
+++ b/headersprovider/headers_provider.go
@@ -2,8 +2,6 @@ package headersprovider
 
 import (
 	"context"
-
-	h "github.com/temporalio/cli/headers"
 )
 
 type HeadersProvider interface {
@@ -18,18 +16,12 @@ type grpcHeaderProvider struct {
 	headers map[string]string
 }
 
-func newGrpcHeaderProvider(headers map[string]string) *grpcHeaderProvider {
-	provider := &grpcHeaderProvider{headers}
-	provider.headers[h.CallerTypeHeaderName] = h.CallerTypeHeaderCLI
-	return provider
-}
-
 func (a grpcHeaderProvider) GetHeaders(ctx context.Context) (map[string]string, error) {
 	return a.headers, nil
 }
 
 func SetGRPCHeadersProvider(headers map[string]string) {
-	headersProvider = newGrpcHeaderProvider(headers)
+	headersProvider = &grpcHeaderProvider{headers}
 }
 
 func SetCurrent(hp HeadersProvider) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removed setting of `caller-type` header from `headers_provider` because it is already being set as part of `cliVersionHeaders` so the value was getting appended twice.

## Why?
<!-- Tell your future self why have you made these changes -->
No need to set the same value twice

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Existing tests and quick local validation

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
