### PR TITLE
Allow setting the auth token via an env var

### DIFF
--- a/temporalcli/headers_test.go
+++ b/temporalcli/headers_test.go
@@ -1,0 +1,49 @@
+package temporalcli_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/cli/temporalcli/devserver"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_SetsAuthHeadersFromEnvVar(t *testing.T) {
+	foundEnchi := false
+	grpcIceptor := func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		if strings.Contains(info.FullMethod, "ListWorkflowExecutions") {
+			md, ok := metadata.FromIncomingContext(ctx)
+			if ok {
+				values := md.Get("authorization")
+				for _, v := range values {
+					if v == "Bearer enchi" {
+						foundEnchi = true
+					}
+				}
+			}
+		}
+		return handler(ctx, req)
+	}
+	devServer := StartDevServer(t, DevServerOptions{
+		StartOptions: devserver.StartOptions{
+			GRPCInterceptors: []grpc.UnaryServerInterceptor{grpcIceptor},
+		},
+	})
+	defer devServer.Stop()
+
+	cmdh := NewCommandHarness(t)
+	err := os.Setenv(`TEMPORAL_CLI_AUTHORIZATION_TOKEN`, "Bearer enchi")
+	require.NoError(t, err)
+	defer os.Unsetenv(`TEMPORAL_CLI_AUTHORIZATION_TOKEN`)
+	res := cmdh.Execute("workflow", "list", "--address", devServer.Address())
+	require.NoError(t, res.Err)
+	require.True(t, foundEnchi)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allow setting `Authorization` header via an env var

## Why?
Existed in tctl, request from user.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/cli/issues/342
2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
