### PR TITLE
When dynamic config is mis-specified say what key is incorrect

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -362,7 +362,7 @@ func getDynamicConfigValues(input []string) (map[dynamicconfig.Key][]dynamicconf
 	for _, keyValStr := range input {
 		keyVal := strings.SplitN(keyValStr, "=", 2)
 		if len(keyVal) != 2 {
-			return nil, fmt.Errorf("dynamic config value not in KEY=JSON_VAL format")
+			return nil, fmt.Errorf("dynamic config value %s not in KEY=JSON_VAL format", keyValStr)
 		}
 		key := dynamicconfig.Key(keyVal[0])
 		// We don't support constraints currently


### PR DESCRIPTION
## What was changed

I improved the error message that appears when you specify dynamic config incorrectly

## Why?

`Error: dynamic config value not in KEY=JSON_VAL format` isn't helpful when you're specifying more than a few values

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
```
$ go run ./cmd/temporal/main.go server start-dev \
  --dynamic-config-value system.forceSearchAttributesCacheRefreshOnRead=true \
  --dynamic-config-value system.enableActivityEagerExecution=true \
  --dynamic-config-value frontend.enableUpdateWorkflowExecution=true \
  --dynamic-config-value frontend.enableUpdateWorkflowExecutionAsyncAccepted=true \
  --dynamic-config-value system.enableEagerWorkflowStart \
  --dynamic-config-value frontend.workerVersioningDataAPIs=true \
  --dynamic-config-value frontend.workerVersioningWorkflowAPIs=true \
  --dynamic-config-value worker.buildIdScavengerEnabled=true \
  --dynamic-config-value worker.removableBuildIdDurationSinceDefault=1
Error: dynamic config value system.enableEagerWorkflowStart not in KEY=JSON_VAL format
```

3. Any docs updates needed?
Nope
