### PR TITLE
Override SDK-set headers for client name and others

### DIFF
--- a/temporalcli/client.go
+++ b/temporalcli/client.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func (c *ClientOptions) dialClient(cctx *CommandContext) (client.Client, error) {
@@ -53,6 +54,14 @@ func (c *ClientOptions) dialClient(cctx *CommandContext) (client.Client, error) 
 			clientOptions.ConnectionOptions.DialOptions, grpc.WithChainUnaryInterceptor(interceptor))
 	}
 
+	// Fixed header overrides
+	clientOptions.ConnectionOptions.DialOptions = append(
+		clientOptions.ConnectionOptions.DialOptions, grpc.WithChainUnaryInterceptor(fixedHeaderOverrideInterceptor))
+
+	// Additional gRPC options
+	clientOptions.ConnectionOptions.DialOptions = append(
+		clientOptions.ConnectionOptions.DialOptions, cctx.Options.AdditionalClientGRPCDialOptions...)
+
 	// TLS
 	var err error
 	if clientOptions.ConnectionOptions.TLS, err = c.tlsConfig(); err != nil {
@@ -90,6 +99,25 @@ func (c *ClientOptions) tlsConfig() (*tls.Config, error) {
 		}
 	}
 	return conf, nil
+}
+
+func fixedHeaderOverrideInterceptor(
+	ctx context.Context,
+	method string, req, reply any,
+	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+) error {
+	// The SDK sets some values on the outgoing metadata that we can't override
+	// via normal headers, so we have to replace directly on the metadata
+	md, _ := metadata.FromOutgoingContext(ctx)
+	if md == nil {
+		md = metadata.MD{}
+	}
+	md.Set("client-name", "temporal-cli")
+	md.Set("client-version", Version)
+	md.Set("supported-server-versions", ">=1.0.0 <2.0.0")
+	md.Set("caller-type", "operator")
+	ctx = metadata.NewOutgoingContext(ctx, md)
+	return invoker(ctx, method, req, reply, cc, opts...)
 }
 
 func payloadCodecInterceptor(namespace, codecEndpoint, codecAuth string) (grpc.UnaryClientInterceptor, error) {

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/temporalproto"
 	"go.temporal.io/server/common/headers"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
@@ -67,6 +68,8 @@ type CommandOptions struct {
 
 	// Defaults to logging error then os.Exit(1)
 	Fail func(error)
+
+	AdditionalClientGRPCDialOptions []grpc.DialOption
 }
 
 func NewCommandContext(ctx context.Context, options CommandOptions) (*CommandContext, context.CancelFunc, error) {

--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -47,6 +47,7 @@ import (
 	"go.temporal.io/server/schema/sqlite"
 	sqliteschema "go.temporal.io/server/schema/sqlite"
 	"go.temporal.io/server/temporal"
+	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 )
 
@@ -71,6 +72,7 @@ type StartOptions struct {
 	FrontendHTTPPort    int
 	DynamicConfigValues map[string]any
 	LogConfig           func([]byte)
+	GRPCInterceptors    []grpc.UnaryServerInterceptor
 }
 
 type Server struct {
@@ -193,6 +195,12 @@ func (s *StartOptions) buildServerOptions() ([]temporal.ServerOption, error) {
 		}
 		opts = append(opts, temporal.WithDynamicConfigClient(dynConf))
 	}
+
+	// gRPC interceptors if set
+	if len(s.GRPCInterceptors) > 0 {
+		opts = append(opts, temporal.WithChainedFrontendGrpcInterceptors(s.GRPCInterceptors...))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
## What was changed

Add `client-name`, `client-version`, `supported-server-versions`, and `caller-type` headers on outbound client calls in CLI refresh code. Previous CLI used outgoing gRPC metadata on the context, but my research has shown we overwrite that anyways. So up until now we may not have been setting these headers properly (making CLI appear as Go SDK).

## Checklist

1. Closes #440