### PR TITLE
Implement workflow count, temporarily remove workflow trace

### DIFF
--- a/temporalcli/commands.activity_test.go
+++ b/temporalcli/commands.activity_test.go
@@ -109,13 +109,13 @@ func (s *SharedServerSuite) TestActivity_Fail_InvalidDetail() {
 // Test helpers
 
 func (s *SharedServerSuite) waitActivityStarted() client.WorkflowRun {
-	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
 		time.Sleep(0xFFFF * time.Hour)
 		return nil, nil
 	})
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1624,7 +1624,6 @@ func NewTemporalWorkflowCommand(cctx *CommandContext, parent *TemporalCommand) *
 	s.Command.AddCommand(&NewTemporalWorkflowStackCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalWorkflowStartCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalWorkflowTerminateCommand(cctx, &s).Command)
-	s.Command.AddCommand(&NewTemporalWorkflowTraceCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalWorkflowUpdateCommand(cctx, &s).Command)
 	s.ClientOptions.buildFlags(cctx, s.Command.PersistentFlags())
 	return &s
@@ -1660,6 +1659,7 @@ func NewTemporalWorkflowCancelCommand(cctx *CommandContext, parent *TemporalWork
 type TemporalWorkflowCountCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
+	Query   string
 }
 
 func NewTemporalWorkflowCountCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowCountCommand {
@@ -1668,8 +1668,13 @@ func NewTemporalWorkflowCountCommand(cctx *CommandContext, parent *TemporalWorkf
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "count [flags]"
 	s.Command.Short = "Count Workflow Executions."
-	s.Command.Long = "TODO"
+	if hasHighlighting {
+		s.Command.Long = "The \x1b[1mtemporal workflow count\x1b[0m command returns a count of Workflow Executions.\n\nUse the options listed below to change the command's behavior."
+	} else {
+		s.Command.Long = "The `temporal workflow count` command returns a count of Workflow Executions.\n\nUse the options listed below to change the command's behavior."
+	}
 	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Filter results using a SQL-like query.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -2139,27 +2144,6 @@ func NewTemporalWorkflowTerminateCommand(cctx *CommandContext, parent *TemporalW
 	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Start a batch to terminate Workflow Executions with given List Filter. Either this or Workflow Id must be set.")
 	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason for termination. Defaults to message with the current user's name.")
 	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Confirm prompt to perform batch. Only allowed if query is present.")
-	s.Command.Run = func(c *cobra.Command, args []string) {
-		if err := s.run(cctx, args); err != nil {
-			cctx.Options.Fail(err)
-		}
-	}
-	return &s
-}
-
-type TemporalWorkflowTraceCommand struct {
-	Parent  *TemporalWorkflowCommand
-	Command cobra.Command
-}
-
-func NewTemporalWorkflowTraceCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowTraceCommand {
-	var s TemporalWorkflowTraceCommand
-	s.Parent = parent
-	s.Command.DisableFlagsInUseLine = true
-	s.Command.Use = "trace [flags]"
-	s.Command.Short = "Trace progress of a Workflow Execution and its children."
-	s.Command.Long = "TODO"
-	s.Command.Args = cobra.NoArgs
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.schedule_test.go
+++ b/temporalcli/commands.schedule_test.go
@@ -18,7 +18,7 @@ import (
 func (s *SharedServerSuite) createSchedule(args ...string) (schedId, schedWfId string, res *CommandResult) {
 	schedId = fmt.Sprintf("sched-%x", rand.Uint32())
 	schedWfId = fmt.Sprintf("my-wf-id-%x", rand.Uint32())
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
 		return nil, workflow.Sleep(ctx, 10*time.Second)
 	})
 	s.T().Cleanup(func() {
@@ -40,7 +40,7 @@ func (s *SharedServerSuite) createSchedule(args ...string) (schedId, schedWfId s
 		"schedule", "create",
 		"--address", s.Address(),
 		"-s", schedId,
-		"--task-queue", s.Worker.Options.TaskQueue,
+		"--task-queue", s.Worker().Options.TaskQueue,
 		"--type", "DevWorkflow",
 		"--workflow-id", schedWfId,
 	}, args...)...,

--- a/temporalcli/commands.taskqueue_test.go
+++ b/temporalcli/commands.taskqueue_test.go
@@ -13,7 +13,7 @@ import (
 func (s *SharedServerSuite) TestTaskQueue_Describe_Simple() {
 	// Wait until the poller appears
 	s.Eventually(func() bool {
-		desc, err := s.Client.DescribeTaskQueue(s.Context, s.Worker.Options.TaskQueue, enums.TASK_QUEUE_TYPE_WORKFLOW)
+		desc, err := s.Client.DescribeTaskQueue(s.Context, s.Worker().Options.TaskQueue, enums.TASK_QUEUE_TYPE_WORKFLOW)
 		s.NoError(err)
 		for _, poller := range desc.Pollers {
 			if poller.Identity == s.DevServer.Options.ClientOptions.Identity {
@@ -27,7 +27,7 @@ func (s *SharedServerSuite) TestTaskQueue_Describe_Simple() {
 	res := s.Execute(
 		"task-queue", "describe",
 		"--address", s.Address(),
-		"--task-queue", s.Worker.Options.TaskQueue,
+		"--task-queue", s.Worker().Options.TaskQueue,
 	)
 	s.NoError(res.Err)
 	// For text, just making sure our client identity is present is good enough
@@ -38,7 +38,7 @@ func (s *SharedServerSuite) TestTaskQueue_Describe_Simple() {
 		"task-queue", "describe",
 		"-o", "json",
 		"--address", s.Address(),
-		"--task-queue", s.Worker.Options.TaskQueue,
+		"--task-queue", s.Worker().Options.TaskQueue,
 	)
 	s.NoError(res.Err)
 	var jsonOut struct {
@@ -55,7 +55,7 @@ func (s *SharedServerSuite) TestTaskQueue_Describe_Simple() {
 		"task-queue", "describe",
 		"-o", "json",
 		"--address", s.Address(),
-		"--task-queue", s.Worker.Options.TaskQueue,
+		"--task-queue", s.Worker().Options.TaskQueue,
 		"--partitions", "10",
 	)
 	s.NoError(res.Err)

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -187,10 +187,6 @@ func (c *TemporalWorkflowTerminateCommand) run(cctx *CommandContext, _ []string)
 	return nil
 }
 
-func (*TemporalWorkflowTraceCommand) run(*CommandContext, []string) error {
-	return fmt.Errorf("TODO")
-}
-
 func (c *TemporalWorkflowUpdateCommand) run(cctx *CommandContext, args []string) error {
 	cl, err := c.Parent.ClientOptions.dialClient(cctx)
 	if err != nil {

--- a/temporalcli/commands.workflow_reset_test.go
+++ b/temporalcli/commands.workflow_reset_test.go
@@ -37,11 +37,11 @@ func (s *SharedServerSuite) awaitNextWorkflow(searchAttr string) {
 
 func (s *SharedServerSuite) TestWorkflow_Reset_ToFirstWorkflowTask() {
 	var wfExecutions, activityExecutions int
-	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
 		activityExecutions++
 		return nil, nil
 	})
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		workflow.ExecuteActivity(ctx, DevActivity, 1).Get(ctx, nil)
 		wfExecutions++
 		return nil, nil
@@ -52,7 +52,7 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToFirstWorkflowTask() {
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
 		client.StartWorkflowOptions{
-			TaskQueue:        s.Worker.Options.TaskQueue,
+			TaskQueue:        s.Worker().Options.TaskQueue,
 			SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 		},
 		DevWorkflow,
@@ -79,11 +79,11 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToFirstWorkflowTask() {
 
 func (s *SharedServerSuite) TestWorkflow_Reset_ToLastWorkflowTask() {
 	var wfExecutions, activityExecutions int
-	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
 		activityExecutions++
 		return nil, nil
 	})
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		workflow.ExecuteActivity(ctx, DevActivity, 1).Get(ctx, nil)
 		wfExecutions++
 		return nil, nil
@@ -94,7 +94,7 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToLastWorkflowTask() {
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
 		client.StartWorkflowOptions{
-			TaskQueue:        s.Worker.Options.TaskQueue,
+			TaskQueue:        s.Worker().Options.TaskQueue,
 			SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 		},
 		DevWorkflow,
@@ -123,7 +123,7 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToEventID() {
 	// We execute two activities and will resume just before the second one. We use the same activity for both
 	// but a unique input so we can check which fake activity is executed
 	var oneExecutions, twoExecutions int
-	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
 		n, ok := a.(float64)
 		if !ok {
 			return nil, fmt.Errorf("expected float64, not %T (%v)", a, a)
@@ -139,7 +139,7 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToEventID() {
 		return n, nil
 	})
 
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		var res any
 		if err := workflow.ExecuteActivity(ctx, DevActivity, 1).Get(ctx, &res); err != nil {
 			return res, err
@@ -153,7 +153,7 @@ func (s *SharedServerSuite) TestWorkflow_Reset_ToEventID() {
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
 		client.StartWorkflowOptions{
-			TaskQueue:        s.Worker.Options.TaskQueue,
+			TaskQueue:        s.Worker().Options.TaskQueue,
 			SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 		},
 		DevWorkflow,

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -16,7 +16,7 @@ import (
 
 func (s *SharedServerSuite) TestWorkflow_Signal_SingleWorkflowSuccess() {
 	// Make workflow wait for signal and then return it
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		var ret any
 		workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, &ret)
 		return ret, nil
@@ -25,7 +25,7 @@ func (s *SharedServerSuite) TestWorkflow_Signal_SingleWorkflowSuccess() {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -62,7 +62,7 @@ func (s *SharedServerSuite) TestWorkflow_Signal_BatchWorkflowSuccessJSON() {
 
 func (s *SharedServerSuite) testSignalBatchWorkflow(json bool) *CommandResult {
 	// Make workflow wait for signal and then return it
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		var ret any
 		workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, &ret)
 		return ret, nil
@@ -75,7 +75,7 @@ func (s *SharedServerSuite) testSignalBatchWorkflow(json bool) *CommandResult {
 		run, err := s.Client.ExecuteWorkflow(
 			s.Context,
 			client.StartWorkflowOptions{
-				TaskQueue:        s.Worker.Options.TaskQueue,
+				TaskQueue:        s.Worker().Options.TaskQueue,
 				SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 			},
 			DevWorkflow,
@@ -120,7 +120,7 @@ func (s *SharedServerSuite) testSignalBatchWorkflow(json bool) *CommandResult {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -180,7 +180,7 @@ func (s *SharedServerSuite) TestWorkflow_Delete_BatchWorkflowSuccess() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithoutReason() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -188,7 +188,7 @@ func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_Without
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -220,7 +220,7 @@ func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_Without
 }
 
 func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithReason() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -228,7 +228,7 @@ func (s *SharedServerSuite) TestWorkflow_Terminate_SingleWorkflowSuccess_WithRea
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -274,7 +274,7 @@ func (s *SharedServerSuite) TestWorkflow_Terminate_BatchWorkflowSuccessJSON() {
 }
 
 func (s *SharedServerSuite) testTerminateBatchWorkflow(json bool) *CommandResult {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -286,7 +286,7 @@ func (s *SharedServerSuite) testTerminateBatchWorkflow(json bool) *CommandResult
 		run, err := s.Client.ExecuteWorkflow(
 			s.Context,
 			client.StartWorkflowOptions{
-				TaskQueue:        s.Worker.Options.TaskQueue,
+				TaskQueue:        s.Worker().Options.TaskQueue,
 				SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 			},
 			DevWorkflow,
@@ -341,7 +341,7 @@ func (s *SharedServerSuite) testTerminateBatchWorkflow(json bool) *CommandResult
 
 func (s *SharedServerSuite) TestWorkflow_Cancel_SingleWorkflowSuccess() {
 	// Make workflow wait for cancel and then return the context's error
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -349,7 +349,7 @@ func (s *SharedServerSuite) TestWorkflow_Cancel_SingleWorkflowSuccess() {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -370,7 +370,7 @@ func (s *SharedServerSuite) TestWorkflow_Cancel_SingleWorkflowSuccess() {
 func (s *SharedServerSuite) TestWorkflow_Update() {
 	updateName := "test-update"
 
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, val any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, val any) (any, error) {
 		// setup a simple workflow which receives non-negative floats in updates and adds them to a running counter
 		counter, ok := val.(float64)
 		if !ok {
@@ -408,7 +408,7 @@ func (s *SharedServerSuite) TestWorkflow_Update() {
 	input := rand.Intn(100)
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		input,
 	)
@@ -457,7 +457,7 @@ func (s *SharedServerSuite) TestWorkflow_Cancel_BatchWorkflowSuccessJSON() {
 
 func (s *SharedServerSuite) testCancelBatchWorkflow(json bool) *CommandResult {
 	// Make workflow wait for cancel and then return the context's error
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		ctx.Done().Receive(ctx, nil)
 		return nil, ctx.Err()
 	})
@@ -469,7 +469,7 @@ func (s *SharedServerSuite) testCancelBatchWorkflow(json bool) *CommandResult {
 		run, err := s.Client.ExecuteWorkflow(
 			s.Context,
 			client.StartWorkflowOptions{
-				TaskQueue:        s.Worker.Options.TaskQueue,
+				TaskQueue:        s.Worker().Options.TaskQueue,
 				SearchAttributes: map[string]any{"CustomKeywordField": searchAttr},
 			},
 			DevWorkflow,
@@ -519,7 +519,7 @@ func (s *SharedServerSuite) TestWorkflow_Query_SingleWorkflowSuccessJSON() {
 }
 
 func (s *SharedServerSuite) testQueryWorkflow(json bool) {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		err := workflow.SetQueryHandler(ctx, "my-query", func(arg string) (any, error) {
 			retme := struct {
 				Echo  string `json:"input"`
@@ -538,7 +538,7 @@ func (s *SharedServerSuite) testQueryWorkflow(json bool) {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -594,7 +594,7 @@ func (s *SharedServerSuite) TestWorkflow_Stack_SingleWorkflowSuccessJSON() {
 
 func (s *SharedServerSuite) testStackWorkflow(json bool) {
 	// Make workflow wait for signal and then return it
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		done := false
 		workflow.Go(ctx, func(ctx workflow.Context) {
 			_ = workflow.Await(ctx, func() bool {
@@ -610,7 +610,7 @@ func (s *SharedServerSuite) testStackWorkflow(json bool) {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -17,11 +17,11 @@ import (
 
 func (s *SharedServerSuite) TestWorkflow_Describe_ActivityFailing() {
 	// Set activity to just continually error
-	s.Worker.OnDevActivity(func(ctx context.Context, a any) (any, error) {
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
 		return nil, fmt.Errorf("intentional error")
 	})
 
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			StartToCloseTimeout: 10 * time.Second,
 		})
@@ -33,7 +33,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_ActivityFailing() {
 	// Start the workflow and wait until it has at least reached activity failure
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -74,7 +74,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_Completed() {
 	// Start the workflow and wait until it has at least reached activity failure
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		map[string]string{"foo": "bar"},
 	)
@@ -110,7 +110,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_ResetPoints() {
 	// Start the workflow and wait until it has at least reached activity failure
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		map[string]string{"foo": "bar"},
 	)
@@ -146,7 +146,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_ResetPoints() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Show_Follow() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		sigs := 0
 		for {
 			workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, nil)
@@ -161,7 +161,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_Follow() {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -193,7 +193,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_Follow() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Show_NoFollow() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		sigs := 0
 		for {
 			workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, nil)
@@ -208,7 +208,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_NoFollow() {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -241,7 +241,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_NoFollow() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Show_JSON() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		sigs := 0
 		for {
 			workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, nil)
@@ -256,7 +256,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_JSON() {
 	// Start the workflow
 	run, err := s.Client.ExecuteWorkflow(
 		s.Context,
-		client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 		DevWorkflow,
 		"ignored",
 	)
@@ -292,7 +292,7 @@ func (s *SharedServerSuite) TestWorkflow_Show_JSON() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_List() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, a any) (any, error) {
 		return a, nil
 	})
 
@@ -300,7 +300,7 @@ func (s *SharedServerSuite) TestWorkflow_List() {
 	for i := 0; i < 3; i++ {
 		run, err := s.Client.ExecuteWorkflow(
 			s.Context,
-			client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+			client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 			DevWorkflow,
 			strconv.Itoa(i),
 		)
@@ -311,7 +311,7 @@ func (s *SharedServerSuite) TestWorkflow_List() {
 	res := s.Execute(
 		"workflow", "list",
 		"--address", s.Address(),
-		"--query", fmt.Sprintf(`TaskQueue="%s"`, s.Worker.Options.TaskQueue),
+		"--query", fmt.Sprintf(`TaskQueue="%s"`, s.Worker().Options.TaskQueue),
 	)
 	s.NoError(res.Err)
 	out := res.Stdout.String()
@@ -321,7 +321,7 @@ func (s *SharedServerSuite) TestWorkflow_List() {
 	res = s.Execute(
 		"workflow", "list",
 		"--address", s.Address(),
-		"--query", fmt.Sprintf(`TaskQueue="%s"`, s.Worker.Options.TaskQueue),
+		"--query", fmt.Sprintf(`TaskQueue="%s"`, s.Worker().Options.TaskQueue),
 		"-o", "json",
 	)
 	s.NoError(res.Err)
@@ -332,7 +332,7 @@ func (s *SharedServerSuite) TestWorkflow_List() {
 }
 
 func (s *SharedServerSuite) TestWorkflow_Count() {
-	s.Worker.OnDevWorkflow(func(ctx workflow.Context, shouldComplete any) (any, error) {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, shouldComplete any) (any, error) {
 		// Only complete if shouldComplete is a true bool
 		shouldCompleteBool, _ := shouldComplete.(bool)
 		return nil, workflow.Await(ctx, func() bool { return shouldCompleteBool })
@@ -342,7 +342,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	for i := 0; i < 5; i++ {
 		_, err := s.Client.ExecuteWorkflow(
 			s.Context,
-			client.StartWorkflowOptions{TaskQueue: s.Worker.Options.TaskQueue},
+			client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
 			DevWorkflow,
 			i < 3,
 		)
@@ -353,7 +353,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	s.Eventually(
 		func() bool {
 			resp, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
-				Query: "TaskQueue = '" + s.Worker.Options.TaskQueue + "'",
+				Query: "TaskQueue = '" + s.Worker().Options.TaskQueue + "'",
 			})
 			s.NoError(err)
 			var completed, running int
@@ -374,7 +374,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	res := s.Execute(
 		"workflow", "count",
 		"--address", s.Address(),
-		"--query", "TaskQueue = '"+s.Worker.Options.TaskQueue+"'",
+		"--query", "TaskQueue = '"+s.Worker().Options.TaskQueue+"'",
 	)
 	s.NoError(res.Err)
 	out := res.Stdout.String()
@@ -384,7 +384,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	res = s.Execute(
 		"workflow", "count",
 		"--address", s.Address(),
-		"--query", "TaskQueue = '"+s.Worker.Options.TaskQueue+"' GROUP BY ExecutionStatus",
+		"--query", "TaskQueue = '"+s.Worker().Options.TaskQueue+"' GROUP BY ExecutionStatus",
 	)
 	s.NoError(res.Err)
 	out = res.Stdout.String()
@@ -396,7 +396,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	res = s.Execute(
 		"workflow", "count",
 		"--address", s.Address(),
-		"--query", "TaskQueue = '"+s.Worker.Options.TaskQueue+"'",
+		"--query", "TaskQueue = '"+s.Worker().Options.TaskQueue+"'",
 		"-o", "json",
 	)
 	s.NoError(res.Err)
@@ -408,7 +408,7 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	res = s.Execute(
 		"workflow", "count",
 		"--address", s.Address(),
-		"--query", "TaskQueue = '"+s.Worker.Options.TaskQueue+"' GROUP BY ExecutionStatus",
+		"--query", "TaskQueue = '"+s.Worker().Options.TaskQueue+"' GROUP BY ExecutionStatus",
 		"-o", "jsonl",
 	)
 	s.NoError(res.Err)

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -723,7 +723,13 @@ Includes options set for [single workflow or batch](#options-set-single-workflow
 
 ### temporal workflow count: Count Workflow Executions.
 
-TODO
+The `temporal workflow count` command returns a count of [Workflow Executions](/concepts/what-is-a-workflow-execution).
+
+Use the options listed below to change the command's behavior.
+
+#### Options
+
+* `--query`, `-q` (string) - Filter results using a SQL-like query.
 
 ### temporal workflow delete: Deletes a Workflow Execution.
 
@@ -1017,10 +1023,6 @@ Use the options listed below to change the behavior of this command.
   Workflow Id must be set.
 * `--reason` (string) - Reason for termination. Defaults to message with the current user's name.
 * `--yes`, `-y` (bool) - Confirm prompt to perform batch. Only allowed if query is present.
-
-### temporal workflow trace: Trace progress of a Workflow Execution and its children.
-
-TODO
 
 ### temporal workflow update: Updates a running workflow synchronously.
 


### PR DESCRIPTION
## What was changed

* Implemented `temporal workflow count`
* Removed `temporal workflow trace` until it can be fixed
* Move the test worker from being per-suite to being per-test (and made it lazy since not all tests need it)