### PR TITLE
Don't run tests in verbose mode in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version: '1.21'
 
       - name: Test
-        run: go test -v ./...
+        run: go test ./...
 
       - name: Regen code, confirm unchanged
         if: ${{ matrix.checkGenCodeTarget }}


### PR DESCRIPTION
## What was changed

CI will now run tests without `-v`.

## Why?
When you run in verbose mode you need to dig through _all_ test outputs and logging to find even a single test failure. In https://github.com/temporalio/cli/actions/runs/7877883209/job/21494958729?pr=443 we have 1000 lines of output and only 20 lines were relevant to the actual failing test.
