### PR TITLE
Fix sources of test instability

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -320,7 +320,7 @@ func assertServerHealth(ctx context.Context, t *testing.T, opts sdkclient.Option
 		t.Error(clientErr)
 	}
 
-	// Give the server 10 seconds to become healthy.
+	// Give the server 1 second to become healthy.
 	for i := 0; i < 10; i++ {
 		_, clientErr = c.CheckHealth(ctx, nil)
 		if clientErr == nil {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -320,8 +320,16 @@ func assertServerHealth(ctx context.Context, t *testing.T, opts sdkclient.Option
 		t.Error(clientErr)
 	}
 
-	if _, err := c.CheckHealth(ctx, nil); err != nil {
-		t.Error(err)
+	// Give the server 10 seconds to become healthy.
+	for i := 0; i < 10; i++ {
+		_, clientErr = c.CheckHealth(ctx, nil)
+		if clientErr == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if clientErr != nil {
+		t.Error(clientErr)
 	}
 
 	// Check for pollers on a system task queue to ensure that the worker service is running.

--- a/server/commands.go
+++ b/server/commands.go
@@ -337,6 +337,7 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 				if err := s.Start(); err != nil {
 					return cli.Exit(fmt.Sprintf("Unable to start server. Error: %v", err), 1)
 				}
+				s.Stop()
 				return cli.Exit("All services are stopped.", 0)
 			},
 		},


### PR DESCRIPTION
- Wait up to 1 second for the server to become healthy before assuming it's failed. After the server starts accepting connections, we were assuming it should be healthy immediately, but that's not always true.

- Make sure the server finishes shutting down before exiting the CLI, because otherwise it will hold open files, and this intermittently breaks tests on Windows (which, unlike POSIXy OSes, will refuse to delete open files).  Closes #338.  I hope.