### PR TITLE
Log env vars which override the env file

### DIFF
--- a/temporalcli/commands.env_test.go
+++ b/temporalcli/commands.env_test.go
@@ -69,4 +69,12 @@ func TestEnv_Simple(t *testing.T) {
 	res = h.Execute("env", "list")
 	h.NoError(res.Err)
 	h.NotContains(res.Stdout.String(), "myenv2")
+
+	// Ensure env var overrides env file
+	res = h.Execute("env", "set", "myenv1.address", "something:1234")
+	h.NoError(res.Err)
+	h.NoError(os.Setenv("TEMPORAL_ADDRESS", "overridden:1235"))
+	defer os.Unsetenv("TEMPORAL_ADDRESS")
+	res = h.Execute("workflow", "list", "--env", "myenv1")
+	h.Contains(res.Stderr.String(), "Env var overrode --env setting")
 }

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -229,10 +229,13 @@ func UnmarshalProtoJSONWithOptions(b []byte, m proto.Message, jsonShorthandPaylo
 	return opts.Unmarshal(b, m)
 }
 
-func (c *CommandContext) populateFlagsFromEnv(flags *pflag.FlagSet) error {
+// Set flag values from environment file & variables. Returns a map of flags->values which were
+// overridden by environment variables.
+func (c *CommandContext) populateFlagsFromEnv(flags *pflag.FlagSet) (func(*slog.Logger), error) {
 	if flags == nil {
-		return nil
+		return func(logger *slog.Logger) {}, nil
 	}
+	var logCalls []func(*slog.Logger)
 	var flagErr error
 	flags.VisitAll(func(flag *pflag.Flag) {
 		// If the flag was already changed by the user, we don't overwrite
@@ -254,11 +257,21 @@ func (c *CommandContext) populateFlagsFromEnv(flags *pflag.FlagSet) error {
 						flag.Name, anns[0], envVal, err)
 					return
 				}
+				if flag.Changed {
+					logCalls = append(logCalls, func(l *slog.Logger) {
+						l.Info("Env var overrode --env setting", "env_var", anns[0], "flag", flag.Name, "value", envVal)
+					})
+				}
 				flag.Changed = true
 			}
 		}
 	})
-	return flagErr
+	logFn := func(logger *slog.Logger) {
+		for _, call := range logCalls {
+			call(logger)
+		}
+	}
+	return logFn, flagErr
 }
 
 // Returns error if JSON output enabled
@@ -307,7 +320,8 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	c.Command.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// Populate environ. We will make the error return here which will cause
 		// usage to be printed.
-		if err := cctx.populateFlagsFromEnv(cmd.Flags()); err != nil {
+		logCalls, err := cctx.populateFlagsFromEnv(cmd.Flags())
+		if err != nil {
 			return err
 		}
 
@@ -318,6 +332,8 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 		}
 
 		res := c.preRun(cctx)
+
+		logCalls(cctx.Logger)
 
 		// Always disable color if JSON output is on (must be run after preRun so JSONOutput is set)
 		if cctx.JSONOutput {

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -229,8 +229,8 @@ func UnmarshalProtoJSONWithOptions(b []byte, m proto.Message, jsonShorthandPaylo
 	return opts.Unmarshal(b, m)
 }
 
-// Set flag values from environment file & variables. Returns a map of flags->values which were
-// overridden by environment variables.
+// Set flag values from environment file & variables. Returns a callback to log anything interesting
+// since logging will not yet be initialized when this runs.
 func (c *CommandContext) populateFlagsFromEnv(flags *pflag.FlagSet) (func(*slog.Logger), error) {
 	if flags == nil {
 		return func(logger *slog.Logger) {}, nil
@@ -259,7 +259,7 @@ func (c *CommandContext) populateFlagsFromEnv(flags *pflag.FlagSet) (func(*slog.
 				}
 				if flag.Changed {
 					logCalls = append(logCalls, func(l *slog.Logger) {
-						l.Info("Env var overrode --env setting", "env_var", anns[0], "flag", flag.Name, "value", envVal)
+						l.Info("Env var overrode --env setting", "env_var", anns[0], "flag", flag.Name)
 					})
 				}
 				flag.Changed = true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Log any time an env var overrides an env file setting

## Why?
It can be a bit confusing if you've forgotten you've set an env var. Helpful reminder.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/cli/issues/293
2. How was this tested:
Added unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
