### PR TITLE
Enhance task-queue describe

### DIFF
--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -135,7 +135,7 @@ const (
 	// Task Queue flags
 	FlagTaskQueueName           = "Name of the Task Queue."
 	FlagTaskQueueTypeDefinition = "Task Queue type [workflow|activity]"
-	FlagPartitionsDefinition    = "Query for all partitions up to this number"
+	FlagPartitionsDefinition    = "Query for all partitions up to this number (experimental+temporary feature)"
 
 	// Namespace update flags
 	FlagActiveClusterDefinition           = "Active cluster name."

--- a/common/defs-flags.go
+++ b/common/defs-flags.go
@@ -135,6 +135,7 @@ const (
 	// Task Queue flags
 	FlagTaskQueueName           = "Name of the Task Queue."
 	FlagTaskQueueTypeDefinition = "Task Queue type [workflow|activity]"
+	FlagPartitionsDefinition    = "Query for all partitions up to this number"
 
 	// Namespace update flags
 	FlagActiveClusterDefinition           = "Active cluster name."

--- a/common/flags.go
+++ b/common/flags.go
@@ -79,6 +79,7 @@ var (
 	FlagOverlapPolicy              = "overlap-policy"
 	FlagOwnerEmail                 = "email"
 	FlagParallelism                = "input-parallelism"
+	FlagPartitions                 = "partitions"
 	FlagPause                      = "pause"
 	FlagPauseOnFailure             = "pause-on-failure"
 	FlagPort                       = "port"

--- a/taskqueue/task_queue.go
+++ b/taskqueue/task_queue.go
@@ -26,6 +26,12 @@ func NewTaskQueueCommands() []*cli.Command {
 					Usage:    common.FlagTaskQueueTypeDefinition,
 					Category: common.CategoryMain,
 				},
+				&cli.IntFlag{
+					Name:     common.FlagPartitions,
+					Value:    1,
+					Usage:    common.FlagPartitionsDefinition,
+					Category: common.CategoryMain,
+				},
 			}, common.FlagsForFormatting...),
 			Action: func(c *cli.Context) error {
 				return DescribeTaskQueue(c)

--- a/taskqueue/task_queue.go
+++ b/taskqueue/task_queue.go
@@ -26,6 +26,7 @@ func NewTaskQueueCommands() []*cli.Command {
 					Usage:    common.FlagTaskQueueTypeDefinition,
 					Category: common.CategoryMain,
 				},
+				// TOOD: remove this when the server does partition fan-out
 				&cli.IntFlag{
 					Name:     common.FlagPartitions,
 					Value:    1,

--- a/taskqueue/task_queue_commands.go
+++ b/taskqueue/task_queue_commands.go
@@ -1,6 +1,7 @@
 package taskqueue
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -9,37 +10,98 @@ import (
 	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl-kit/pkg/output"
 	"github.com/urfave/cli/v2"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/tqname"
 )
 
 // DescribeTaskQueue show pollers info of a given taskqueue
 func DescribeTaskQueue(c *cli.Context) error {
-	sdkClient, err := client.GetSDKClient(c)
+	taskQueue := c.String(common.FlagTaskQueue)
+	tqName, err := tqname.FromBaseName(taskQueue)
 	if err != nil {
 		return err
 	}
-	taskQueue := c.String(common.FlagTaskQueue)
 	taskQueueType := strToTaskQueueType(c.String(common.FlagTaskQueueType))
+	partitions := c.Int(common.FlagPartitions)
 
 	ctx, cancel := common.NewContext(c)
 	defer cancel()
-	resp, err := sdkClient.DescribeTaskQueue(ctx, taskQueue, taskQueueType)
+
+	frontendClient := client.Factory(c.App).FrontendClient(c)
+	namespace, err := common.RequiredFlag(c, common.FlagNamespace)
 	if err != nil {
-		return fmt.Errorf("unable to describe task queue: %w", err)
+		return err
+	}
+
+	type statusWithPartition struct {
+		Partition int `json:"partition"`
+		taskqueuepb.TaskQueueStatus
+	}
+	type pollerWithPartition struct {
+		Partition int `json:"partition"`
+		taskqueuepb.PollerInfo
+		// copy this out to display nicer in table or card, but not json
+		VersionCaps *commonpb.WorkerVersionCapabilities `json:"-"`
+	}
+
+	var statuses []any
+	var pollers []any
+
+	for p := 0; p < partitions; p++ {
+		resp, err := frontendClient.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+			Namespace: namespace,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: tqName.WithPartition(p).FullName(),
+				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+			},
+			TaskQueueType:          taskQueueType,
+			IncludeTaskQueueStatus: true,
+		})
+		// note that even if it doesn't exist before this call, DescribeTaskQueue will return something
+		if err != nil {
+			return fmt.Errorf("unable to describe task queue: %w", err)
+		}
+		statuses = append(statuses, &statusWithPartition{
+			Partition:       p,
+			TaskQueueStatus: *resp.TaskQueueStatus,
+		})
+		for _, pi := range resp.Pollers {
+			pollers = append(pollers, &pollerWithPartition{
+				Partition:   p,
+				PollerInfo:  *pi,
+				VersionCaps: pi.WorkerVersionCapabilities,
+			})
+		}
+	}
+
+	if output.OutputOption(c.String(output.FlagOutput)) == output.JSON {
+		// handle specially so we output a single object instead of two
+		b, err := json.MarshalIndent(map[string]any{
+			"taskQueues": statuses,
+			"pollers":    pollers,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Println(string(b))
+		return err
 	}
 
 	opts := &output.PrintOptions{
-		// TODO enable when versioning feature is out
-		// Fields: []string{"Identity", "LastAccessTime", "RatePerSecond", "WorkerVersioningId"},
-		Fields: []string{"Identity", "LastAccessTime", "RatePerSecond"},
+		Fields: []string{"Partition", "TaskQueueStatus.RatePerSecond", "TaskQueueStatus.BacklogCountHint", "TaskQueueStatus.ReadLevel", "TaskQueueStatus.AckLevel", "TaskQueueStatus.TaskIdBlock"},
 	}
-	var items []interface{}
-	for _, e := range resp.Pollers {
-		items = append(items, e)
+	err = output.PrintItems(c, statuses, opts)
+	if err != nil {
+		return err
 	}
-	return output.PrintItems(c, items, opts)
+
+	opts = &output.PrintOptions{
+		Fields: []string{"Partition", "PollerInfo.Identity", "PollerInfo.LastAccessTime", "PollerInfo.RatePerSecond", "VersionCaps.BuildId", "VersionCaps.UseVersioning"},
+	}
+	return output.PrintItems(c, pollers, opts)
 }
 
 // ListTaskQueuePartitions gets all the taskqueue partition and host information.

--- a/taskqueue/task_queue_commands.go
+++ b/taskqueue/task_queue_commands.go
@@ -44,12 +44,13 @@ func DescribeTaskQueue(c *cli.Context) error {
 		Partition int `json:"partition"`
 		taskqueuepb.PollerInfo
 		// copy this out to display nicer in table or card, but not json
-		VersionCaps *commonpb.WorkerVersionCapabilities `json:"-"`
+		Versioning *commonpb.WorkerVersionCapabilities `json:"-"`
 	}
 
 	var statuses []any
 	var pollers []any
 
+	// TOOD: remove this when the server does partition fan-out
 	for p := 0; p < partitions; p++ {
 		resp, err := frontendClient.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 			Namespace: namespace,
@@ -70,9 +71,9 @@ func DescribeTaskQueue(c *cli.Context) error {
 		})
 		for _, pi := range resp.Pollers {
 			pollers = append(pollers, &pollerWithPartition{
-				Partition:   p,
-				PollerInfo:  *pi,
-				VersionCaps: pi.WorkerVersionCapabilities,
+				Partition:  p,
+				PollerInfo: *pi,
+				Versioning: pi.WorkerVersionCapabilities,
 			})
 		}
 	}
@@ -99,7 +100,7 @@ func DescribeTaskQueue(c *cli.Context) error {
 	}
 
 	opts = &output.PrintOptions{
-		Fields: []string{"Partition", "PollerInfo.Identity", "PollerInfo.LastAccessTime", "PollerInfo.RatePerSecond", "VersionCaps.BuildId", "VersionCaps.UseVersioning"},
+		Fields: []string{"Partition", "PollerInfo.Identity", "PollerInfo.LastAccessTime", "PollerInfo.RatePerSecond", "Versioning.BuildId", "Versioning.UseVersioning"},
 	}
 	return output.PrintItems(c, pollers, opts)
 }


### PR DESCRIPTION
## What was changed
- `temporal task-queue describe` prints the `TaskQueueStatus` parts of the `DescribeTaskQueue` response
- It now takes a `--partitions` flag to query for multiple partitions.

Partition fan-out is more properly done server-side, but that'll take longer and in the meantime (and on older server versions) this is still useful.

## Why?
More useful for debugging.

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested:
Manually

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
