### PR TITLE
Emit JSONL from `workflow list --output json`

### DIFF
--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -212,7 +212,7 @@ func (c *TemporalWorkflowListCommand) run(cctx *CommandContext, args []string) e
 			execsProcessed++
 			// For JSON we are going to dump one line of JSON per execution
 			if cctx.JSONOutput {
-				_ = cctx.Printer.PrintStructured(exec, printer.StructuredOptions{})
+				_ = cctx.Printer.PrintJSON(exec, "", printer.StructuredOptions{})
 			} else {
 				// For non-JSON, we are doing a table for each page
 				textTable = append(textTable, map[string]any{

--- a/temporalcli/internal/printer/printer.go
+++ b/temporalcli/internal/printer/printer.go
@@ -81,9 +81,8 @@ type TableOptions struct {
 
 // For JSON, if v is a proto message, protojson encoding is used
 func (p *Printer) PrintStructured(v any, options StructuredOptions) error {
-	// JSON
 	if p.JSON {
-		return p.printJSON(v, options)
+		return p.PrintJSON(v, p.JSONIndent, options)
 	}
 
 	// Get data
@@ -170,12 +169,12 @@ func (p *Printer) writef(s string, v ...any) {
 	}
 }
 
-func (p *Printer) printJSON(v any, options StructuredOptions) error {
+func (p *Printer) PrintJSON(v any, indent string, options StructuredOptions) error {
 	shorthandPayloads := p.JSONPayloadShorthand
 	if options.OverrideJSONPayloadShorthand != nil {
 		shorthandPayloads = *options.OverrideJSONPayloadShorthand
 	}
-	b, err := p.jsonVal(v, p.JSONIndent, shorthandPayloads)
+	b, err := p.jsonVal(v, indent, shorthandPayloads)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What was changed
Change `workflow list --output json` to emit JSONL format.

## Why?
Currently it emits one multiline JSON object per workflow, so the result is (in the case of >1 workflow) neither valid JSON nor valid JSONL. Most tools will not be able to parse this (although as it happens, `jq` does parse this).
