### PR TITLE
Remove OpenAPI config

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -241,7 +241,6 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 						Port:                uiPort,
 						TemporalGRPCAddress: frontendAddr,
 						EnableUI:            true,
-						EnableOpenAPI:       true,
 						UIAssetPath:         uiAssetPath,
 						Codec: uiconfig.Codec{
 							Endpoint: uiCodecEndpoint,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
With ui-server v2.21.0, we removed all the OpenAPI swagger docs and config for setting up OpenAPI (HTTP API is no longer defined in ui-server)

<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
