### PR TITLE
Embed fallback tzdata

### DIFF
--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -7,6 +7,9 @@ import (
 	// Load sqlite storage driver
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 
+	// Embed time zone database as a fallback if platform database can't be found
+	_ "time/tzdata"
+
 	"github.com/temporalio/cli/app"
 )
 


### PR DESCRIPTION
## What was changed
Embed time zone database in case platform database can't be found.

## Why?
This ensures time zones are always available, even on Windows which does not supply a time zone database (at least in a format that Go understands).