### PR TITLE
Do not use payload shorthand on workflow show

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1936,9 +1936,9 @@ func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkfl
 	s.Command.Use = "show [flags]"
 	s.Command.Short = "Show Event History for a Workflow Execution."
 	if hasHighlighting {
-		s.Command.Long = "The \x1b[1mtemporal workflow show\x1b[0m command provides the Event History for a\nWorkflow Execution.\n\nUse the options listed below to change the command's behavior."
+		s.Command.Long = "The \x1b[1mtemporal workflow show\x1b[0m command provides the Event History for a\nWorkflow Execution. With JSON output specified, this output can be given to\nan SDK to perform a replay.\n\nUse the options listed below to change the command's behavior."
 	} else {
-		s.Command.Long = "The `temporal workflow show` command provides the Event History for a\nWorkflow Execution.\n\nUse the options listed below to change the command's behavior."
+		s.Command.Long = "The `temporal workflow show` command provides the Event History for a\nWorkflow Execution. With JSON output specified, this output can be given to\nan SDK to perform a replay.\n\nUse the options listed below to change the command's behavior."
 	}
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -269,7 +269,7 @@ func (*TemporalWorkflowCountCommand) run(*CommandContext, []string) error {
 	return fmt.Errorf("TODO")
 }
 
-func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, args []string) error {
+func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) error {
 	// Call describe
 	cl, err := c.Parent.ClientOptions.dialClient(cctx)
 	if err != nil {
@@ -308,7 +308,13 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, args []string) e
 		}
 		outStruct := history.History{}
 		outStruct.Events = events
-		if err := cctx.Printer.PrintStructured(&outStruct, printer.StructuredOptions{}); err != nil {
+		// We intentionally disable shorthand because "workflow show" for JSON needs
+		// to support SDK replayers which do not work with shorthand
+		jsonPayloadShorthand := false
+		err = cctx.Printer.PrintStructured(&outStruct, printer.StructuredOptions{
+			OverrideJSONPayloadShorthand: &jsonPayloadShorthand,
+		})
+		if err != nil {
 			return fmt.Errorf("failed printing structured output: %w", err)
 		}
 	}

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -2,6 +2,7 @@ package temporalcli_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -256,7 +257,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_JSON() {
 		s.Context,
 		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
 		DevWorkflow,
-		"ignored",
+		"workflow-param",
 	)
 	s.NoError(err)
 
@@ -270,6 +271,8 @@ func (s *SharedServerSuite) TestWorkflow_Show_JSON() {
 	out := res.Stdout.String()
 	s.Contains(out, `"events": [`)
 	s.Contains(out, `"eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED"`)
+	// Make sure payloads are still encoded non-shorthand
+	s.Contains(out, base64.StdEncoding.EncodeToString([]byte(`"workflow-param"`)))
 
 	// Send signals to complete
 	s.NoError(s.Client.SignalWorkflow(s.Context, run.GetID(), "", "my-signal", nil))

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -886,7 +886,8 @@ Use the options listed below to change reset behavior.
 ### temporal workflow show: Show Event History for a Workflow Execution.
 
 The `temporal workflow show` command provides the [Event History](/concepts/what-is-an-event-history) for a
-[Workflow Execution](/concepts/what-is-a-workflow-execution).
+[Workflow Execution](/concepts/what-is-a-workflow-execution). With JSON output specified, this output can be given to
+an SDK to perform a replay.
 
 Use the options listed below to change the command's behavior.
 


### PR DESCRIPTION
## What was changed

We use "JSON payload shorthand" by default in our JSON protos throughout the CLI. Payloads are notoriously hard to use as base64 input/output, so this helps others, but for `workflow show -o json` specifically it makes the JSON incompatible with SDK replayers. So we have disabled the default (and there's no real way to put the default back at this time, though we can discuss in the future if needed).