### PR TITLE
Insecure CSRF cookie

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -245,6 +245,9 @@ func NewServerCommands(defaultCfg *sconfig.Config) []*cli.Command {
 						Codec: uiconfig.Codec{
 							Endpoint: uiCodecEndpoint,
 						},
+						CORS: uiconfig.CORS{
+							CookieInsecure: true,
+						},
 					}
 
 					opt, err := newUIOption(uiBaseCfg)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
CSRF cookie is now set without `Secure` attribute.

## Why?
<!-- Tell your future self why have you made these changes -->
Now CSRF cookie is `Secure` but development servers are usually used locally without HTTPS. For some reason, it works fine in Chrome (there is an exception for `localhost` domain in `Secure` handling) but does not work in Safari.

Since `start-dev` command starts a **development** server, I think it is safe to use insecure cookies here.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Checked locally with different browsers.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No.