### PR TITLE
Replace release workflow with goreleaser from main

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,21 +1,25 @@
-name: Release
+name: goreleaser
 
 on:
+  workflow_dispatch:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '**'
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          submodules: recursive
+          fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
 
       - name: Get build date
         id: date
@@ -38,7 +42,7 @@ jobs:
         run: echo "::set-output name=go::$(go version | cut -d ' ' -f 3)"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
           args: release


### PR DESCRIPTION
## What was changed

Replace release GH workflow with goreleaser from main so that it will run on release and can be manually triggered. I suspect once cli-rewrite is on main we may make the name more generic to support things like docker publish