### PR TITLE
Add goreleaser and Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+
+      - name: Get build date
+        id: date
+        run: echo "::set-output name=date::$(date '+%F-%T')"
+
+      - name: Get build unix timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date '+%s')"
+
+      - name: Get git branch
+        id: branch
+        run: echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
+
+      - name: Get build platform
+        id: platform
+        run: echo "::set-output name=platform::$(go version | cut -d ' ' -f 4)"
+
+      - name: Get Go version
+        id: go
+        run: echo "::set-output name=go::$(go version | cut -d ' ' -f 3)"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_DATE: ${{ steps.date.outputs.date }}
+          BUILD_TS_UNIX: ${{ steps.timestamp.outputs.timestamp }}
+          GIT_BRANCH: ${{ steps.branch.outputs.branch }}
+          BUILD_PLATFORM: ${{ steps.platform.outputs.platform }}
+          GO_VERSION: ${{ steps.go.outputs.go }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,67 @@
+before:
+  hooks:
+    - go mod download
+
+release:
+  prerelease: auto
+  draft: false
+  name_template: "v{{.Version}}"
+
+archives:
+  - <<: &archive_defaults
+      name_template: "temporal_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: nix
+    builds:
+      - nix
+    format: tar.gz
+    files:
+      - LICENSE
+
+  - <<: *archive_defaults
+    id: windows-zip
+    builds:
+      - windows
+    format: zip
+    files:
+      - LICENSE
+
+    # used by SDKs as zip cannot be used by rust https://github.com/zip-rs/zip/issues/108
+  - <<: *archive_defaults
+    id: windows-targz
+    builds:
+      - windows
+    files:
+      - LICENSE
+
+builds:
+  - <<: &build_defaults
+      dir: cmd/temporal
+      binary: temporal
+      ldflags:
+        - -s -w -X github.com/temporalio/cli/temporalcli.Version={{.Version}}
+      goarch:
+        - amd64
+        - arm64
+      env:
+        - CGO_ENABLED=0
+    id: nix
+    goos:
+      - linux
+      - darwin
+
+  - <<: *build_defaults
+    id: windows
+    goos:
+      - windows
+    hooks:
+      post: # TODO sign Windows release
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+changelog:
+  skip: true
+
+announce:
+  skip: "true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.22-bookworm as builder
+
+WORKDIR /app
+
+# Copy everything
+COPY . ./
+
+# Build
+RUN go build ./cmd/temporal
+
+# Use slim container for running
+FROM debian:bookworm-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy binary
+COPY --from=builder /app/temporal /app/temporal
+
+# Set CLI as primary entrypoint
+ENTRYPOINT ["/app/temporal"]

--- a/README.md
+++ b/README.md
@@ -4,5 +4,39 @@ Temporal command-line interface and development server.
 
 ⚠️ Under active development and inputs/outputs may change ⚠️
 
-See [the documentation](https://docs.temporal.io/cli) for install and usage information. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for build and development information.
+**[DOCUMENTATION](https://docs.temporal.io/cli)**
+
+## Quick Install
+
+Reference [the documentation](https://docs.temporal.io/cli) for detailed install information.
+
+### Install via Homebrew
+
+    brew install temporal
+
+### Install via download
+
+1. Download the version for your OS and architecture:
+    - [Linux amd64](https://temporal.download/cli/archive/latest?platform=linux&arch=amd64)
+    - [Linux arm64](https://temporal.download/cli/archive/latest?platform=linux&arch=arm64)
+    - [macOS amd64](https://temporal.download/cli/archive/latest?platform=darwin&arch=amd64)
+    - [macOS arm64](https://temporal.download/cli/archive/latest?platform=darwin&arch=arm64) (Apple silicon)
+    - [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
+2. Extract the downloaded archive.
+3. Add the `temporal` binary to your `PATH` (`temporal.exe` for Windows).
+
+### Build
+
+1. Install [Go](https://go.dev/)
+2. Clone repository
+3. Switch to cloned directory, and run `go build ./cmd/temporal`
+
+The executable will be at `temporal` (`temporal.exe` for Windows).
+
+## Usage
+
+Reference [the documentation](https://docs.temporal.io/cli) for detailed usage information.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## What was changed

* Add `.goreleaser`
* Add `Dockerfile`
* Add release workflow that invokes Goreleaser (will add Docker publishing later as we get closer to release)
* Add intentionally-very-minimal README

Everything else about releases is expected to remain the same in the nearterm (with other non-Brew package managers done separately as separate projects).

## Known incompatibilities

No install shell script anymore, we will follow the likes of many other single-binary pieces of software and direct them to download, extract, and use (ideally supporting more package managers so the direct usage is less common).