### PR TITLE
Adding namespace commands to cli

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -652,11 +652,11 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.Command.Flags().StringVar(&s.Description, "description", "", "Namespace description.")
 	s.Command.Flags().StringVar(&s.Email, "email", "", "Owner email.")
 	s.Command.Flags().BoolVar(&s.PromoteGlobal, "promote-global", false, "Promote local namespace to global namespace.")
-	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
+	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "")
 	s.Command.Flags().Var(&s.HistoryArchivalState, "history-archival-state", "History archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.HistoryUri, "history-uri", "", "Optionally specify history archival URI (cannot be changed after first time archival is enabled).")
 	s.Command.Flags().DurationVar(&s.Retention, "retention", 0, "Length of time a closed Workflow is preserved before deletion.")
-	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
+	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
 	s.Command.Run = func(c *cobra.Command, args []string) {

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -550,6 +550,7 @@ func NewTemporalOperatorNamespaceCreateCommand(cctx *CommandContext, parent *Tem
 type TemporalOperatorNamespaceDeleteCommand struct {
 	Parent  *TemporalOperatorNamespaceCommand
 	Command cobra.Command
+	Yes     bool
 }
 
 func NewTemporalOperatorNamespaceDeleteCommand(cctx *CommandContext, parent *TemporalOperatorNamespaceCommand) *TemporalOperatorNamespaceDeleteCommand {
@@ -560,6 +561,7 @@ func NewTemporalOperatorNamespaceDeleteCommand(cctx *CommandContext, parent *Tem
 	s.Command.Short = "Deletes an existing Namespace."
 	s.Command.Long = "The temporal operator namespace delete command deletes a given Namespace from the system."
 	s.Command.Args = cobra.ExactArgs(1)
+	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Confirm prompt to perform deletion.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -621,7 +623,7 @@ type TemporalOperatorNamespaceUpdateCommand struct {
 	Command                 cobra.Command
 	ActiveCluster           string
 	Cluster                 []string
-	Data                    string
+	Data                    []string
 	Description             string
 	Email                   string
 	PromoteGlobal           bool
@@ -630,6 +632,7 @@ type TemporalOperatorNamespaceUpdateCommand struct {
 	Retention               string
 	VisibilityArchivalState StringEnum
 	VisibilityUri           string
+	Verbose                 bool
 }
 
 func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *TemporalOperatorNamespaceCommand) *TemporalOperatorNamespaceUpdateCommand {
@@ -638,11 +641,15 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "update [flags] [namespace]"
 	s.Command.Short = "Updates a Namespace."
-	s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\ntemporal operator namespace update --active-cluster=NewActiveCluster.\n\nNamespaces can also be promoted to global Namespaces.\ntemporal operator namespace --promote-global=true.\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\ntemporal operator namespace update --history-archival-state=\"enabled\" --visibility-archival-state=\"disabled\"."
+	if hasHighlighting {
+		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n\x1b[1mtemporal operator namespace update --active-cluster=NewActiveCluster\x1b[0m\n\nNamespaces can also be promoted to global Namespaces.\n\x1b[1mtemporal operator namespace --promote-global\x1b[0m\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n\x1b[1mtemporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled\x1b[0m"
+	} else {
+		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n`temporal operator namespace update --active-cluster=NewActiveCluster`\n\nNamespaces can also be promoted to global Namespaces.\n`temporal operator namespace --promote-global`\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n`temporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled`"
+	}
 	s.Command.Args = cobra.ExactArgs(1)
 	s.Command.Flags().StringVar(&s.ActiveCluster, "active-cluster", "", "Active cluster name.")
 	s.Command.Flags().StringArrayVar(&s.Cluster, "cluster", nil, "Cluster names.")
-	s.Command.Flags().StringVar(&s.Data, "data", "", "Namespace data in key=value format. Use JSON for values.")
+	s.Command.Flags().StringArrayVar(&s.Data, "data", nil, "Namespace data in key=value format. Use JSON for values.")
 	s.Command.Flags().StringVar(&s.Description, "description", "", "Namespace description.")
 	s.Command.Flags().StringVar(&s.Email, "email", "", "Owner email.")
 	s.Command.Flags().BoolVar(&s.PromoteGlobal, "promote-global", false, "Promote local namespace to global namespace.")
@@ -653,6 +660,7 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
+	s.Command.Flags().BoolVarP(&s.Verbose, "verbose", "v", false, "Print applied namespace changes.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -509,7 +509,7 @@ type TemporalOperatorNamespaceCreateCommand struct {
 	Global                  bool
 	HistoryArchivalState    StringEnum
 	HistoryUri              string
-	Retention               string
+	Retention               time.Duration
 	VisibilityArchivalState StringEnum
 	VisibilityUri           string
 }
@@ -535,7 +535,7 @@ func NewTemporalOperatorNamespaceCreateCommand(cctx *CommandContext, parent *Tem
 	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.HistoryArchivalState, "history-archival-state", "History archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.HistoryUri, "history-uri", "", "Optionally specify history archival URI (cannot be changed after first time archival is enabled).")
-	s.Command.Flags().StringVar(&s.Retention, "retention", "3", "Length of time (in days) a closed Workflow is preserved before deletion.")
+	s.Command.Flags().DurationVar(&s.Retention, "retention", 259200000*time.Millisecond, "Length of time a closed Workflow is preserved before deletion.")
 	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
@@ -629,10 +629,9 @@ type TemporalOperatorNamespaceUpdateCommand struct {
 	PromoteGlobal           bool
 	HistoryArchivalState    StringEnum
 	HistoryUri              string
-	Retention               string
+	Retention               time.Duration
 	VisibilityArchivalState StringEnum
 	VisibilityUri           string
-	Verbose                 bool
 }
 
 func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *TemporalOperatorNamespaceCommand) *TemporalOperatorNamespaceUpdateCommand {
@@ -642,9 +641,9 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.Command.Use = "update [flags] [namespace]"
 	s.Command.Short = "Updates a Namespace."
 	if hasHighlighting {
-		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n\x1b[1mtemporal operator namespace update --active-cluster=NewActiveCluster\x1b[0m\n\nNamespaces can also be promoted to global Namespaces.\n\x1b[1mtemporal operator namespace --promote-global\x1b[0m\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n\x1b[1mtemporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled\x1b[0m"
+		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n\x1b[1mtemporal operator namespace update --active-cluster=NewActiveCluster\x1b[0m\n\nNamespaces can also be promoted to global Namespaces.\n\x1b[1mtemporal operator namespace update --promote-global\x1b[0m\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n\x1b[1mtemporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled\x1b[0m"
 	} else {
-		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n`temporal operator namespace update --active-cluster=NewActiveCluster`\n\nNamespaces can also be promoted to global Namespaces.\n`temporal operator namespace --promote-global`\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n`temporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled`"
+		s.Command.Long = "The temporal operator namespace update command updates a Namespace.\n\nNamespaces can be assigned a different active Cluster.\n`temporal operator namespace update --active-cluster=NewActiveCluster`\n\nNamespaces can also be promoted to global Namespaces.\n`temporal operator namespace update --promote-global`\n\nAny Archives that were previously enabled or disabled can be changed through this command.\nHowever, URI values for archival states cannot be changed after the states are enabled.\n`temporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled`"
 	}
 	s.Command.Args = cobra.ExactArgs(1)
 	s.Command.Flags().StringVar(&s.ActiveCluster, "active-cluster", "", "Active cluster name.")
@@ -656,11 +655,10 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.HistoryArchivalState, "history-archival-state", "History archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.HistoryUri, "history-uri", "", "Optionally specify history archival URI (cannot be changed after first time archival is enabled).")
-	s.Command.Flags().StringVar(&s.Retention, "retention", "3", "Length of time (in days) a closed Workflow is preserved before deletion.")
+	s.Command.Flags().DurationVar(&s.Retention, "retention", 0, "Length of time a closed Workflow is preserved before deletion.")
 	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
-	s.Command.Flags().BoolVarP(&s.Verbose, "verbose", "v", false, "Print applied namespace changes.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -283,7 +283,7 @@ func (c *CommandContext) promptString(message string, expected string, autoConfi
 	}
 	c.Printer.Print(message, " ")
 	if autoConfirm {
-		c.Printer.Println("yes")
+		c.Printer.Println(expected)
 		return true, nil
 	}
 	line, _ := bufio.NewReader(c.Options.Stdin).ReadString('\n')

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -287,7 +287,7 @@ func (c *CommandContext) promptString(message string, expected string, autoConfi
 		return true, nil
 	}
 	line, _ := bufio.NewReader(c.Options.Stdin).ReadString('\n')
-	line = strings.TrimSpace(strings.ToLower(line))
+	line = strings.TrimSpace(line)
 	return line == expected, nil
 }
 

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -276,6 +276,21 @@ func (c *CommandContext) promptYes(message string, autoConfirm bool) (bool, erro
 	return line == "y" || line == "yes", nil
 }
 
+// Returns error if JSON output enabled
+func (c *CommandContext) promptString(message string, expected string, autoConfirm bool) (bool, error) {
+	if c.JSONOutput && !autoConfirm {
+		return false, fmt.Errorf("must bypass prompts when using JSON output")
+	}
+	c.Printer.Print(message, " ")
+	if autoConfirm {
+		c.Printer.Println("yes")
+		return true, nil
+	}
+	line, _ := bufio.NewReader(c.Options.Stdin).ReadString('\n')
+	line = strings.TrimSpace(strings.ToLower(line))
+	return line == expected, nil
+}
+
 // Execute runs the Temporal CLI with the given context and options. This
 // intentionally does not return an error but rather invokes Fail on the
 // options.

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -147,7 +147,6 @@ func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []
 
 		for _, ns := range resp.GetNamespaces() {
 			if cctx.JSONOutput {
-				// For JSON we are going to dump one line of JSON per execution
 				_ = cctx.Printer.PrintStructured(ns, printer.StructuredOptions{})
 			}
 		}

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -67,7 +67,7 @@ func (c *TemporalOperatorNamespaceDeleteCommand) run(cctx *CommandContext, args 
 	yes, err := cctx.promptString(
 		color.RedString("Are you sure you want to delete namespace %s? Type namespace name to confirm:", namespaceName),
 		namespaceName,
-		false)
+		c.Yes)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args 
 		}
 		data := map[string]string{}
 		if len(c.Data) > 0 {
-			data, err = stringKeysValues(strings.Split(c.Data, ","))
+			data, err = stringKeysValues(c.Data)
 			if err != nil {
 				return err
 			}
@@ -237,6 +237,10 @@ func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args 
 			Config:            updateConfig,
 			ReplicationConfig: replicationConfig,
 		}
+	}
+
+	if c.Verbose {
+		_ = cctx.Printer.PrintStructured(updateRequest, printer.StructuredOptions{})
 	}
 
 	_, err = cl.WorkflowService().UpdateNamespace(cctx, updateRequest)

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -122,7 +122,7 @@ func (c *TemporalOperatorNamespaceDescribeCommand) run(cctx *CommandContext, arg
 	if cctx.JSONOutput {
 		return cctx.Printer.PrintStructured(resp, printer.StructuredOptions{})
 	}
-	return printNamespaceDescriptions(cctx, resp)
+	return printNamespaceDescription(cctx, resp)
 }
 
 func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []string) error {
@@ -130,6 +130,10 @@ func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []
 	if err != nil {
 		return err
 	}
+
+	// This is a listing command subject to json vs jsonl rules
+	cctx.Printer.StartList()
+	defer cctx.Printer.EndList()
 
 	var nextPageToken []byte
 	for {
@@ -141,11 +145,14 @@ func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []
 			return fmt.Errorf("failed listing namespaces: %w", err)
 		}
 
-		if cctx.JSONOutput {
-			// For JSON we are going to dump one line of JSON per execution
-			_ = cctx.Printer.PrintStructured(resp.Namespaces, printer.StructuredOptions{})
-		} else {
-			_ = printNamespaceDescriptions(cctx, resp.Namespaces...)
+		for _, ns := range resp.GetNamespaces() {
+			if cctx.JSONOutput {
+				// For JSON we are going to dump one line of JSON per execution
+				_ = cctx.Printer.PrintStructured(ns, printer.StructuredOptions{})
+			} else {
+				_ = printNamespaceDescription(cctx, ns)
+				cctx.Printer.Println()
+			}
 		}
 
 		nextPageToken = resp.GetNextPageToken()
@@ -262,31 +269,28 @@ func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args 
 	return nil
 }
 
-func printNamespaceDescriptions(cctx *CommandContext, responses ...*workflowservice.DescribeNamespaceResponse) error {
-	namespaces := make([]map[string]any, len(responses))
-	for i, resp := range responses {
-		namespaces[i] = map[string]any{
-			"NamespaceInfo.Name":                   resp.NamespaceInfo.Name,
-			"NamespaceInfo.Id":                     resp.NamespaceInfo.Id,
-			"NamespaceInfo.Description":            resp.NamespaceInfo.Description,
-			"NamespaceInfo.OwnerEmail":             resp.NamespaceInfo.OwnerEmail,
-			"NamespaceInfo.State":                  resp.NamespaceInfo.State,
-			"NamespaceInfo.Data":                   resp.NamespaceInfo.Data,
-			"Config.WorkflowExecutionRetentionTtl": resp.Config.WorkflowExecutionRetentionTtl.AsDuration(),
-			"ReplicationConfig.ActiveClusterName":  resp.ReplicationConfig.ActiveClusterName,
-			"ReplicationConfig.Clusters":           resp.ReplicationConfig.Clusters,
-			"Config.HistoryArchivalState":          resp.Config.HistoryArchivalState,
-			"Config.VisibilityArchivalState":       resp.Config.VisibilityArchivalState,
-			"IsGlobalNamespace":                    resp.IsGlobalNamespace,
-			"FailoverVersion":                      resp.FailoverVersion,
-			"FailoverHistory":                      resp.FailoverHistory,
-			"Config.HistoryArchivalUri":            resp.Config.HistoryArchivalUri,
-			"Config.VisibilityArchivalUri":         resp.Config.VisibilityArchivalUri,
-		}
+func printNamespaceDescription(cctx *CommandContext, resp *workflowservice.DescribeNamespaceResponse) error {
+	ns := map[string]any{
+		"NamespaceInfo.Name":                   resp.NamespaceInfo.Name,
+		"NamespaceInfo.Id":                     resp.NamespaceInfo.Id,
+		"NamespaceInfo.Description":            resp.NamespaceInfo.Description,
+		"NamespaceInfo.OwnerEmail":             resp.NamespaceInfo.OwnerEmail,
+		"NamespaceInfo.State":                  resp.NamespaceInfo.State,
+		"NamespaceInfo.Data":                   resp.NamespaceInfo.Data,
+		"Config.WorkflowExecutionRetentionTtl": resp.Config.WorkflowExecutionRetentionTtl.AsDuration(),
+		"ReplicationConfig.ActiveClusterName":  resp.ReplicationConfig.ActiveClusterName,
+		"ReplicationConfig.Clusters":           resp.ReplicationConfig.Clusters,
+		"Config.HistoryArchivalState":          resp.Config.HistoryArchivalState,
+		"Config.VisibilityArchivalState":       resp.Config.VisibilityArchivalState,
+		"IsGlobalNamespace":                    resp.IsGlobalNamespace,
+		"FailoverVersion":                      resp.FailoverVersion,
+		"FailoverHistory":                      resp.FailoverHistory,
+		"Config.HistoryArchivalUri":            resp.Config.HistoryArchivalUri,
+		"Config.VisibilityArchivalUri":         resp.Config.VisibilityArchivalUri,
 	}
 
 	return cctx.Printer.PrintStructured(
-		namespaces,
+		ns,
 		printer.StructuredOptions{
 			Fields: []string{
 				"NamespaceInfo.Name", "NamespaceInfo.Id", "NamespaceInfo.Description",

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -1,0 +1,316 @@
+package temporalcli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/temporalio/cli/temporalcli/internal/printer"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/replication/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func (c *TemporalOperatorNamespaceCreateCommand) run(cctx *CommandContext, args []string) error {
+	namespaceName := args[0]
+	cl, err := c.Parent.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	retention, err := timestamp.ParseDurationDefaultDays(c.Retention)
+
+	var clusters []*replication.ClusterReplicationConfig
+	for _, clusterName := range c.Cluster {
+		clusters = append(clusters, &replication.ClusterReplicationConfig{
+			ClusterName: clusterName,
+		})
+	}
+
+	data := map[string]string{}
+	if len(c.Data) > 0 {
+		data, err = stringKeysValues(strings.Split(c.Data, ","))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = cl.WorkflowService().RegisterNamespace(cctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        namespaceName,
+		Description:                      c.Description,
+		OwnerEmail:                       c.Email,
+		WorkflowExecutionRetentionPeriod: durationpb.New(retention),
+		Clusters:                         clusters,
+		ActiveClusterName:                c.ActiveCluster,
+		Data:                             data,
+		IsGlobalNamespace:                c.Global,
+		HistoryArchivalState:             archivalState(c.HistoryArchivalState.Value),
+		HistoryArchivalUri:               c.HistoryUri,
+		VisibilityArchivalState:          archivalState(c.VisibilityArchivalState.Value),
+		VisibilityArchivalUri:            c.VisibilityUri,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create namespace: %w", err)
+	}
+	cctx.Printer.Println(color.GreenString("Namespace %s successfully registered.", namespaceName))
+	return nil
+}
+
+func (c *TemporalOperatorNamespaceDeleteCommand) run(cctx *CommandContext, args []string) error {
+	namespaceName := args[0]
+	yes, err := cctx.promptString(
+		color.RedString("Are you sure you want to delete namespace %s? Type namespace name to confirm:", namespaceName),
+		namespaceName,
+		false)
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return fmt.Errorf("user denied confirmation")
+	}
+	cl, err := c.Parent.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+	resp, err := cl.OperatorService().DeleteNamespace(cctx, &operatorservice.DeleteNamespaceRequest{
+		Namespace: namespaceName,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to delete namespace: %w", err)
+	}
+	if cctx.JSONOutput {
+		return cctx.Printer.PrintStructured(resp, printer.StructuredOptions{})
+	}
+	cctx.Printer.Println(color.GreenString("Namespace %s has been deleted.", namespaceName))
+	return nil
+}
+
+func (c *TemporalOperatorNamespaceDescribeCommand) run(cctx *CommandContext, args []string) error {
+	namespaceName, namespaceID, err := getNamespaceFromIDArgs(cctx, c.NamespaceId, args)
+	if err != nil {
+		return err
+	}
+
+	cl, err := c.Parent.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+	resp, err := cl.WorkflowService().DescribeNamespace(cctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: namespaceName,
+		Id:        namespaceID,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to describe namespace: %w", err)
+	}
+	if cctx.JSONOutput {
+		return cctx.Printer.PrintStructured(resp, printer.StructuredOptions{})
+	}
+	return printNamespaces(cctx, resp)
+}
+
+func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := c.Parent.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+
+	var nextPageToken []byte
+	for {
+		resp, err := cl.WorkflowService().ListNamespaces(cctx, &workflowservice.ListNamespacesRequest{
+			NextPageToken: nextPageToken,
+			PageSize:      100,
+		})
+		if err != nil {
+			return fmt.Errorf("failed listing namespaces: %w", err)
+		}
+		if cctx.JSONOutput {
+			// For JSON we are going to dump one line of JSON per execution
+			_ = cctx.Printer.PrintStructured(resp.Namespaces, printer.StructuredOptions{})
+		} else {
+			_ = printNamespaces(cctx, resp.Namespaces...)
+		}
+		nextPageToken = resp.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			return nil
+		}
+	}
+}
+
+func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args []string) error {
+	ns := args[0]
+	cl, err := c.Parent.Parent.ClientOptions.dialClient(cctx)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	var updateRequest *workflowservice.UpdateNamespaceRequest
+
+	if c.PromoteGlobal {
+		fmt.Printf("Will promote local namespace to global namespace for:%s, other flag will be omitted. "+
+			"If it is already global namespace, this will be no-op.\n", ns)
+		updateRequest = &workflowservice.UpdateNamespaceRequest{
+			Namespace:        ns,
+			PromoteNamespace: true,
+		}
+	} else if len(c.ActiveCluster) > 0 {
+		fmt.Printf("Will set active cluster name to: %s, other flag will be omitted.\n", c.ActiveCluster)
+		replicationConfig := &replication.NamespaceReplicationConfig{
+			ActiveClusterName: c.ActiveCluster,
+		}
+		updateRequest = &workflowservice.UpdateNamespaceRequest{
+			Namespace:         ns,
+			ReplicationConfig: replicationConfig,
+		}
+	} else {
+		resp, err := cl.WorkflowService().DescribeNamespace(cctx, &workflowservice.DescribeNamespaceRequest{
+			Namespace: ns,
+		})
+		if err != nil {
+			switch err.(type) {
+			case *serviceerror.NamespaceNotFound:
+				return err
+			default:
+				return fmt.Errorf("namespace update failed: %w", err)
+			}
+		}
+
+		description := resp.NamespaceInfo.GetDescription()
+		ownerEmail := resp.NamespaceInfo.GetOwnerEmail()
+		retention := resp.Config.GetWorkflowExecutionRetentionTtl()
+
+		if len(c.Description) > 0 {
+			description = c.Description
+		}
+		if len(c.Email) > 0 {
+			ownerEmail = c.Email
+		}
+		data := map[string]string{}
+		if len(c.Data) > 0 {
+			data, err = stringKeysValues(strings.Split(c.Data, ","))
+			if err != nil {
+				return err
+			}
+		}
+		if len(c.Retention) > 0 {
+			ret, err := timestamp.ParseDurationDefaultDays(c.Retention)
+			if err != nil {
+				return fmt.Errorf("option retention format is invalid: %w", err)
+			}
+			retention = durationpb.New(ret)
+		}
+		var clusters []*replication.ClusterReplicationConfig
+		if len(c.Cluster) > 0 {
+			for _, clusterName := range c.Cluster {
+				clusters = append(clusters, &replication.ClusterReplicationConfig{
+					ClusterName: clusterName,
+				})
+			}
+		}
+		updateInfo := &namespace.UpdateNamespaceInfo{
+			Description: description,
+			OwnerEmail:  ownerEmail,
+			Data:        data,
+		}
+
+		updateConfig := &namespace.NamespaceConfig{
+			WorkflowExecutionRetentionTtl: retention,
+			HistoryArchivalState:          archivalState(c.HistoryArchivalState.String()),
+			HistoryArchivalUri:            c.HistoryUri,
+			VisibilityArchivalState:       archivalState(c.VisibilityArchivalState.String()),
+			VisibilityArchivalUri:         c.VisibilityUri,
+		}
+		replicationConfig := &replication.NamespaceReplicationConfig{
+			Clusters: clusters,
+		}
+		updateRequest = &workflowservice.UpdateNamespaceRequest{
+			Namespace:         ns,
+			UpdateInfo:        updateInfo,
+			Config:            updateConfig,
+			ReplicationConfig: replicationConfig,
+		}
+	}
+
+	_, err = cl.WorkflowService().UpdateNamespace(cctx, updateRequest)
+	if err != nil {
+		switch err.(type) {
+		case *serviceerror.NamespaceNotFound:
+			return err
+		default:
+			return fmt.Errorf("namespace update failed: %w", err)
+		}
+	} else {
+		cctx.Printer.Println(color.GreenString("namespace %s update succeeded.", ns))
+	}
+	return nil
+}
+
+func printNamespaces(cctx *CommandContext, responses ...*workflowservice.DescribeNamespaceResponse) error {
+	namespaces := make([]map[string]any, len(responses))
+	for i, resp := range responses {
+		namespaces[i] = map[string]any{
+			"NamespaceInfo.Name":                   resp.NamespaceInfo.Name,
+			"NamespaceInfo.Id":                     resp.NamespaceInfo.Id,
+			"NamespaceInfo.Description":            resp.NamespaceInfo.Description,
+			"NamespaceInfo.OwnerEmail":             resp.NamespaceInfo.OwnerEmail,
+			"NamespaceInfo.State":                  resp.NamespaceInfo.State,
+			"NamespaceInfo.Data":                   resp.NamespaceInfo.Data,
+			"Config.WorkflowExecutionRetentionTtl": resp.Config.WorkflowExecutionRetentionTtl.AsDuration(),
+			"ReplicationConfig.ActiveClusterName":  resp.ReplicationConfig.ActiveClusterName,
+			"ReplicationConfig.Clusters":           resp.ReplicationConfig.Clusters,
+			"Config.HistoryArchivalState":          resp.Config.HistoryArchivalState,
+			"Config.VisibilityArchivalState":       resp.Config.VisibilityArchivalState,
+			"IsGlobalNamespace":                    resp.IsGlobalNamespace,
+			"FailoverVersion":                      resp.FailoverVersion,
+			"FailoverHistory":                      resp.FailoverHistory,
+		}
+	}
+
+	return cctx.Printer.PrintStructured(
+		namespaces,
+		printer.StructuredOptions{
+			Fields: []string{
+				"NamespaceInfo.Name", "NamespaceInfo.Id", "NamespaceInfo.Description",
+				"NamespaceInfo.OwnerEmail", "NamespaceInfo.State", "NamespaceInfo.Data",
+				"Config.WorkflowExecutionRetentionTtl", "ReplicationConfig.ActiveClusterName",
+				"ReplicationConfig.Clusters", "Config.HistoryArchivalState", "Config.VisibilityArchivalState",
+				"IsGlobalNamespace", "FailoverVersion", "FailoverHistory",
+			},
+		},
+	)
+}
+
+func archivalState(input string) enums.ArchivalState {
+	switch input {
+	case "disabled":
+		return enums.ARCHIVAL_STATE_DISABLED
+	case "enabled":
+		return enums.ARCHIVAL_STATE_ENABLED
+	}
+	return enums.ARCHIVAL_STATE_UNSPECIFIED
+}
+
+func getNamespaceFromIDArgs(cctx *CommandContext, nsID string, args []string) (string, string, error) {
+	if nsID == "" && len(args) == 0 {
+		return "", "", fmt.Errorf("provide either namespace-id flag or namespace as an argument")
+	}
+
+	if nsID != "" && len(args) > 0 {
+		cctx.Printer.Println(color.YellowString("Both namespace-id flag and namespace are provided. Will use namespace Id to describe namespace"))
+		return "", nsID, nil
+	}
+
+	if nsID != "" {
+		return "", nsID, nil
+	}
+
+	return args[0], "", nil
+}

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -122,7 +122,7 @@ func (c *TemporalOperatorNamespaceDescribeCommand) run(cctx *CommandContext, arg
 	if cctx.JSONOutput {
 		return cctx.Printer.PrintStructured(resp, printer.StructuredOptions{})
 	}
-	return printNamespaceDescription(cctx, resp)
+	return printNamespaceDescriptions(cctx, resp)
 }
 
 func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []string) error {
@@ -149,10 +149,11 @@ func (c *TemporalOperatorNamespaceListCommand) run(cctx *CommandContext, args []
 			if cctx.JSONOutput {
 				// For JSON we are going to dump one line of JSON per execution
 				_ = cctx.Printer.PrintStructured(ns, printer.StructuredOptions{})
-			} else {
-				_ = printNamespaceDescription(cctx, ns)
-				cctx.Printer.Println()
 			}
+		}
+
+		if !cctx.JSONOutput {
+			_ = printNamespaceDescriptions(cctx, resp.Namespaces...)
 		}
 
 		nextPageToken = resp.GetNextPageToken()
@@ -269,28 +270,31 @@ func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args 
 	return nil
 }
 
-func printNamespaceDescription(cctx *CommandContext, resp *workflowservice.DescribeNamespaceResponse) error {
-	ns := map[string]any{
-		"NamespaceInfo.Name":                   resp.NamespaceInfo.Name,
-		"NamespaceInfo.Id":                     resp.NamespaceInfo.Id,
-		"NamespaceInfo.Description":            resp.NamespaceInfo.Description,
-		"NamespaceInfo.OwnerEmail":             resp.NamespaceInfo.OwnerEmail,
-		"NamespaceInfo.State":                  resp.NamespaceInfo.State,
-		"NamespaceInfo.Data":                   resp.NamespaceInfo.Data,
-		"Config.WorkflowExecutionRetentionTtl": resp.Config.WorkflowExecutionRetentionTtl.AsDuration(),
-		"ReplicationConfig.ActiveClusterName":  resp.ReplicationConfig.ActiveClusterName,
-		"ReplicationConfig.Clusters":           resp.ReplicationConfig.Clusters,
-		"Config.HistoryArchivalState":          resp.Config.HistoryArchivalState,
-		"Config.VisibilityArchivalState":       resp.Config.VisibilityArchivalState,
-		"IsGlobalNamespace":                    resp.IsGlobalNamespace,
-		"FailoverVersion":                      resp.FailoverVersion,
-		"FailoverHistory":                      resp.FailoverHistory,
-		"Config.HistoryArchivalUri":            resp.Config.HistoryArchivalUri,
-		"Config.VisibilityArchivalUri":         resp.Config.VisibilityArchivalUri,
+func printNamespaceDescriptions(cctx *CommandContext, responses ...*workflowservice.DescribeNamespaceResponse) error {
+	namespaces := make([]map[string]any, len(responses))
+	for i, resp := range responses {
+		namespaces[i] = map[string]any{
+			"NamespaceInfo.Name":                   resp.NamespaceInfo.Name,
+			"NamespaceInfo.Id":                     resp.NamespaceInfo.Id,
+			"NamespaceInfo.Description":            resp.NamespaceInfo.Description,
+			"NamespaceInfo.OwnerEmail":             resp.NamespaceInfo.OwnerEmail,
+			"NamespaceInfo.State":                  resp.NamespaceInfo.State,
+			"NamespaceInfo.Data":                   resp.NamespaceInfo.Data,
+			"Config.WorkflowExecutionRetentionTtl": resp.Config.WorkflowExecutionRetentionTtl.AsDuration(),
+			"ReplicationConfig.ActiveClusterName":  resp.ReplicationConfig.ActiveClusterName,
+			"ReplicationConfig.Clusters":           resp.ReplicationConfig.Clusters,
+			"Config.HistoryArchivalState":          resp.Config.HistoryArchivalState,
+			"Config.VisibilityArchivalState":       resp.Config.VisibilityArchivalState,
+			"IsGlobalNamespace":                    resp.IsGlobalNamespace,
+			"FailoverVersion":                      resp.FailoverVersion,
+			"FailoverHistory":                      resp.FailoverHistory,
+			"Config.HistoryArchivalUri":            resp.Config.HistoryArchivalUri,
+			"Config.VisibilityArchivalUri":         resp.Config.VisibilityArchivalUri,
+		}
 	}
 
 	return cctx.Printer.PrintStructured(
-		ns,
+		namespaces,
 		printer.StructuredOptions{
 			Fields: []string{
 				"NamespaceInfo.Name", "NamespaceInfo.Id", "NamespaceInfo.Description",

--- a/temporalcli/commands.operator_namespace_test.go
+++ b/temporalcli/commands.operator_namespace_test.go
@@ -9,20 +9,12 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 )
 
-func (s *SharedServerSuite) TestOperator_Namespace_Create_WithoutName() {
-	res := s.Execute(
-		"operator", "namespace", "create",
-	)
-	s.Error(res.Err)
-	s.Contains(res.Err.Error(), "required flag(s) \"name\" not set")
-}
-
 func (s *SharedServerSuite) TestOperator_Namespace_Create_List_And_Describe() {
-	namespaceName := "test_namespace"
+	nsName := "test_namespace"
 	res := s.Execute(
 		"operator", "namespace", "create",
 		"--address", s.Address(),
-		"--name", namespaceName,
+		nsName,
 	)
 	s.NoError(res.Err)
 
@@ -36,7 +28,7 @@ func (s *SharedServerSuite) TestOperator_Namespace_Create_List_And_Describe() {
 	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &listResp))
 	var uuid string
 	for _, ns := range listResp {
-		if ns.NamespaceInfo.Name == namespaceName {
+		if ns.NamespaceInfo.Name == nsName {
 			uuid = ns.NamespaceInfo.Id
 		}
 	}
@@ -45,13 +37,13 @@ func (s *SharedServerSuite) TestOperator_Namespace_Create_List_And_Describe() {
 	res = s.Execute(
 		"operator", "namespace", "describe",
 		"--address", s.Address(),
-		"--namespace-id", uuid,
 		"--output", "json",
+		nsName,
 	)
 	s.NoError(res.Err)
 	var describeResp workflowservice.DescribeNamespaceResponse
 	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp, true))
-	s.Equal(namespaceName, describeResp.NamespaceInfo.Name)
+	s.Equal(nsName, describeResp.NamespaceInfo.Name)
 
 	// Validate default values
 	s.Equal("active", describeResp.ReplicationConfig.ActiveClusterName)
@@ -65,4 +57,148 @@ func (s *SharedServerSuite) TestOperator_Namespace_Create_List_And_Describe() {
 	s.Equal(describeResp.Config.WorkflowExecutionRetentionTtl.AsDuration(), 72*time.Hour)
 	s.Equal(enums.ARCHIVAL_STATE_DISABLED, describeResp.Config.VisibilityArchivalState)
 	s.Len(describeResp.Config.VisibilityArchivalUri, 0)
+}
+
+func (s *SharedServerSuite) TestNamespaceUpdate_Verbose() {
+	nsName := "test-namespace-update-verbose"
+
+	res := s.Execute(
+		"operator", "namespace", "create",
+		"--address", s.Address(),
+		"--description", "description before",
+		"--email", "email@before",
+		"--retention", "1",
+		nsName,
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"operator", "namespace", "update",
+		"--address", s.Address(),
+		"--description", "description after",
+		"--email", "email@after",
+		"--retention", "2",
+		"--output", "json",
+		"--verbose",
+		nsName,
+	)
+	s.NoError(res.Err)
+	s.ContainsOnSameLine(res.Stdout.String(), "workflowExecutionRetentionTtl", "172800s")
+	s.ContainsOnSameLine(res.Stdout.String(), "description", "description after")
+	s.ContainsOnSameLine(res.Stdout.String(), "ownerEmail", "email@after")
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		nsName,
+	)
+	s.NoError(res.Err)
+	var describeResp workflowservice.DescribeNamespaceResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp, true))
+
+	s.Equal("description after", describeResp.NamespaceInfo.Description)
+	s.Equal("email@after", describeResp.NamespaceInfo.OwnerEmail)
+	s.Equal(48*time.Hour, describeResp.Config.WorkflowExecutionRetentionTtl.AsDuration())
+}
+
+func (s *SharedServerSuite) TestNamespaceUpdate_Data() {
+	nsName := "default"
+	res := s.Execute(
+		"operator", "namespace", "update",
+		"--address", s.Address(),
+		"--data", "k1=v1",
+		"--data", "k2=v2",
+		nsName,
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		nsName,
+	)
+	s.NoError(res.Err)
+	var describeResp workflowservice.DescribeNamespaceResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp, true))
+
+	s.Equal("v1", describeResp.NamespaceInfo.Data["k1"])
+	s.Equal("v2", describeResp.NamespaceInfo.Data["k2"])
+}
+
+func (s *SharedServerSuite) TestNamespaceUpdate_NamespaceDontExist() {
+	nsName := "missing-namespace"
+	res := s.Execute(
+		"operator", "namespace", "update",
+		"--email", "email@after",
+		"--address", s.Address(),
+		nsName,
+	)
+	s.Error(res.Err)
+	s.Contains(res.Err.Error(), "Namespace missing-namespace is not found")
+}
+
+func (s *SharedServerSuite) TestDeleteNamespace() {
+	nsName := "test-namespace"
+	res := s.Execute(
+		"operator", "namespace", "create",
+		"--address", s.Address(),
+		nsName,
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		nsName,
+	)
+	s.NoError(res.Err)
+	var describeResp workflowservice.DescribeNamespaceResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp, true))
+	s.Equal(nsName, describeResp.NamespaceInfo.Name)
+
+	res = s.Execute(
+		"operator", "namespace", "delete",
+		"--address", s.Address(),
+		"--yes",
+		nsName,
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		nsName,
+	)
+	s.Error(res.Err)
+	s.Contains(res.Err.Error(), "Namespace test-namespace is not found")
+}
+
+func (s *SharedServerSuite) TestDescribeWithID() {
+	res := s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		"default",
+	)
+	s.NoError(res.Err)
+
+	var describeResp1 workflowservice.DescribeNamespaceResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp1, true))
+	nsID := describeResp1.NamespaceInfo.Id
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--output", "json",
+		"--namespace-id", nsID,
+	)
+	s.NoError(res.Err)
+	var describeResp2 workflowservice.DescribeNamespaceResponse
+
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp2, true))
+	s.Equal(describeResp1.NamespaceInfo, describeResp2.NamespaceInfo)
 }

--- a/temporalcli/commands.operator_namespace_test.go
+++ b/temporalcli/commands.operator_namespace_test.go
@@ -1,0 +1,68 @@
+package temporalcli_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/temporalio/cli/temporalcli"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func (s *SharedServerSuite) TestOperator_Namespace_Create_WithoutName() {
+	res := s.Execute(
+		"operator", "namespace", "create",
+	)
+	s.Error(res.Err)
+	s.Contains(res.Err.Error(), "required flag(s) \"name\" not set")
+}
+
+func (s *SharedServerSuite) TestOperator_Namespace_Create_List_And_Describe() {
+	namespaceName := "test_namespace"
+	res := s.Execute(
+		"operator", "namespace", "create",
+		"--address", s.Address(),
+		"--name", namespaceName,
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"operator", "namespace", "list",
+		"--address", s.Address(),
+		"--output", "json",
+	)
+	s.NoError(res.Err)
+	var listResp []workflowservice.DescribeNamespaceResponse
+	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &listResp))
+	var uuid string
+	for _, ns := range listResp {
+		if ns.NamespaceInfo.Name == namespaceName {
+			uuid = ns.NamespaceInfo.Id
+		}
+	}
+	s.NotEmpty(uuid)
+
+	res = s.Execute(
+		"operator", "namespace", "describe",
+		"--address", s.Address(),
+		"--namespace-id", uuid,
+		"--output", "json",
+	)
+	s.NoError(res.Err)
+	var describeResp workflowservice.DescribeNamespaceResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &describeResp, true))
+	s.Equal(namespaceName, describeResp.NamespaceInfo.Name)
+
+	// Validate default values
+	s.Equal("active", describeResp.ReplicationConfig.ActiveClusterName)
+	s.Equal("active", describeResp.ReplicationConfig.Clusters[0].ClusterName)
+	s.Len(describeResp.NamespaceInfo.Data, 0)
+	s.Len(describeResp.NamespaceInfo.Description, 0)
+	s.Len(describeResp.NamespaceInfo.OwnerEmail, 0)
+	s.Equal(false, describeResp.IsGlobalNamespace)
+	s.Equal(enums.ARCHIVAL_STATE_DISABLED, describeResp.Config.HistoryArchivalState)
+	s.Len(describeResp.Config.HistoryArchivalUri, 0)
+	s.Equal(describeResp.Config.WorkflowExecutionRetentionTtl.AsDuration(), 72*time.Hour)
+	s.Equal(enums.ARCHIVAL_STATE_DISABLED, describeResp.Config.VisibilityArchivalState)
+	s.Len(describeResp.Config.VisibilityArchivalUri, 0)
+}

--- a/temporalcli/commands.operator_namespace_test.go
+++ b/temporalcli/commands.operator_namespace_test.go
@@ -1,7 +1,7 @@
 package temporalcli_test
 
 import (
-	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/temporalio/cli/temporalcli"
@@ -24,10 +24,11 @@ func (s *SharedServerSuite) TestOperator_NamespaceCreateListAndDescribe() {
 		"--output", "json",
 	)
 	s.NoError(res.Err)
-	var listResp []workflowservice.DescribeNamespaceResponse
-	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &listResp))
+	output := fmt.Sprintf("{\"namespaces\": %s}", res.Stdout.String())
+	var listResp workflowservice.ListNamespacesResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions([]byte(output), &listResp, true))
 	var uuid string
-	for _, ns := range listResp {
+	for _, ns := range listResp.Namespaces {
 		if ns.NamespaceInfo.Name == nsName {
 			uuid = ns.NamespaceInfo.Id
 		}

--- a/temporalcli/commandsmd/code.go
+++ b/temporalcli/commandsmd/code.go
@@ -186,7 +186,9 @@ func (c *Command) writeCode(w *codeWriter) error {
 	} else {
 		w.writeLinef("s.Command.Long = %q", c.LongPlain)
 	}
-	if c.ExactArgs > 0 {
+	if c.MaximumArgs > 0 {
+		w.writeLinef("s.Command.Args = %v.MaximumNArgs(%v)", w.importCobra(), c.MaximumArgs)
+	} else if c.ExactArgs > 0 {
 		w.writeLinef("s.Command.Args = %v.ExactArgs(%v)", w.importCobra(), c.ExactArgs)
 	} else {
 		w.writeLinef("s.Command.Args = %v.NoArgs", w.importCobra())

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -15,6 +15,7 @@ This document has a specific structure used by a parser. Here are the rules:
     * End of long description can have XML comment section that has `*` bulleted attributes (one line per bullet):
       * `* has-init` - Will assume an `initCommand` method is on the command
       * `* exact-args=<number>` - Require this exact number of args
+      * `* maximum-args=<number>` - Require this maximum number of args
   * Can have `#### Options` or `#### Options set for <options-set-name>` which can have options.
     * Can have bullets
       * Each bullet is `* <option-names> (<data-type>) - <short-description>. <extra-attributes>`.
@@ -208,6 +209,101 @@ Cluster commands follow this syntax: `temporal operator cluster [command] [comma
 
 * `--frontend-address` (string) - IP address to bind the frontend service to. Required.
 * `--enable-connection` (bool) - enable cross cluster connection.
+
+### temporal operator namespace: Operations performed on Namespaces.
+
+Namespace commands perform operations on Namespaces contained in the Temporal Cluster.
+
+Cluster commands follow this syntax: `temporal operator namespace [command] [command options]`
+
+### temporal operator namespace create [namespace]: Registers a new Namespace.
+
+The temporal operator namespace create command creates a new Namespace on the Server.
+Namespaces can be created on the active Cluster, or any named Cluster.
+`temporal operator namespace create --cluster=MyCluster example-1`
+
+Global Namespaces can also be created.
+`temporal operator namespace create --global example-2`
+
+Other settings, such as retention and Visibility Archival State, can be configured as needed.
+For example, the Visibility Archive can be set on a separate URI.
+`temporal operator namespace create --retention=5 --visibility-archival-state=enabled --visibility-uri=some-uri example-3`
+
+<!--
+* exact-args=1
+-->
+
+#### Options
+* `--active-cluster` (string) - Active cluster name.
+* `--cluster` (string[]) - Cluster names.
+* `--data` (string) - Namespace data in key=value format. Use JSON for values.
+* `--description` (string) - Namespace description.
+* `--email` (string) - Owner email.
+* `--global` (bool) - Whether the namespace is a global namespace.
+* `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled. Default: disabled.
+* `--history-uri` (string) - Optionally specify history archival URI (cannot be changed after first time archival is enabled).
+* `--retention` (string) - Length of time (in days) a closed Workflow is preserved before deletion. Default: 3.
+* `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
+* `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
+
+### temporal operator namespace delete [namespace]: Deletes an existing Namespace.
+
+The temporal operator namespace delete command deletes a given Namespace from the system.
+
+<!--
+* exact-args=1
+-->
+ 
+### temporal operator namespace describe [namespace]: Describe a Namespace by its name or ID.
+
+The temporal operator namespace describe command provides Namespace information.
+Namespaces are identified by Namespace ID.
+
+`temporal operator namespace describe --namespace-id=some-namespace-id`
+`temporal operator namespace describe example-namespace-name`
+
+<!--
+* maximum-args=1
+-->
+
+#### Options
+
+* `--namespace-id` (string) -  Namespace ID.
+
+### temporal operator namespace list:  List all Namespaces.
+
+The temporal operator namespace list command lists all Namespaces on the Server.
+
+### temporal operator namespace update [namespace]: Updates a Namespace.
+
+The temporal operator namespace update command updates a Namespace.
+
+Namespaces can be assigned a different active Cluster.
+`temporal operator namespace update --active-cluster=NewActiveCluster`
+
+Namespaces can also be promoted to global Namespaces.
+`temporal operator namespace --promote-global`
+
+Any Archives that were previously enabled or disabled can be changed through this command.
+However, URI values for archival states cannot be changed after the states are enabled.
+`temporal operator namespace update --history-archival-state=enabled --visibility-archival-state=disabled`
+
+<!--
+* exact-args=1
+-->
+
+#### Options
+* `--active-cluster` (string) - Active cluster name.
+* `--cluster` (string[]) - Cluster names.
+* `--data` (string) - Namespace data in key=value format. Use JSON for values.
+* `--description` (string) - Namespace description.
+* `--email` (string) - Owner email.
+* `--promote-global` (bool) - Promote local namespace to global namespace.
+* `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled. Default: disabled.
+* `--history-uri` (string) - Optionally specify history archival URI (cannot be changed after first time archival is enabled).
+* `--retention` (string) - Length of time (in days) a closed Workflow is preserved before deletion. Default: 3.
+* `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
+* `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
 
 ### temporal operator search-attribute: Operations applying to Search Attributes
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -243,7 +243,7 @@ For example, the Visibility Archive can be set on a separate URI.
 * `--global` (bool) - Whether the namespace is a global namespace.
 * `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled. Default: disabled.
 * `--history-uri` (string) - Optionally specify history archival URI (cannot be changed after first time archival is enabled).
-* `--retention` (string) - Length of time (in days) a closed Workflow is preserved before deletion. Default: 3.
+* `--retention` (duration) - Length of time a closed Workflow is preserved before deletion. Default: 72h.
 * `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
 * `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
 
@@ -287,7 +287,7 @@ Namespaces can be assigned a different active Cluster.
 `temporal operator namespace update --active-cluster=NewActiveCluster`
 
 Namespaces can also be promoted to global Namespaces.
-`temporal operator namespace --promote-global`
+`temporal operator namespace update --promote-global`
 
 Any Archives that were previously enabled or disabled can be changed through this command.
 However, URI values for archival states cannot be changed after the states are enabled.
@@ -306,10 +306,9 @@ However, URI values for archival states cannot be changed after the states are e
 * `--promote-global` (bool) - Promote local namespace to global namespace.
 * `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled. Default: disabled.
 * `--history-uri` (string) - Optionally specify history archival URI (cannot be changed after first time archival is enabled).
-* `--retention` (string) - Length of time (in days) a closed Workflow is preserved before deletion. Default: 3.
+* `--retention` (duration) - Length of time a closed Workflow is preserved before deletion.
 * `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
 * `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
-* `--verbose`, `-v` (bool) - Print applied namespace changes.
 
 ### temporal operator search-attribute: Operations applying to Search Attributes
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -234,6 +234,7 @@ For example, the Visibility Archive can be set on a separate URI.
 -->
 
 #### Options
+
 * `--active-cluster` (string) - Active cluster name.
 * `--cluster` (string[]) - Cluster names.
 * `--data` (string) - Namespace data in key=value format. Use JSON for values.
@@ -253,7 +254,11 @@ The temporal operator namespace delete command deletes a given Namespace from th
 <!--
 * exact-args=1
 -->
- 
+
+#### Options
+
+* `--yes`, `-y` (bool) - Confirm prompt to perform deletion.
+
 ### temporal operator namespace describe [namespace]: Describe a Namespace by its name or ID.
 
 The temporal operator namespace describe command provides Namespace information.
@@ -295,7 +300,7 @@ However, URI values for archival states cannot be changed after the states are e
 #### Options
 * `--active-cluster` (string) - Active cluster name.
 * `--cluster` (string[]) - Cluster names.
-* `--data` (string) - Namespace data in key=value format. Use JSON for values.
+* `--data` (string[]) - Namespace data in key=value format. Use JSON for values.
 * `--description` (string) - Namespace description.
 * `--email` (string) - Owner email.
 * `--promote-global` (bool) - Promote local namespace to global namespace.
@@ -304,6 +309,7 @@ However, URI values for archival states cannot be changed after the states are e
 * `--retention` (string) - Length of time (in days) a closed Workflow is preserved before deletion. Default: 3.
 * `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
 * `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
+* `--verbose`, `-v` (bool) - Print applied namespace changes.
 
 ### temporal operator search-attribute: Operations applying to Search Attributes
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -304,10 +304,10 @@ However, URI values for archival states cannot be changed after the states are e
 * `--description` (string) - Namespace description.
 * `--email` (string) - Owner email.
 * `--promote-global` (bool) - Promote local namespace to global namespace.
-* `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled. Default: disabled.
+* `--history-archival-state` (string-enum) - History archival state. Options: disabled, enabled.
 * `--history-uri` (string) - Optionally specify history archival URI (cannot be changed after first time archival is enabled).
 * `--retention` (duration) - Length of time a closed Workflow is preserved before deletion.
-* `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled. Default: disabled.
+* `--visibility-archival-state` (string-enum) - Visibility archival state. Options: disabled, enabled.
 * `--visibility-uri` (string) - Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).
 
 ### temporal operator search-attribute: Operations applying to Search Attributes

--- a/temporalcli/commandsmd/parse.go
+++ b/temporalcli/commandsmd/parse.go
@@ -25,6 +25,7 @@ type Command struct {
 	OptionsSets     []CommandOptions
 	HasInit         bool
 	ExactArgs       int
+	MaximumArgs     int
 }
 
 type CommandOptions struct {
@@ -111,9 +112,17 @@ func (c *Command) parseSection(section string) error {
 				if c.ExactArgs, err = strconv.Atoi(strings.TrimPrefix(bullet, "* exact-args=")); err != nil {
 					return fmt.Errorf("invalid exact-args: %w", err)
 				}
+			case strings.HasPrefix(bullet, "* maximum-args="):
+				var err error
+				if c.MaximumArgs, err = strconv.Atoi(strings.TrimPrefix(bullet, "* maximum-args=")); err != nil {
+					return fmt.Errorf("invalid maximum-args: %w", err)
+				}
 			default:
 				return fmt.Errorf("unrecognized attribute bullet: %q", bullet)
 			}
+		}
+		if c.MaximumArgs != 0 && c.ExactArgs != 0 {
+			return fmt.Errorf("cannot have both maximum-args and exact-args")
 		}
 	}
 


### PR DESCRIPTION
## What was changed
Adding operator namespace commands to cli. These are the commands that are added
* operator namespace create
* operator namespace delete
* operator namespace describe
* operator namespace list
* operator nemspace update

## Breaking changes
* Removed --verbose option from `namespace update` command. This option is used to print update request payload.
* Previous cli was printing historyArchivalUri and visibilityArchivalUri fields only if the option `--fields` is set to `long` when executing `namespace describe` command. Here we are always printing those fields since we dont have `--fields` option.

## Why?

## Checklist

2. How was this tested:
Unit tests.

3. Any docs updates needed?
