### PR TITLE
Implement `workflow terminate` command

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -645,7 +645,7 @@ func (v *SingleWorkflowOrBatchOptions) buildFlags(cctx *CommandContext, f *pflag
 	f.StringVarP(&v.WorkflowId, "workflow-id", "w", "", "Workflow Id. Either this or query must be set.")
 	f.StringVarP(&v.RunId, "run-id", "r", "", "Run Id. Cannot be set when query is set.")
 	f.StringVarP(&v.Query, "query", "q", "", "Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
-	f.StringVar(&v.Reason, "reason", "", "Reason to perform batch. Only allowed if query is present unless the command specifies otherwise.")
+	f.StringVar(&v.Reason, "reason", "", "Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. Defaults to message with the current user's name.")
 	f.BoolVarP(&v.Yes, "yes", "y", false, "Confirm prompt to perform batch. Only allowed if query is present.")
 }
 
@@ -776,9 +776,13 @@ func NewTemporalWorkflowStartCommand(cctx *CommandContext, parent *TemporalWorkf
 }
 
 type TemporalWorkflowTerminateCommand struct {
-	Parent  *TemporalWorkflowCommand
-	Command cobra.Command
-	SingleWorkflowOrBatchOptions
+	Parent     *TemporalWorkflowCommand
+	Command    cobra.Command
+	WorkflowId string
+	RunId      string
+	Query      string
+	Reason     string
+	Yes        bool
 }
 
 func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowTerminateCommand {
@@ -788,12 +792,16 @@ func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalW
 	s.Command.Use = "terminate [flags]"
 	s.Command.Short = "Terminate Workflow Execution by ID or List Filter."
 	if hasHighlighting {
-		s.Command.Long = "The \x1b[1mtemporal workflow terminate\x1b[0m command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a \x1b[1mWorkflowExecutionTerminated\x1b[0m event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use \x1b[1mtemporal workflow cancel\x1b[0m if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n\x1b[1mtemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\x1b[0m\n\n...or in bulk via a visibility query list filter:\n\n\x1b[1mtemporal workflow terminate --query=MyQuery\x1b[0m\n\nUse the options listed below to change the behavior of this command."
+		s.Command.Long = "The \x1b[1mtemporal workflow terminate\x1b[0m command is used to terminate a Workflow Execution. \nCanceling a running Workflow Execution records a \x1b[1mWorkflowExecutionTerminated\x1b[0m event as the closing Event in the workflow's Event History. \nWorkflow code is oblivious to termination. Use \x1b[1mtemporal workflow cancel\x1b[0m if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n\x1b[1mtemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\x1b[0m\n\n...or in bulk via a visibility query list filter:\n\x1b[1mtemporal workflow terminate --query=MyQuery\x1b[0m\n\nUse the options listed below to change the behavior of this command."
 	} else {
-		s.Command.Long = "The `temporal workflow terminate` command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n```\ntemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\n```\n\n...or in bulk via a visibility query list filter:\n\n```\ntemporal workflow terminate --query=MyQuery\n```\n\nUse the options listed below to change the behavior of this command."
+		s.Command.Long = "The `temporal workflow terminate` command is used to terminate a Workflow Execution. \nCanceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. \nWorkflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n```\ntemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\n```\n\n...or in bulk via a visibility query list filter:\n```\ntemporal workflow terminate --query=MyQuery\n```\n\nUse the options listed below to change the behavior of this command."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
+	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow Id. Either this or query must be set.")
+	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run Id. Cannot be set when query is set.")
+	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
+	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason to terminate this workflow. Defaults to message with the current user's name.")
+	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Confirm prompt to perform batch. Only allowed if query is present.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -645,7 +645,7 @@ func (v *SingleWorkflowOrBatchOptions) buildFlags(cctx *CommandContext, f *pflag
 	f.StringVarP(&v.WorkflowId, "workflow-id", "w", "", "Workflow Id. Either this or query must be set.")
 	f.StringVarP(&v.RunId, "run-id", "r", "", "Run Id. Cannot be set when query is set.")
 	f.StringVarP(&v.Query, "query", "q", "", "Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
-	f.StringVar(&v.Reason, "reason", "", "Reason to perform batch. Only allowed if query is present. Defaults to message with user name and time.")
+	f.StringVar(&v.Reason, "reason", "", "Reason to perform batch. Only allowed if query is present unless the command specifies otherwise.")
 	f.BoolVarP(&v.Yes, "yes", "y", false, "Confirm prompt to perform batch. Only allowed if query is present.")
 }
 
@@ -788,9 +788,9 @@ func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalW
 	s.Command.Use = "terminate [flags]"
 	s.Command.Short = "Terminate Workflow Execution by ID or List Filter."
 	if hasHighlighting {
-		s.Command.Long = "The \x1b[1mtemporal workflow terminate\x1b[0m command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a \x1b[1mWorkflowExecutionTerminated\x1b[0m event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.\n\nExecutions may be terminated by ID:\n\x1b[1mtemporal workflow terminate --workflow-id MyWorkflowId\x1b[0m\n\n...or in bulk via a visibility query list filter:\n\n\x1b[1mtemporal workflow terminate --query=MyQuery\x1b[0m\n\nUse the options listed below to change the behavior of this command."
+		s.Command.Long = "The \x1b[1mtemporal workflow terminate\x1b[0m command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a \x1b[1mWorkflowExecutionTerminated\x1b[0m event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use \x1b[1mtemporal workflow cancel\x1b[0m if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n\x1b[1mtemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\x1b[0m\n\n...or in bulk via a visibility query list filter:\n\n\x1b[1mtemporal workflow terminate --query=MyQuery\x1b[0m\n\nUse the options listed below to change the behavior of this command."
 	} else {
-		s.Command.Long = "The `temporal workflow terminate` command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.\n\nExecutions may be terminated by ID:\n```\ntemporal workflow terminate --workflow-id MyWorkflowId\n```\n\n...or in bulk via a visibility query list filter:\n\n```\ntemporal workflow terminate --query=MyQuery\n```\n\nUse the options listed below to change the behavior of this command."
+		s.Command.Long = "The `temporal workflow terminate` command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.\n\nExecutions may be terminated by ID with an optional reason:\n```\ntemporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId\n```\n\n...or in bulk via a visibility query list filter:\n\n```\ntemporal workflow terminate --query=MyQuery\n```\n\nUse the options listed below to change the behavior of this command."
 	}
 	s.Command.Args = cobra.NoArgs
 	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -799,8 +799,8 @@ func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalW
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow Id. Either this or query must be set.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run Id. Cannot be set when query is set.")
-	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
-	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason to terminate this workflow. Defaults to message with the current user's name.")
+	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Start a batch to terminate Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
+	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason for termination. Defaults to message with the current user's name.")
 	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Confirm prompt to perform batch. Only allowed if query is present.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -778,6 +778,7 @@ func NewTemporalWorkflowStartCommand(cctx *CommandContext, parent *TemporalWorkf
 type TemporalWorkflowTerminateCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
+	SingleWorkflowOrBatchOptions
 }
 
 func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowTerminateCommand {
@@ -786,8 +787,13 @@ func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalW
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "terminate [flags]"
 	s.Command.Short = "Terminate Workflow Execution by ID or List Filter."
-	s.Command.Long = "TODO"
+	if hasHighlighting {
+		s.Command.Long = "The \x1b[1mtemporal workflow terminate\x1b[0m command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a \x1b[1mWorkflowExecutionTerminated\x1b[0m event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.\n\nExecutions may be terminated by ID:\n\x1b[1mtemporal workflow terminate --workflow-id MyWorkflowId\x1b[0m\n\n...or in bulk via a visibility query list filter:\n\n\x1b[1mtemporal workflow terminate --query=MyQuery\x1b[0m\n\nUse the options listed below to change the behavior of this command."
+	} else {
+		s.Command.Long = "The `temporal workflow terminate` command is used to terminate a Workflow Execution. Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.\n\nExecutions may be terminated by ID:\n```\ntemporal workflow terminate --workflow-id MyWorkflowId\n```\n\n...or in bulk via a visibility query list filter:\n\n```\ntemporal workflow terminate --query=MyQuery\n```\n\nUse the options listed below to change the behavior of this command."
+	}
 	s.Command.Args = cobra.NoArgs
+	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -91,7 +91,16 @@ func (c *TemporalWorkflowTerminateCommand) run(cctx *CommandContext, _ []string)
 	}
 	defer cl.Close()
 
-	exec, batchReq, err := c.workflowExecOrBatch(cctx, c.Parent.Namespace, cl, singleOrBatchOverrides{
+	// We create a faux SingleWorkflowOrBatchOptions to use the shared logic
+	opts := SingleWorkflowOrBatchOptions{
+		WorkflowId: c.WorkflowId,
+		RunId:      c.RunId,
+		Query:      c.Query,
+		Reason:     c.Reason,
+		Yes:        c.Yes,
+	}
+
+	exec, batchReq, err := opts.workflowExecOrBatch(cctx, c.Parent.Namespace, cl, singleOrBatchOverrides{
 		// You're allowed to specify a reason when terminating a workflow
 		AllowReasonWithWorkflowID: true,
 	})

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -135,6 +135,8 @@ func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess() {
 		"workflow", "terminate",
 		"--address", s.Address(),
 		"-w", run.GetID(),
+		// Ensure that we can provide a reason
+		"--reason", "terminate-test",
 	)
 	s.NoError(res.Err)
 

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -114,3 +114,98 @@ func (s *SharedServerSuite) testSignalBatchWorkflow(json bool) *CommandResult {
 	}
 	return res
 }
+func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess() {
+	// Make workflow wait for termination and then return the context's error
+	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+		ctx.Done().Receive(ctx, nil)
+		return nil, ctx.Err()
+	})
+
+	// Start the workflow
+	run, err := s.Client.ExecuteWorkflow(
+		s.Context,
+		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		DevWorkflow,
+		"ignored",
+	)
+	s.NoError(err)
+
+	// Send terminate
+	res := s.Execute(
+		"workflow", "terminate",
+		"--address", s.Address(),
+		"-w", run.GetID(),
+	)
+	s.NoError(res.Err)
+
+	// Confirm workflow was terminated
+	s.Contains(run.Get(s.Context, nil).Error(), "terminated")
+}
+
+func (s *SharedServerSuite) TestWorkflow_Terminate_BatchWorkflowSuccess() {
+	res := s.testTerminateBatchWorkflow(false)
+	s.Contains(res.Stdout.String(), "approximately 5 workflow(s)")
+	s.Contains(res.Stdout.String(), "Started batch")
+}
+
+func (s *SharedServerSuite) TestWorkflow_Terminate_BatchWorkflowSuccessJSON() {
+	res := s.testTerminateBatchWorkflow(true)
+	var jsonRes map[string]any
+	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &jsonRes))
+	s.NotEmpty(jsonRes["batchJobId"])
+}
+
+func (s *SharedServerSuite) testTerminateBatchWorkflow(json bool) *CommandResult {
+	// Make workflow wait for terminate and then return the context's error
+	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+		ctx.Done().Receive(ctx, nil)
+		return nil, ctx.Err()
+	})
+
+	// Start 5 workflows
+	runs := make([]client.WorkflowRun, 5)
+	searchAttr := "keyword-" + uuid.NewString()
+	for i := range runs {
+		run, err := s.Client.ExecuteWorkflow(
+			s.Context,
+			client.StartWorkflowOptions{
+				TaskQueue:        s.Worker.Options.TaskQueue,
+				SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
+			},
+			DevWorkflow,
+			"ignored",
+		)
+		s.NoError(err)
+		runs[i] = run
+	}
+
+	// Wait for all to appear in list
+	s.Eventually(func() bool {
+		resp, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
+			Query: "CustomKeywordField = '" + searchAttr + "'",
+		})
+		s.NoError(err)
+		return len(resp.Executions) == len(runs)
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Send batch terminate with a "y" for non-json or "--yes" for json
+	args := []string{
+		"workflow", "terminate",
+		"--address", s.Address(),
+		"--query", "CustomKeywordField = '" + searchAttr + "'",
+		"--reason", "terminate-test",
+	}
+	if json {
+		args = append(args, "--yes", "-o", "json")
+	} else {
+		s.CommandHarness.Stdin.WriteString("y\n")
+	}
+	res := s.Execute(args...)
+	s.NoError(res.Err)
+
+	// Confirm that all workflows are terminated
+	for _, run := range runs {
+		s.Contains(run.Get(s.Context, nil).Error(), "terminated")
+	}
+	return res
+}

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -405,8 +405,8 @@ Use the options listed below to change the behavior of this command.
 
 * `--workflow-id`, `-w` (string) - Workflow Id. Either this or query must be set.
 * `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
-* `--query`, `-q` (string) - Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.
-* `--reason` (string) - Reason to terminate this workflow. Defaults to message with the current user's name.
+* `--query`, `-q` (string) - Start a batch to terminate Workflow Executions with given List Filter. Either this or Workflow Id must be set.
+* `--reason` (string) - Reason for termination. Defaults to message with the current user's name.
 * `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
 ### temporal workflow trace: Trace progress of a Workflow Execution and its children.

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -338,8 +338,7 @@ Includes options set for [payload input](#options-set-for-payload-input).
 * `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
 * `--query`, `-q` (string) - Start a batch to Signal Workflow Executions with given List Filter. Either this or
   Workflow Id must be set.
-* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. Defaults to message with user name
-  and time.
+* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. 
 * `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
 ### temporal workflow stack: Query a Workflow Execution with __stack_trace as the query type.

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -386,7 +386,24 @@ temporal workflow start \
 
 ### temporal workflow terminate: Terminate Workflow Execution by ID or List Filter.
 
-TODO
+The `temporal workflow terminate` command is used to terminate a [Workflow Execution](/concepts/what-is-a-workflow-execution). Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.
+
+Executions may be terminated by [ID](/concepts/what-is-a-workflow-id):
+```
+temporal workflow terminate --workflow-id MyWorkflowId
+```
+
+...or in bulk via a visibility query [list filter](/concepts/what-is-a-list-filter):
+
+```
+temporal workflow terminate --query=MyQuery
+```
+
+Use the options listed below to change the behavior of this command.
+
+#### Options
+
+Includes options set for [single workflow or batch](#options-set-single-workflow-or-batch)
 
 ### temporal workflow trace: Trace progress of a Workflow Execution and its children.
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -338,7 +338,7 @@ Includes options set for [payload input](#options-set-for-payload-input).
 * `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
 * `--query`, `-q` (string) - Start a batch to Signal Workflow Executions with given List Filter. Either this or
   Workflow Id must be set.
-* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. 
+* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. Defaults to message with the current user's name.
 * `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
 ### temporal workflow stack: Query a Workflow Execution with __stack_trace as the query type.
@@ -385,7 +385,9 @@ temporal workflow start \
 
 ### temporal workflow terminate: Terminate Workflow Execution by ID or List Filter.
 
-The `temporal workflow terminate` command is used to terminate a [Workflow Execution](/concepts/what-is-a-workflow-execution). Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.
+The `temporal workflow terminate` command is used to terminate a [Workflow Execution](/concepts/what-is-a-workflow-execution). 
+Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. 
+Workflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.
 
 Executions may be terminated by [ID](/concepts/what-is-a-workflow-id) with an optional reason:
 ```
@@ -393,7 +395,6 @@ temporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId
 ```
 
 ...or in bulk via a visibility query [list filter](/concepts/what-is-a-list-filter):
-
 ```
 temporal workflow terminate --query=MyQuery
 ```
@@ -402,7 +403,11 @@ Use the options listed below to change the behavior of this command.
 
 #### Options
 
-Includes options set for [single workflow or batch](#options-set-single-workflow-or-batch)
+* `--workflow-id`, `-w` (string) - Workflow Id. Either this or query must be set.
+* `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
+* `--query`, `-q` (string) - Start a batch to Signal Workflow Executions with given List Filter. Either this or Workflow Id must be set.
+* `--reason` (string) - Reason to terminate this workflow. Defaults to message with the current user's name.
+* `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
 ### temporal workflow trace: Trace progress of a Workflow Execution and its children.
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -338,7 +338,7 @@ Includes options set for [payload input](#options-set-for-payload-input).
 * `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
 * `--query`, `-q` (string) - Start a batch to Signal Workflow Executions with given List Filter. Either this or
   Workflow Id must be set.
-* `--reason` (string) - Reason to perform batch. Only allowed if query is present. Defaults to message with user name
+* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies otherwise. Defaults to message with user name
   and time.
 * `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
@@ -386,11 +386,11 @@ temporal workflow start \
 
 ### temporal workflow terminate: Terminate Workflow Execution by ID or List Filter.
 
-The `temporal workflow terminate` command is used to terminate a [Workflow Execution](/concepts/what-is-a-workflow-execution). Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. No further command tasks may be scheduled after running this command.
+The `temporal workflow terminate` command is used to terminate a [Workflow Execution](/concepts/what-is-a-workflow-execution). Canceling a running Workflow Execution records a `WorkflowExecutionTerminated` event as the closing Event in the workflow's Event History. Workflow code is oblivious to termination. Use `temporal workflow cancel` if you need to perform cleanup in your workflow.
 
-Executions may be terminated by [ID](/concepts/what-is-a-workflow-id):
+Executions may be terminated by [ID](/concepts/what-is-a-workflow-id) with an optional reason:
 ```
-temporal workflow terminate --workflow-id MyWorkflowId
+temporal workflow terminate [--reason my-reason] --workflow-id MyWorkflowId
 ```
 
 ...or in bulk via a visibility query [list filter](/concepts/what-is-a-list-filter):


### PR DESCRIPTION
# What was changed

I implemented `temporal workflow terminate`, which should behave the same as in the existing CLI except for the same caveats/improvements as in #432.

I extended the existing `SingleWorkflowOrBatch` functions to allow a command to opt-in to supplying a reason alongside a workflow id as terminate allows for this.