### PR TITLE
CLI Refresh: Output improvements on start-dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	github.com/temporalio/ui-server/v2 v2.23.0
+	github.com/temporalio/ui-server/v2 v2.23.1-0.20240212143757-2e990617b977
 	go.temporal.io/api v1.26.2-0.20231129165614-630d88440548
 	go.temporal.io/sdk v1.25.2-0.20231204212658-5fdbecc56c8c
 	go.temporal.io/server v1.23.0-rc2.0.20231212000105-51ea367f9f37

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1-0.20231116015023-bd4fb7678499 h1:PUclzwrSQgakQIiEvvgVdcfulynpX0JM1f716pEcCTU=
 github.com/temporalio/tchannel-go v1.22.1-0.20231116015023-bd4fb7678499/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
-github.com/temporalio/ui-server/v2 v2.23.0 h1:h5z0k4nLfsKICoenvvIng7NjsRJ3GWc0CKuCtaRgyp0=
-github.com/temporalio/ui-server/v2 v2.23.0/go.mod h1:TKQ+QW229khWmUaR1CooYOS5953zZfBXxo8t1Kc5CBY=
+github.com/temporalio/ui-server/v2 v2.23.1-0.20240212143757-2e990617b977 h1:XmzWx7H2y7enNNYlzceLzCKvm/cs+BQ7paNVgm0Tq2Q=
+github.com/temporalio/ui-server/v2 v2.23.1-0.20240212143757-2e990617b977/go.mod h1:TKQ+QW229khWmUaR1CooYOS5953zZfBXxo8t1Kc5CBY=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -208,6 +208,7 @@ type TemporalServerStartDevCommand struct {
 	SqlitePragma       []string
 	DynamicConfigValue []string
 	LogConfig          bool
+	LogLevelServer     StringEnum
 }
 
 func NewTemporalServerStartDevCommand(cctx *CommandContext, parent *TemporalServerCommand) *TemporalServerStartDevCommand {
@@ -229,13 +230,15 @@ func NewTemporalServerStartDevCommand(cctx *CommandContext, parent *TemporalServ
 	s.Command.Flags().IntVar(&s.MetricsPort, "metrics-port", 0, "Port for /metrics. Default is off.")
 	s.Command.Flags().IntVar(&s.UiPort, "ui-port", 0, "Port for the Web UI. Default is --port + 1000.")
 	s.Command.Flags().BoolVar(&s.Headless, "headless", false, "Disable the Web UI.")
-	s.Command.Flags().StringVar(&s.Ip, "ip", "127.0.0.1", "IP address to bind the frontend service to.")
+	s.Command.Flags().StringVar(&s.Ip, "ip", "localhost", "IP address to bind the frontend service to.")
 	s.Command.Flags().StringVar(&s.UiIp, "ui-ip", "", "IP address to bind the Web UI to. Default is same as --ip.")
 	s.Command.Flags().StringVar(&s.UiAssetPath, "ui-asset-path", "", "UI custom assets path.")
 	s.Command.Flags().StringVar(&s.UiCodecEndpoint, "ui-codec-endpoint", "", "UI remote codec HTTP endpoint.")
 	s.Command.Flags().StringArrayVar(&s.SqlitePragma, "sqlite-pragma", nil, "Specify SQLite pragma statements in pragma=value format.")
 	s.Command.Flags().StringArrayVar(&s.DynamicConfigValue, "dynamic-config-value", nil, "Dynamic config value, as KEY=JSON_VALUE (string values need quotes).")
 	s.Command.Flags().BoolVar(&s.LogConfig, "log-config", false, "Log the server config being used in stderr.")
+	s.LogLevelServer = NewStringEnum([]string{"debug", "info", "warn", "error", "off"}, "warn")
+	s.Command.Flags().Var(&s.LogLevelServer, "log-level-server", "Log level for the server only.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string) error {
+	// Have to assume "localhost" is 127.0.0.1 for server to work (it expects IP)
+	if t.Ip == "localhost" {
+		t.Ip = "127.0.0.1"
+	}
 	// Prepare options
 	opts := devserver.StartOptions{
 		FrontendIP:       t.Ip,
@@ -17,6 +21,11 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 		DatabaseFile:     t.DbFilename,
 		MetricsPort:      t.MetricsPort,
 		FrontendHTTPPort: t.HttpPort,
+	}
+	if t.LogLevelServer.Value == "off" {
+		opts.LogLevel = 100
+	} else if err := opts.LogLevel.UnmarshalText([]byte(t.LogLevelServer.Value)); err != nil {
+		return fmt.Errorf("invalid log level %q: %w", t.LogLevelServer.Value, err)
 	}
 	// Setup UI
 	if !t.Headless {
@@ -49,14 +58,22 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 	}
 
 	// Start, wait for context complete, then stop
-	cctx.Logger.Info("Starting dev server...")
 	s, err := devserver.Start(opts)
 	if err != nil {
 		return fmt.Errorf("failed starting server: %w", err)
 	}
 	defer s.Stop()
+
+	friendlyIP := t.Ip
+	if friendlyIP == "127.0.0.1" {
+		friendlyIP = "localhost"
+	}
+	cctx.Printer.Printlnf("Temporal server is running at: %v:%v", friendlyIP, t.Port)
+	if !t.Headless {
+		cctx.Printer.Printlnf("Web UI is running at: http://%v:%v", friendlyIP, opts.UIPort)
+	}
 	<-cctx.Done()
-	cctx.Logger.Info("Stopping dev server...")
+	cctx.Printer.Println("Stopping server...")
 	return nil
 }
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -144,13 +144,15 @@ To persist Workflows across runs, use:
 * `--metrics-port` (int) - Port for /metrics. Default is off.
 * `--ui-port` (int) - Port for the Web UI. Default is --port + 1000.
 * `--headless` (bool) - Disable the Web UI.
-* `--ip` (string) - IP address to bind the frontend service to. Default: 127.0.0.1.
+* `--ip` (string) - IP address to bind the frontend service to. Default: localhost.
 * `--ui-ip` (string) - IP address to bind the Web UI to. Default is same as --ip.
 * `--ui-asset-path` (string) - UI custom assets path.
 * `--ui-codec-endpoint` (string) - UI remote codec HTTP endpoint.
 * `--sqlite-pragma` (string[]) - Specify SQLite pragma statements in pragma=value format.
 * `--dynamic-config-value` (string[]) - Dynamic config value, as KEY=JSON_VALUE (string values need quotes).
 * `--log-config` (bool) - Log the server config being used in stderr.
+* `--log-level-server` (string-enum) - Log level for the server only. Options: debug, info, warn, error, off. Default:
+  warn.
 
 ### temporal task-queue: Manage Task Queues.
 

--- a/temporalcli/devserver/log.go
+++ b/temporalcli/devserver/log.go
@@ -8,7 +8,10 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-type slogLogger struct{ log *slog.Logger }
+type slogLogger struct {
+	log   *slog.Logger
+	level slog.Level
+}
 
 var _ log.Logger
 
@@ -23,7 +26,7 @@ func (s slogLogger) Panic(msg string, tags ...tag.Tag)  { s.Log(slog.LevelError,
 func (s slogLogger) Fatal(msg string, tags ...tag.Tag)  { s.Log(slog.LevelError, msg, tags) }
 
 func (s slogLogger) Log(level slog.Level, msg string, tags []tag.Tag) {
-	if s.log.Enabled(context.Background(), level) {
+	if level >= s.level && s.log.Enabled(context.Background(), level) {
 		s.log.LogAttrs(context.Background(), level, msg, logTagsToAttrs(tags)...)
 	}
 }

--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -56,6 +56,7 @@ type StartOptions struct {
 	FrontendPort int
 	Namespaces   []string
 	Logger       *slog.Logger
+	LogLevel     slog.Level
 
 	// Optional fields
 	UIIP                string // Empty means no UI
@@ -137,6 +138,8 @@ func (s *StartOptions) buildUIServer() *uiserver.Server {
 		EnableUI:            true,
 		UIAssetPath:         s.UIAssetPath,
 		Codec:               uiconfig.Codec{Endpoint: s.UICodecEndpoint},
+		// TODO(cretz): Pending https://github.com/temporalio/ui/pull/1858
+		// HideLogs:            true,
 	}))
 }
 
@@ -163,7 +166,10 @@ func (s *StartOptions) buildServerOptions() ([]temporal.ServerOption, error) {
 	}
 
 	// Build common opts
-	logger := slogLogger{s.Logger}
+	logger := slogLogger{
+		log:   s.Logger,
+		level: s.LogLevel,
+	}
 	authorizer, err := authorization.GetAuthorizerFromConfig(&conf.Global.Authorization)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating authorizer: %w", err)

--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -138,8 +138,7 @@ func (s *StartOptions) buildUIServer() *uiserver.Server {
 		EnableUI:            true,
 		UIAssetPath:         s.UIAssetPath,
 		Codec:               uiconfig.Codec{Endpoint: s.UICodecEndpoint},
-		// TODO(cretz): Pending https://github.com/temporalio/ui/pull/1858
-		// HideLogs:            true,
+		HideLogs:            true,
 	}))
 }
 


### PR DESCRIPTION
## What was changed

* Split CLI log level from server log level (server "info" is much noisier than CLI) and defaulted it to warn
* Put simple non-log text output for started server and UI server as requested at #66
* Defaulted IP to `localhost` and translate internally to 127.0.0.1 for use but keep as localhost for text output
* Once https://github.com/temporalio/ui/pull/1858 is available and potential future server shutdown changes, many of the spurios output will be removed

Now when you run `temporal server start-dev`, this is the output:

```
Temporal server is running at: localhost:7233
Web UI is running at: http://localhost:8233
```

(many suggestions came from @lorensr)