### PR TITLE
CLI Refresh: `batch` commands 

### DIFF
--- a/temporalcli/commands.batch.go
+++ b/temporalcli/commands.batch.go
@@ -1,0 +1,157 @@
+package temporalcli
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/temporalio/cli/temporalcli/internal/printer"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+)
+
+type (
+	batchDescribe struct {
+		State          string
+		Type           string
+		StartTime      time.Time
+		CloseTime      time.Time
+		CompletedCount string
+		FailureCount   string
+	}
+	batchTableRow struct {
+		JobId     string
+		State     string
+		StartTime time.Time
+		CloseTime time.Time
+	}
+)
+
+func (c TemporalBatchDescribeCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	resp, err := cl.WorkflowService().DescribeBatchOperation(cctx, &workflowservice.DescribeBatchOperationRequest{
+		Namespace: c.Parent.Namespace,
+		JobId:     c.JobId,
+	})
+	var notFound *serviceerror.NotFound
+	if errors.As(err, &notFound) {
+		return fmt.Errorf("could not find Batch Job '%v'", c.JobId)
+	} else if err != nil {
+		return fmt.Errorf("failed to describe batch job: %w", err)
+	}
+
+	if cctx.JSONOutput {
+		return cctx.Printer.PrintStructured(resp, printer.StructuredOptions{})
+	}
+
+	_ = cctx.Printer.PrintStructured(batchDescribe{
+		Type:           resp.OperationType.String(),
+		State:          resp.State.String(),
+		StartTime:      resp.StartTime.AsTime(),
+		CloseTime:      resp.CloseTime.AsTime(),
+		CompletedCount: fmt.Sprintf("%d/%d", resp.CompleteOperationCount, resp.TotalOperationCount),
+		FailureCount:   fmt.Sprintf("%d/%d", resp.FailureOperationCount, resp.TotalOperationCount),
+	}, printer.StructuredOptions{})
+
+	return nil
+}
+
+func (c TemporalBatchListCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	pageFetcher := c.pageFetcher(cctx, cl)
+	var nextPageToken []byte
+	var jobsProcessed int
+	for pageIndex := 0; ; pageIndex++ {
+		page, err := pageFetcher(nextPageToken)
+		if err != nil {
+			return fmt.Errorf("failed to list batch jobs: %w", err)
+		}
+
+		if pageIndex == 0 && len(page.GetOperationInfo()) == 0 {
+			if cctx.JSONOutput {
+				_ = cctx.Printer.PrintStructured([]any{}, printer.StructuredOptions{})
+			}
+			return nil
+		}
+
+		var textTable []batchTableRow
+		for _, job := range page.GetOperationInfo() {
+			if c.Limit > 0 && jobsProcessed >= c.Limit {
+				break
+			}
+			jobsProcessed++
+			// For JSON we are going to dump one line of JSON per execution
+			if cctx.JSONOutput {
+				_ = cctx.Printer.PrintStructured(job, printer.StructuredOptions{})
+			} else {
+				// For non-JSON, we are doing a table for each page
+				textTable = append(textTable, batchTableRow{
+					JobId:     job.JobId,
+					State:     job.State.String(),
+					StartTime: job.StartTime.AsTime(),
+					CloseTime: job.CloseTime.AsTime(),
+				})
+			}
+		}
+		// Print table, headers only on first table
+		if len(textTable) > 0 {
+			_ = cctx.Printer.PrintStructured(textTable, printer.StructuredOptions{
+				Table: &printer.TableOptions{NoHeader: pageIndex > 0},
+			})
+		}
+		// Stop if next page token non-existing or list reached limit
+		nextPageToken = page.GetNextPageToken()
+		if len(nextPageToken) == 0 || (c.Limit > 0 && jobsProcessed >= c.Limit) {
+			return nil
+		}
+	}
+}
+
+func (c *TemporalBatchListCommand) pageFetcher(
+	cctx *CommandContext,
+	cl client.Client,
+) func(next []byte) (*workflowservice.ListBatchOperationsResponse, error) {
+	return func(next []byte) (*workflowservice.ListBatchOperationsResponse, error) {
+		return cl.WorkflowService().ListBatchOperations(cctx, &workflowservice.ListBatchOperationsRequest{
+			Namespace:     c.Parent.Namespace,
+			NextPageToken: next,
+		})
+	}
+}
+
+func (c TemporalBatchTerminateCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	_, err = cl.WorkflowService().StopBatchOperation(cctx, &workflowservice.StopBatchOperationRequest{
+		Namespace: c.Parent.Namespace,
+		JobId:     c.JobId,
+		Reason:    c.Reason,
+		Identity:  clientIdentity(),
+	})
+
+	var notFound *serviceerror.NotFound
+	if errors.As(err, &notFound) {
+		return fmt.Errorf("could not find Batch Job '%v'", c.JobId)
+	} else if err != nil {
+		return fmt.Errorf("failed to terminate batch job: %w", err)
+	}
+
+	cctx.Printer.Printlnf("terminated Batch Job '%v'", c.JobId)
+
+	return nil
+}

--- a/temporalcli/commands.batch.go
+++ b/temporalcli/commands.batch.go
@@ -151,7 +151,7 @@ func (c TemporalBatchTerminateCommand) run(cctx *CommandContext, args []string) 
 		return fmt.Errorf("failed to terminate batch job: %w", err)
 	}
 
-	cctx.Printer.Printlnf("terminated Batch Job '%v'", c.JobId)
+	cctx.Printer.Printlnf("Terminated Batch Job '%v'", c.JobId)
 
 	return nil
 }

--- a/temporalcli/commands.batch_test.go
+++ b/temporalcli/commands.batch_test.go
@@ -3,7 +3,6 @@ package temporalcli_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ func (s *SharedServerSuite) TestBatchJob_Describe() {
 				"batch", "describe",
 				"--address", s.Address(),
 				"--job-id", "not-found")
-			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+			s.EqualError(res.Err, "could not find Batch Job 'not-found'")
 		})
 
 		t.Run("as json", func(t *testing.T) {
@@ -30,7 +29,7 @@ func (s *SharedServerSuite) TestBatchJob_Describe() {
 				"--address", s.Address(),
 				"--job-id", "not-found",
 				"-o", "json")
-			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+			s.EqualError(res.Err, "could not find Batch Job 'not-found'")
 		})
 	})
 
@@ -167,7 +166,7 @@ func (s *SharedServerSuite) TestBatchJob_Terminate() {
 				"--address", s.Address(),
 				"--job-id", "not-found",
 				"--reason", "testing")
-			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+			s.EqualError(res.Err, "could not find Batch Job 'not-found'")
 		})
 
 		t.Run("as json", func(t *testing.T) {
@@ -177,7 +176,7 @@ func (s *SharedServerSuite) TestBatchJob_Terminate() {
 				"--job-id", "not-found",
 				"--reason", "testing",
 				"-o", "json")
-			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+			s.EqualError(res.Err, "could not find Batch Job 'not-found'")
 		})
 	})
 

--- a/temporalcli/commands.batch_test.go
+++ b/temporalcli/commands.batch_test.go
@@ -192,7 +192,7 @@ func (s *SharedServerSuite) TestBatchJob_Terminate() {
 				"--reason", "testing")
 			s.NoError(res.Err)
 			s.Empty(res.Stderr.String())
-			s.Equal("terminated Batch Job '"+jobId+"'\n", res.Stdout.String())
+			s.Equal("Terminated Batch Job '"+jobId+"'\n", res.Stdout.String())
 		})
 
 		t.Run("as json", func(t *testing.T) {

--- a/temporalcli/commands.batch_test.go
+++ b/temporalcli/commands.batch_test.go
@@ -1,0 +1,231 @@
+package temporalcli_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"go.temporal.io/api/batch/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func (s *SharedServerSuite) TestBatchJob_Describe() {
+	s.t.Run("non-existing job id", func(t *testing.T) {
+		t.Run("as text", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "describe",
+				"--address", s.Address(),
+				"--job-id", "not-found")
+			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "describe",
+				"--address", s.Address(),
+				"--job-id", "not-found",
+				"-o", "json")
+			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+		})
+	})
+
+	s.t.Run("existing job id", func(t *testing.T) {
+		// kickstart batch job (using Client directly to provide a `JobId`)
+		jobId := "TestBatchJob_Describe"
+		s.startBatchJob(jobId, s.Namespace())
+
+		t.Run("as text", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "describe",
+				"--address", s.Address(),
+				"--job-id", jobId)
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+
+			out := res.Stdout.String()
+			s.ContainsOnSameLine(out, "State", "Running")
+			s.ContainsOnSameLine(out, "Type", "Terminate")
+			s.ContainsOnSameLine(out, "CompletedCount", "0/0")
+			s.ContainsOnSameLine(out, "FailureCount", "0/0")
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "describe",
+				"--address", s.Address(),
+				"--job-id", jobId,
+				"-o", "json")
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+
+			spew.Dump(res.Stdout.String())
+
+			var jsonOut map[string]any
+			s.NoError(json.Unmarshal(res.Stdout.Bytes(), &jsonOut))
+			s.Equal(jobId, jsonOut["jobId"])
+			s.Equal("BATCH_OPERATION_TYPE_TERMINATE", jsonOut["operationType"])
+			s.Equal("REASON", jsonOut["reason"])
+		})
+	})
+}
+
+func (s *SharedServerSuite) TestBatchJob_List() {
+	// NOTE: this test is the only test to use the "batch-empty" namespace;
+	// ie it is guaranteed to be empty at the start
+
+	s.t.Run("no batch jobs", func(t *testing.T) {
+		t.Run("as text", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "list",
+				"--namespace", "batch-empty",
+				"--address", s.Address())
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+			s.Empty(res.Stdout.String())
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "list",
+				"--address", s.Address(),
+				"--namespace", "batch-empty",
+				"-o", "json",
+			)
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+			s.Equal("[]\n", res.Stdout.String())
+		})
+	})
+
+	s.t.Run("a few batch jobs", func(t *testing.T) {
+		// start a few batch jobs
+		for i := 0; i < 3; i++ {
+			s.startBatchJob(fmt.Sprintf("TestBatchJob_List_%d", i), "batch-empty")
+		}
+
+		t.Run("as text", func(t *testing.T) {
+			var res *CommandResult
+			s.Eventually(func() bool {
+				res = s.Execute(
+					"batch", "list",
+					"--address", s.Address(),
+					"--namespace", "batch-empty")
+				s.NoError(res.Err)
+				s.Empty(res.Stderr.String())
+				return strings.Count(res.Stdout.String(), "Completed") == 3
+			}, 5*time.Second, 100*time.Millisecond)
+
+			out := res.Stdout.String()
+			s.Equal(4, strings.Count(out, "\n"), "expect 3 data rows + 1 header row")
+			s.ContainsOnSameLine(out, "JobId", "State", "StartTime", "CloseTime") // header
+			s.ContainsOnSameLine(out, "TestBatchJob_List_2", "Completed")
+			s.ContainsOnSameLine(out, "TestBatchJob_List_1", "Completed")
+			s.ContainsOnSameLine(out, "TestBatchJob_List_0", "Completed")
+		})
+
+		t.Run("as text with limit", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "list",
+				"--address", s.Address(),
+				"--namespace", "batch-empty",
+				"--limit", "1")
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+
+			out := res.Stdout.String()
+			s.Equal(2, strings.Count(out, "\n"), "expect 1 data row + 1 header row")
+			s.ContainsOnSameLine(out, "JobId", "State", "StartTime", "CloseTime") // header
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "list",
+				"--address", s.Address(),
+				"--namespace", "batch-empty",
+				"-o", "json")
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+
+			out := res.Stdout.String()
+			s.ContainsOnSameLine(out, "\"jobId\": \"TestBatchJob_List_2\"")
+			s.ContainsOnSameLine(out, "\"jobId\": \"TestBatchJob_List_1\"")
+			s.ContainsOnSameLine(out, "\"jobId\": \"TestBatchJob_List_0\"")
+		})
+	})
+}
+
+func (s *SharedServerSuite) TestBatchJob_Terminate() {
+	s.t.Run("non-existing job id", func(t *testing.T) {
+		t.Run("as text", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "terminate",
+				"--address", s.Address(),
+				"--job-id", "not-found",
+				"--reason", "testing")
+			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			res := s.Execute(
+				"batch", "terminate",
+				"--address", s.Address(),
+				"--job-id", "not-found",
+				"--reason", "testing",
+				"-o", "json")
+			s.Error(res.Err, errors.New("could not find Batch Job 'not-found'"))
+		})
+	})
+
+	s.t.Run("existing job id", func(t *testing.T) {
+		t.Run("as text", func(t *testing.T) {
+			jobId := "TestBatchJob_Terminate_Text"
+			s.startBatchJob(jobId, s.Namespace())
+
+			res := s.Execute(
+				"batch", "terminate",
+				"--address", s.Address(),
+				"--job-id", jobId,
+				"--reason", "testing")
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+			s.Equal("terminated Batch Job '"+jobId+"'\n", res.Stdout.String())
+		})
+
+		t.Run("as json", func(t *testing.T) {
+			jobId := "TestBatchJob_Terminate_JSON"
+			s.startBatchJob(jobId, s.Namespace())
+
+			res := s.Execute(
+				"batch", "terminate",
+				"--address", s.Address(),
+				"--job-id", jobId,
+				"--reason", "testing",
+				"-o", "json")
+			s.NoError(res.Err)
+			s.Empty(res.Stderr.String())
+			s.Empty(res.Stdout.String())
+		})
+	})
+}
+
+// kickstart batch job (using Client directly to provide a `JobId`)
+func (s *SharedServerSuite) startBatchJob(jobId, namespace string) {
+	_, err := s.Client.WorkflowService().StartBatchOperation(
+		context.Background(),
+		&workflowservice.StartBatchOperationRequest{
+			JobId:           jobId,
+			Namespace:       namespace,
+			VisibilityQuery: "WorkflowType=\"BATCH-TEST\"",
+			Reason:          "REASON",
+			Operation: &workflowservice.StartBatchOperationRequest_TerminationOperation{
+				TerminationOperation: &batch.BatchOperationTermination{},
+			},
+		},
+	)
+	s.NoError(err)
+}

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -250,7 +250,10 @@ func StartDevServer(t *testing.T, options DevServerOptions) *DevServer {
 		d.Options.FrontendPort = devserver.MustGetFreePort()
 	}
 	if len(d.Options.Namespaces) == 0 {
-		d.Options.Namespaces = []string{"default"}
+		d.Options.Namespaces = []string{
+			"default",
+			"batch-empty", // for test `TestBatchJob_List
+		}
 	}
 	if d.Options.Logger == nil {
 		w := &concurrentWriter{w: &d.logOutput, wLock: &d.logOutputLock}
@@ -277,6 +280,7 @@ func StartDevServer(t *testing.T, options DevServerOptions) *DevServer {
 	}
 	d.Options.DynamicConfigValues["system.forceSearchAttributesCacheRefreshOnRead"] = true
 	d.Options.DynamicConfigValues["frontend.enableUpdateWorkflowExecution"] = true
+	d.Options.DynamicConfigValues["frontend.MaxConcurrentBatchOperationPerNamespace"] = 1000
 
 	d.Options.GRPCInterceptors = append(
 		d.Options.GRPCInterceptors,

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -94,6 +94,47 @@ Fail an Activity.
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 
 
+### temporal batch: Manage Batch Jobs
+
+Batch commands change multiple Workflow Executions.
+
+#### Options
+
+Includes options set for [client](#options-set-for-client).
+
+### temporal batch describe: Show Batch Job progress.
+
+The temporal batch describe command shows the progress of an ongoing Batch Job.
+
+`temporal batch describe --job-id=MyJobId`
+
+#### Options
+
+* `--job-id` (string) - The Batch Job Id to describe. Required.
+
+### temporal batch list: List all Batch Jobs
+
+The temporal batch list command returns all Batch Jobs.
+Batch Jobs can be returned for an entire Cluster or a single Namespace.
+
+`temporal batch list --namespace=MyNamespace`
+
+#### Options
+
+* `--limit` (int) - Limit the number of items to print.
+
+### temporal batch terminate: Terminate a Batch Job
+
+The temporal batch terminate command terminates a Batch Job with the provided Job Id.
+For future reference, provide a reason for terminating the Batch Job.
+
+`temporal batch terminate --job-id=MyJobId --reason=JobReason`
+
+#### Options
+
+* `--job-id` (string) - The Batch Job Id to terminate. Required.
+* `--reason` (string) - Reason for terminating the Batch Job. Required.
+
 ### temporal env: Manage environments.
 
 Use the '--env <env name>' option with other commands to point the CLI at a different Temporal Server instance. If --env


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

Add support for `batch` commands.

Notable differences to current `main`:

- captures "not found" errors from Server and presents a better message
- prints `batch describe` as card instead of table
- prints empty JSON array for empty result set from `batch list`