### PR TITLE
Implement activity commands

### DIFF
--- a/temporalcli/commands.activity.go
+++ b/temporalcli/commands.activity.go
@@ -1,0 +1,73 @@
+package temporalcli
+
+import (
+	"fmt"
+
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func (c *TemporalActivityCompleteCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	metadata := map[string][]byte{"encoding": []byte("json/plain")}
+	resultPayloads, err := CreatePayloads([][]byte{[]byte(c.Result)}, metadata, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.WorkflowService().RespondActivityTaskCompletedById(cctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+		Namespace:  c.Parent.Namespace,
+		WorkflowId: c.WorkflowId,
+		RunId:      c.RunId,
+		ActivityId: c.ActivityId,
+		Result:     resultPayloads,
+		Identity:   c.Identity,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to complete Activity: %w", err)
+	}
+	return nil
+}
+
+func (c *TemporalActivityFailCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	metadata := map[string][]byte{"encoding": []byte("json/plain")}
+	var detailPayloads *common.Payloads
+	detailPayloads = nil
+	if len(c.Detail) > 0 {
+		detailPayloads, err = CreatePayloads([][]byte{[]byte(c.Detail)}, metadata, false)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = cl.WorkflowService().RespondActivityTaskFailedById(cctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+		Namespace:  c.Parent.Namespace,
+		WorkflowId: c.WorkflowId,
+		RunId:      c.RunId,
+		ActivityId: c.ActivityId,
+		Failure: &failure.Failure{
+			Message: c.Reason,
+			Source:  "CLI",
+			FailureInfo: &failure.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failure.ApplicationFailureInfo{
+				NonRetryable: true,
+				Details:      detailPayloads,
+			}},
+		},
+		Identity: c.Identity,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to fail Activity: %w", err)
+	}
+	return nil
+}

--- a/temporalcli/commands.activity.go
+++ b/temporalcli/commands.activity.go
@@ -42,10 +42,9 @@ func (c *TemporalActivityFailCommand) run(cctx *CommandContext, args []string) e
 	}
 	defer cl.Close()
 
-	metadata := map[string][]byte{"encoding": []byte("json/plain")}
 	var detailPayloads *common.Payloads
-	detailPayloads = nil
 	if len(c.Detail) > 0 {
+		metadata := map[string][]byte{"encoding": []byte("json/plain")}
 		detailPayloads, err = CreatePayloads([][]byte{[]byte(c.Detail)}, metadata, false)
 		if err != nil {
 			return err

--- a/temporalcli/commands.activity_test.go
+++ b/temporalcli/commands.activity_test.go
@@ -1,0 +1,150 @@
+package temporalcli_test
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	"go.temporal.io/sdk/client"
+)
+
+func (s *SharedServerSuite) TestActivity_Complete() {
+	run := s.waitActivityStarted()
+	wid := run.GetID()
+	aid := "dev-activity-id"
+	identity := "MyIdentity"
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", aid,
+		"--workflow-id", wid,
+		"--result", "\"complete-activity-result\"",
+		"--identity", identity,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+	var actual string
+	s.NoError(run.Get(s.Context, &actual))
+	s.Equal("complete-activity-result", actual)
+
+	started, completed, failed := s.getActivityEvents(wid, aid)
+	s.NotNil(started)
+	s.Nil(failed)
+	s.NotNil(completed)
+	s.Equal("\"complete-activity-result\"", string(completed.Result.Payloads[0].GetData()))
+	s.Equal(identity, completed.GetIdentity())
+}
+
+func (s *SharedServerSuite) TestActivity_Fail() {
+	run := s.waitActivityStarted()
+	wid := run.GetID()
+	aid := "dev-activity-id"
+	detail := "{\"myKey\": \"myValue\"}"
+	reason := "MyReason"
+	identity := "MyIdentity"
+	res := s.Execute(
+		"activity", "fail",
+		"--activity-id", aid,
+		"--workflow-id", wid,
+		"--run-id", run.GetRunID(),
+		"--detail", detail,
+		"--reason", reason,
+		"--identity", identity,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+	err := run.Get(s.Context, nil)
+	s.NotNil(err)
+
+	started, completed, failed := s.getActivityEvents(wid, aid)
+	s.NotNil(started)
+	s.Nil(completed)
+	s.NotNil(failed)
+	s.Equal(
+		detail,
+		string(failed.GetFailure().GetApplicationFailureInfo().GetDetails().Payloads[0].GetData()),
+	)
+	s.Equal(reason, failed.GetFailure().Message)
+	s.Equal(identity, failed.GetIdentity())
+}
+
+func (s *SharedServerSuite) TestActivity_Complete_InvalidResult() {
+	run := s.waitActivityStarted()
+	wid := run.GetID()
+	aid := "dev-activity-id"
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", aid,
+		"--workflow-id", wid,
+		"--result", "{not json}",
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "is not valid JSON")
+
+	started, completed, failed := s.getActivityEvents(wid, aid)
+	s.Nil(started)
+	s.Nil(completed)
+	s.Nil(failed)
+}
+
+func (s *SharedServerSuite) TestActivity_Fail_InvalidDetail() {
+	run := s.waitActivityStarted()
+	wid := run.GetID()
+	aid := "dev-activity-id"
+	res := s.Execute(
+		"activity", "fail",
+		"--activity-id", aid,
+		"--workflow-id", wid,
+		"--detail", "{not json}",
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "is not valid JSON")
+
+	started, completed, failed := s.getActivityEvents(wid, aid)
+	s.Nil(started)
+	s.Nil(completed)
+	s.Nil(failed)
+}
+
+// Test helpers
+
+func (s *SharedServerSuite) waitActivityStarted() client.WorkflowRun {
+	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		time.Sleep(0xFFFF * time.Hour)
+		return nil, nil
+	})
+	run, err := s.Client.ExecuteWorkflow(
+		s.Context,
+		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		DevWorkflow,
+		"ignored",
+	)
+	s.NoError(err)
+	s.Eventually(func() bool {
+		resp, err := s.Client.DescribeWorkflowExecution(s.Context, run.GetID(), run.GetRunID())
+		s.NoError(err)
+		return len(resp.PendingActivities) > 0
+	}, 5*time.Second, 100*time.Millisecond)
+	return run
+}
+
+func (s *SharedServerSuite) getActivityEvents(workflowID, activityID string) (
+	started *history.ActivityTaskStartedEventAttributes,
+	completed *history.ActivityTaskCompletedEventAttributes,
+	failed *history.ActivityTaskFailedEventAttributes,
+) {
+	iter := s.Client.GetWorkflowHistory(s.Context, workflowID, "", false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for iter.HasNext() {
+		event, err := iter.Next()
+		s.NoError(err)
+		if attrs := event.GetActivityTaskStartedEventAttributes(); attrs != nil {
+			started = attrs
+		} else if attrs := event.GetActivityTaskCompletedEventAttributes(); attrs != nil {
+			completed = attrs
+			s.Equal("json/plain", string(completed.Result.Payloads[0].Metadata["encoding"]))
+		} else if attrs := event.GetActivityTaskFailedEventAttributes(); attrs != nil {
+			failed = attrs
+		}
+	}
+	return started, completed, failed
+}

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -67,7 +67,7 @@ func NewTemporalActivityCommand(cctx *CommandContext, parent *TemporalCommand) *
 	var s TemporalActivityCommand
 	s.Parent = parent
 	s.Command.Use = "activity"
-	s.Command.Short = "Complete or fail an activity."
+	s.Command.Short = "Complete or fail an Activity."
 	s.Command.Long = ""
 	s.Command.Args = cobra.NoArgs
 	s.Command.AddCommand(&NewTemporalActivityCompleteCommand(cctx, &s).Command)
@@ -90,17 +90,17 @@ func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalAc
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "complete [flags]"
-	s.Command.Short = "Complete an activity."
+	s.Command.Short = "Complete an Activity."
 	if hasHighlighting {
-		s.Command.Long = "Complete an Activity Execution.\n\n\x1b[1mtemporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{\"MyResultKey\": \"MyResultVal\"}'\x1b[0m"
+		s.Command.Long = "Complete an Activity.\n\n\x1b[1mtemporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{\"MyResultKey\": \"MyResultVal\"}'\x1b[0m"
 	} else {
-		s.Command.Long = "Complete an Activity Execution.\n\n`temporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{\"MyResultKey\": \"MyResultVal\"}'`"
+		s.Command.Long = "Complete an Activity.\n\n`temporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{\"MyResultKey\": \"MyResultVal\"}'`"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Flags().StringVar(&s.ActivityId, "activity-id", "", "The Activity to be completed.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
-	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of operator.")
+	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of user submitting this request.")
 	s.Command.Flags().StringVar(&s.Result, "result", "", "The result with which to complete the Activity (JSON).")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "result")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -126,11 +126,11 @@ func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivi
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "fail [flags]"
-	s.Command.Short = "Fail an activity."
+	s.Command.Short = "Fail an Activity."
 	if hasHighlighting {
-		s.Command.Long = "Fail an Activity Execution.\n\n\x1b[1mtemporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId\x1b[0m"
+		s.Command.Long = "Fail an Activity.\n\n\x1b[1mtemporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId\x1b[0m"
 	} else {
-		s.Command.Long = "Fail an Activity Execution.\n\n`temporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId`"
+		s.Command.Long = "Fail an Activity.\n\n`temporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId`"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -2,7 +2,6 @@ package temporalcli
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -312,24 +311,7 @@ func (p *PayloadInputOptions) buildRawInputPayloads() (*common.Payloads, error) 
 		}
 		metadata[metaPieces[0]] = []byte(metaPieces[1])
 	}
-
-	// Create payloads
-	ret := &common.Payloads{Payloads: make([]*common.Payload, len(inData))}
-	for i, in := range inData {
-		// First, if it's JSON, validate that it is accurate
-		if strings.HasPrefix(string(metadata["encoding"]), "json/") && !json.Valid(in) {
-			return nil, fmt.Errorf("input #%v is not valid JSON", i+1)
-		}
-		// Decode base64 if base64'd (std encoding only for now)
-		if p.InputBase64 {
-			var err error
-			if in, err = base64.StdEncoding.DecodeString(string(in)); err != nil {
-				return nil, fmt.Errorf("input #%v is not valid base64", i+1)
-			}
-		}
-		ret.Payloads[i] = &common.Payload{Data: in, Metadata: metadata}
-	}
-	return ret, nil
+	return CreatePayloads(inData, metadata, p.InputBase64)
 }
 
 // Rules:

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -434,7 +434,10 @@ func (d *devOperations) DevWorkflow(ctx workflow.Context, input any) (any, error
 	if callback != nil {
 		return callback(ctx, input)
 	}
-	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 10 * time.Second})
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+		ActivityID:          "dev-activity-id",
+	})
 	var res any
 	err := workflow.ExecuteActivity(ctx, DevActivity, input).Get(ctx, &res)
 	return res, err

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -57,6 +57,43 @@ This document has a specific structure used by a parser. Here are the rules:
 * `--color` (string-enum) - Set coloring. Options: always, never, auto. Default: auto.
 * `--no-json-shorthand-payloads` (bool) - Always all payloads as raw payloads even if they are JSON.
 
+### temporal activity: Complete or fail an activity.
+
+#### Options
+
+Includes options set for [client](#options-set-for-client).
+
+
+### temporal activity complete: Complete an activity.
+
+Complete an Activity Execution.
+
+`temporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{"MyResultKey": "MyResultVal"}'`
+
+#### Options
+
+* `--activity-id` (string) - The Activity to be completed. Required.
+* `--identity` (string) - Identity of operator.
+* `--result` (string) - The result with which to complete the Activity (JSON). Required.
+
+Includes options set for [workflow reference](#options-set-for-workflow-reference).
+
+### temporal activity fail: Fail an activity.
+
+Fail an Activity Execution.
+
+`temporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId`
+
+#### Options
+
+* `--activity-id` (string) - The Activity to be failed. Required.
+* `--detail` (string) - JSON data describing reason for failing the Activity.
+* `--identity` (string) - Identity of user submitting this request.
+* `--reason` (string) - Reason for failing the Activity.
+
+Includes options set for [workflow reference](#options-set-for-workflow-reference).
+
+
 ### temporal env: Manage environments.
 
 Use the '--env <env name>' option with other commands to point the CLI at a different Temporal Server instance. If --env

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -57,30 +57,30 @@ This document has a specific structure used by a parser. Here are the rules:
 * `--color` (string-enum) - Set coloring. Options: always, never, auto. Default: auto.
 * `--no-json-shorthand-payloads` (bool) - Always all payloads as raw payloads even if they are JSON.
 
-### temporal activity: Complete or fail an activity.
+### temporal activity: Complete or fail an Activity.
 
 #### Options
 
 Includes options set for [client](#options-set-for-client).
 
 
-### temporal activity complete: Complete an activity.
+### temporal activity complete: Complete an Activity.
 
-Complete an Activity Execution.
+Complete an Activity.
 
 `temporal activity complete --activity-id=MyActivityId --workflow-id=MyWorkflowId --result='{"MyResultKey": "MyResultVal"}'`
 
 #### Options
 
 * `--activity-id` (string) - The Activity to be completed. Required.
-* `--identity` (string) - Identity of operator.
+* `--identity` (string) - Identity of user submitting this request.
 * `--result` (string) - The result with which to complete the Activity (JSON). Required.
 
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 
-### temporal activity fail: Fail an activity.
+### temporal activity fail: Fail an Activity.
 
-Fail an Activity Execution.
+Fail an Activity.
 
 `temporal activity fail --activity-id=MyActivityId --workflow-id=MyWorkflowId`
 

--- a/temporalcli/payload.go
+++ b/temporalcli/payload.go
@@ -1,0 +1,29 @@
+package temporalcli
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.temporal.io/api/common/v1"
+)
+
+func CreatePayloads(data [][]byte, metadata map[string][]byte, isBase64 bool) (*common.Payloads, error) {
+	ret := &common.Payloads{Payloads: make([]*common.Payload, len(data))}
+	for i, in := range data {
+		// If it's JSON, validate it
+		if strings.HasPrefix(string(metadata["encoding"]), "json/") && !json.Valid(in) {
+			return nil, fmt.Errorf("input #%v is not valid JSON", i+1)
+		}
+		// Decode base64 if base64'd (std encoding only for now)
+		if isBase64 {
+			var err error
+			if in, err = base64.StdEncoding.DecodeString(string(in)); err != nil {
+				return nil, fmt.Errorf("input #%v is not valid base64", i+1)
+			}
+		}
+		ret.Payloads[i] = &common.Payload{Data: in, Metadata: metadata}
+	}
+	return ret, nil
+}


### PR DESCRIPTION
## What was changed
Implement `temporal activity fail` and `temporal activity complete`

## How was this tested
- PR includes end-to-end tests
- I modified [`samples-python:hello/hello_activity.py`](https://github.com/temporalio/samples-python/blob/main/hello/hello_activity.py) to sleep for a long time in the activity, issued CLI commands (examples below), and confirmed results in web UI.

<details>

```diff
commit 5519021cac3a1d0b9818d903882e0e053ad3df8b (HEAD -> update-reapply)
Author: Dan Davison <dan.davison@temporal.io>
Date:   Mon Feb 12 18:02:34 2024 -0500

    Test cli activity commands

diff --git a/hello/hello_activity.py b/hello/hello_activity.py
index 6615b55..a8a8e54 100644
--- a/hello/hello_activity.py
+++ b/hello/hello_activity.py
@@ -21,6 +21,7 @@ class ComposeGreetingInput:
 @activity.defn
 async def compose_greeting(input: ComposeGreetingInput) -> str:
     activity.logger.info("Running activity with parameter %s" % input)
+    await asyncio.sleep(0xFFFFFFFF)
     return f"{input.greeting}, {input.name}!"
 
 
@@ -33,7 +34,8 @@ class GreetingWorkflow:
         return await workflow.execute_activity(
             compose_greeting,
             ComposeGreetingInput("Hello", name),
-            start_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=0xFFFFFFFF),
+            activity_id="MyActivityId",
         )
```

</details>

## Example commands tested
```
temporal-new activity complete --activity-id MyActivityId --workflow-id MyWorkflowId --result '{"resultkey": "resultval"}' --identity 'MyIdentity' --run-id e592b7a1-a15d-4de1-83b4-32ec070706fa
temporal-new activity fail --activity-id MyActivityId --workflow-id MyWorkflowId --detail '{"detailkey": "detailval"}' --run-id d9049fc2-ad6c-4f3e-9f04-52b287a7e913 --reason 'top-level-reason' --identity 'MyIdentity'
```

