### PR TITLE
CLI Refresh: `workflow delete` command

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -3,6 +3,7 @@
 package temporalcli
 
 import (
+	"fmt"
 	"github.com/mattn/go-isatty"
 
 	"github.com/spf13/cobra"
@@ -1357,6 +1358,7 @@ func NewTemporalWorkflowCountCommand(cctx *CommandContext, parent *TemporalWorkf
 type TemporalWorkflowDeleteCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
+	SingleWorkflowOrBatchOptions
 }
 
 func NewTemporalWorkflowDeleteCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowDeleteCommand {
@@ -1365,8 +1367,15 @@ func NewTemporalWorkflowDeleteCommand(cctx *CommandContext, parent *TemporalWork
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "delete [flags]"
 	s.Command.Short = "Deletes a Workflow Execution."
-	s.Command.Long = "TODO"
+	start := "`"
+	end := "`"
+	if hasHighlighting {
+		start = "\x1b[1m"
+		end = "\x1b[0m"
+	}
+	s.Command.Long = fmt.Sprintf("The %stemporal workflow delete%s command is used to delete a specific Workflow Execution \n(when WorkflowExecution.run_id is provided) or the latest Workflow Execution \n(when WorkflowExecution.run_id is not provided). \nIf the Workflow Execution is Running, it will be terminated before deletion.", start, end)
 	s.Command.Args = cobra.NoArgs
+	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -3,7 +3,6 @@
 package temporalcli
 
 import (
-	"fmt"
 	"github.com/mattn/go-isatty"
 
 	"github.com/spf13/cobra"
@@ -1367,13 +1366,11 @@ func NewTemporalWorkflowDeleteCommand(cctx *CommandContext, parent *TemporalWork
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "delete [flags]"
 	s.Command.Short = "Deletes a Workflow Execution."
-	start := "`"
-	end := "`"
 	if hasHighlighting {
-		start = "\x1b[1m"
-		end = "\x1b[0m"
+		s.Command.Long = "The \x1b[1mtemporal workflow delete\x1b[0m command is used to delete a specific Workflow Execution.\nThis asynchronously deletes a workflow's Event History.\nIf the Workflow Execution is Running, it will be terminated before deletion.\n\n\x1b[1mtemporal workflow delete \\\n\t\t--workflow-id MyWorkflowId \\\x1b[0m\n\nUse the options listed below to change the command's behavior."
+	} else {
+		s.Command.Long = "The `temporal workflow delete` command is used to delete a specific Workflow Execution.\nThis asynchronously deletes a workflow's Event History.\nIf the Workflow Execution is Running, it will be terminated before deletion.\n\n```\ntemporal workflow delete \\\n\t\t--workflow-id MyWorkflowId \\\n```\n\nUse the options listed below to change the command's behavior."
 	}
-	s.Command.Long = fmt.Sprintf("The %stemporal workflow delete%s command is used to delete a specific Workflow Execution. \nThis asynchronously deletes a workflow's [Event History](/concepts/what-is-an-event-history). \nIf the Workflow Execution is Running, it will be terminated before deletion.", start, end)
 	s.Command.Args = cobra.NoArgs
 	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1373,7 +1373,7 @@ func NewTemporalWorkflowDeleteCommand(cctx *CommandContext, parent *TemporalWork
 		start = "\x1b[1m"
 		end = "\x1b[0m"
 	}
-	s.Command.Long = fmt.Sprintf("The %stemporal workflow delete%s command is used to delete a specific Workflow Execution \n(when WorkflowExecution.run_id is provided) or the latest Workflow Execution \n(when WorkflowExecution.run_id is not provided). \nIf the Workflow Execution is Running, it will be terminated before deletion.", start, end)
+	s.Command.Long = fmt.Sprintf("The %stemporal workflow delete%s command is used to delete a specific Workflow Execution. \nThis asynchronously deletes a workflow's [Event History](/concepts/what-is-an-event-history). \nIf the Workflow Execution is Running, it will be terminated before deletion.", start, end)
 	s.Command.Args = cobra.NoArgs
 	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -159,12 +159,11 @@ func (c *TemporalWorkflowTerminateCommand) run(cctx *CommandContext, _ []string)
 		// You're allowed to specify a reason when terminating a workflow
 		AllowReasonWithWorkflowID: true,
 	})
-	if err != nil {
-		return err
-	}
 
 	// Run single or batch
-	if exec != nil {
+	if err != nil {
+		return err
+	} else if exec != nil {
 		reason := c.Reason
 		if reason == "" {
 			reason = defaultReason()
@@ -174,7 +173,7 @@ func (c *TemporalWorkflowTerminateCommand) run(cctx *CommandContext, _ []string)
 			return fmt.Errorf("failed to terminate workflow: %w", err)
 		}
 		cctx.Printer.Println("Workflow terminated")
-	} else if batchReq != nil {
+	} else { // batchReq != nil
 		batchReq.Operation = &workflowservice.StartBatchOperationRequest_TerminationOperation{
 			TerminationOperation: &batch.BatchOperationTermination{
 				Identity: clientIdentity(),

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -24,18 +24,17 @@ func (c *TemporalWorkflowCancelCommand) run(cctx *CommandContext, args []string)
 	defer cl.Close()
 
 	exec, batchReq, err := c.workflowExecOrBatch(cctx, c.Parent.Namespace, cl, singleOrBatchOverrides{})
-	if err != nil {
-		return err
-	}
 
 	// Run single or batch
-	if exec != nil {
+	if err != nil {
+		return err
+	} else if exec != nil {
 		err = cl.CancelWorkflow(cctx, exec.WorkflowId, exec.RunId)
 		if err != nil {
 			return fmt.Errorf("failed to cancel workflow: %w", err)
 		}
 		cctx.Printer.Println("Canceled workflow")
-	} else if batchReq != nil {
+	} else { // batchReq != nil
 		batchReq.Operation = &workflowservice.StartBatchOperationRequest_CancellationOperation{
 			CancellationOperation: &batch.BatchOperationCancellation{
 				Identity: clientIdentity(),
@@ -57,12 +56,11 @@ func (c *TemporalWorkflowDeleteCommand) run(cctx *CommandContext, args []string)
 	defer cl.Close()
 
 	exec, batchReq, err := c.workflowExecOrBatch(cctx, c.Parent.Namespace, cl, singleOrBatchOverrides{})
-	if err != nil {
-		return err
-	}
 
 	// Run single or batch
-	if exec != nil {
+	if err != nil {
+		return err
+	} else if exec != nil {
 		_, err := cl.WorkflowService().DeleteWorkflowExecution(cctx, &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace:         c.Parent.Namespace,
 			WorkflowExecution: &common.WorkflowExecution{WorkflowId: c.WorkflowId, RunId: c.RunId},
@@ -71,7 +69,7 @@ func (c *TemporalWorkflowDeleteCommand) run(cctx *CommandContext, args []string)
 			return fmt.Errorf("failed to delete workflow: %w", err)
 		}
 		cctx.Printer.Println("Delete workflow succeeded")
-	} else if batchReq != nil {
+	} else { // batchReq != nil
 		batchReq.Operation = &workflowservice.StartBatchOperationRequest_DeletionOperation{
 			DeletionOperation: &batch.BatchOperationDeletion{
 				Identity: clientIdentity(),

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -159,7 +159,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 		}
 
 		return false
-	}, 10*time.Second, time.Second, "timed out awaiting for workflows termination")
+	}, 5*time.Second, 100 * time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -157,7 +157,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 	res := s.Execute(
 		"workflow", "delete",
 		"--address", s.Address(),
-		"--query", "WorkflowId = 'delete-test-1' OR WorkflowId = 'delete-test-2'",
+		"--query", "TaskQueue = 'delete-test' AND (WorkflowId = 'delete-test-1' OR WorkflowId = 'delete-test-2')",
 		"--reason", "test",
 		"-y",
 	)
@@ -182,7 +182,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 		}
 
 		return false
-	}, 5*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
+	}, 10*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -168,6 +168,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 	s.Eventually(func() bool {
 		wfs, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: s.Namespace(),
+			Query:     "TaskQueue = 'delete-test'",
 		})
 		s.NoError(err)
 
@@ -181,7 +182,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 		}
 
 		return false
-	}, 10*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
+	}, 5*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -176,7 +176,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 		}
 
 		return false
-	}, 5*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
+	}, 8*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -164,7 +164,6 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 	s.NoError(res.Err)
 
 	// Confirm workflows were deleted
-	i := 0
 	s.Eventually(func() bool {
 		wfs, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: s.Namespace(),
@@ -172,17 +171,12 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 		})
 		s.NoError(err)
 
-		for _, e := range wfs.GetExecutions() {
-			fmt.Printf("check %d, wf %+v\n", i, e.GetExecution().GetWorkflowId())
-		}
-		i++
-
 		if len(wfs.GetExecutions()) == 1 && wfs.GetExecutions()[0].GetExecution().GetWorkflowId() == "delete-test-3" {
 			return true
 		}
 
 		return false
-	}, 10*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
+	}, 5*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -164,18 +164,24 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 	s.NoError(res.Err)
 
 	// Confirm workflows were deleted
+	i := 0
 	s.Eventually(func() bool {
 		wfs, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: s.Namespace(),
 		})
 		s.NoError(err)
 
+		for _, e := range wfs.GetExecutions() {
+			fmt.Printf("check %d, wf %+v\n", i, e.GetExecution().GetWorkflowId())
+		}
+		i++
+
 		if len(wfs.GetExecutions()) == 1 && wfs.GetExecutions()[0].GetExecution().GetWorkflowId() == "delete-test-3" {
 			return true
 		}
 
 		return false
-	}, 5*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
+	}, 10*time.Second, 100*time.Millisecond, "timed out awaiting for workflows termination")
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -581,15 +581,9 @@ temporal workflow delete \
 
 Use the options listed below to change the command's behavior.
 
-#### Options set for single workflow or batch:
+#### Options
 
-* `--workflow-id`, `-w` (string) - Workflow Id. Either this or query must be set.
-* `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
-* `--query`, `-q` (string) - Start a batch to operate on Workflow Executions with given List Filter. Either this or
-  Workflow Id must be set.
-* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies
-  otherwise. Defaults to message with the current user's name.
-* `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
+Includes options set for [single workflow or batch](#options-set-single-workflow-or-batch)
 
 ### temporal workflow describe: Show information about a Workflow Execution.
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -570,7 +570,27 @@ TODO
 
 ### temporal workflow delete: Deletes a Workflow Execution.
 
-TODO
+The `temporal workflow delete` command is used to delete a specific [Workflow Execution](/concepts/what-is-a-workflow-execution)
+(when WorkflowExecution.run_id is provided) or the latest [Workflow Execution](/concepts/what-is-a-workflow-execution)
+(when WorkflowExecution.run_id is not provided).
+If the [Workflow Execution](/concepts/what-is-a-workflow-execution) is Running, it will be terminated before deletion.
+
+```
+temporal workflow delete \
+		--workflow-id MyWorkflowId \
+```
+
+Use the options listed below to change the command's behavior.
+
+#### Options set for single workflow or batch:
+
+* `--workflow-id`, `-w` (string) - Workflow Id. Either this or query must be set.
+* `--run-id`, `-r` (string) - Run Id. Cannot be set when query is set.
+* `--query`, `-q` (string) - Start a batch to operate on Workflow Executions with given List Filter. Either this or
+  Workflow Id must be set.
+* `--reason` (string) - Reason to perform batch. Only allowed if query is present unless the command specifies
+  otherwise. Defaults to message with the current user's name.
+* `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
 
 ### temporal workflow describe: Show information about a Workflow Execution.
 

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -570,9 +570,8 @@ TODO
 
 ### temporal workflow delete: Deletes a Workflow Execution.
 
-The `temporal workflow delete` command is used to delete a specific [Workflow Execution](/concepts/what-is-a-workflow-execution)
-(when WorkflowExecution.run_id is provided) or the latest [Workflow Execution](/concepts/what-is-a-workflow-execution)
-(when WorkflowExecution.run_id is not provided).
+The `temporal workflow delete` command is used to delete a specific [Workflow Execution](/concepts/what-is-a-workflow-execution).
+This asynchronously deletes a workflow's [Event History](/concepts/what-is-an-event-history).
 If the [Workflow Execution](/concepts/what-is-a-workflow-execution) is Running, it will be terminated before deletion.
 
 ```


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add support for workflow delete command. The functionality is mostly unchanged from current CLI, but the output may be different.

## Why?
For the CLI refresh

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Tested in commands.workflow_test.go and via CLI with local dev environment.
