### PR TITLE
Fixes typos in the commands Markdown source

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -55,7 +55,7 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Command.PersistentFlags().Var(&s.TimeFormat, "time-format", "Time format. Accepted values: relative, iso, raw.")
 	s.Color = NewStringEnum([]string{"always", "never", "auto"}, "auto")
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Set coloring. Accepted values: always, never, auto.")
-	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Always all payloads as raw payloads even if they are JSON.")
+	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Always show all payloads as raw payloads even if they are JSON.")
 	s.initCommand(cctx)
 	return &s
 }
@@ -1263,7 +1263,7 @@ func NewTemporalServerStartDevCommand(cctx *CommandContext, parent *TemporalServ
 	s.Command.Flags().StringVar(&s.UiCodecEndpoint, "ui-codec-endpoint", "", "UI remote codec HTTP endpoint.")
 	s.Command.Flags().StringArrayVar(&s.SqlitePragma, "sqlite-pragma", nil, "Specify SQLite pragma statements in pragma=value format.")
 	s.Command.Flags().StringArrayVar(&s.DynamicConfigValue, "dynamic-config-value", nil, "Dynamic config value, as KEY=JSON_VALUE (string values need quotes).")
-	s.Command.Flags().BoolVar(&s.LogConfig, "log-config", false, "Log the server config being used in stderr.")
+	s.Command.Flags().BoolVar(&s.LogConfig, "log-config", false, "Log the server config being used to stderr.")
 	s.LogLevelServer = NewStringEnum([]string{"debug", "info", "warn", "error", "never"}, "warn")
 	s.Command.Flags().Var(&s.LogLevelServer, "log-level-server", "Log level for the server only. Accepted values: debug, info, warn, error, never.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -1347,7 +1347,7 @@ func NewTemporalTaskQueueGetBuildIdReachabilityCommand(cctx *CommandContext, par
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "get-build-id-reachability [flags]"
 	s.Command.Short = "Retrieves information about the reachability of Build IDs on one or more Task Queues."
-	s.Command.Long = "This command can tell you whether or not Build IDs may be used for for new, existing, or closed workflows. Both the '--build-id' and '--task-queue' flags may be specified multiple times. If you do not provide a task queue, reachability for the provided Build IDs will be checked against all task queues."
+	s.Command.Long = "This command can tell you whether or not Build IDs may be used for new, existing, or closed workflows. Both the '--build-id' and '--task-queue' flags may be specified multiple times. If you do not provide a task queue, reachability for the provided Build IDs will be checked against all task queues."
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringArrayVar(&s.BuildId, "build-id", nil, "Which Build ID to get reachability information for. May be specified multiple times.")
 	s.ReachabilityType = NewStringEnum([]string{"open", "closed", "existing"}, "existing")
@@ -1502,7 +1502,7 @@ func NewTemporalTaskQueueUpdateBuildIdsPromoteIdInSetCommand(cctx *CommandContex
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "promote-id-in-set [flags]"
 	s.Command.Short = "Promote an existing build ID to become the default for its containing set."
-	s.Command.Long = "New tasks compatible with the the set will be dispatched to the default id."
+	s.Command.Long = "New tasks compatible with the set will be dispatched to the default id."
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "An existing build id which will be promoted to be the default inside its containing set.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "build-id")

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -56,7 +56,7 @@ This document has a specific structure used by a parser. Here are the rules:
 * `--output`, `-o` (string-enum) - Data output format. Options: text, json, jsonl. Default: text.
 * `--time-format` (string-enum) - Time format. Options: relative, iso, raw. Default: relative.
 * `--color` (string-enum) - Set coloring. Options: always, never, auto. Default: auto.
-* `--no-json-shorthand-payloads` (bool) - Always all payloads as raw payloads even if they are JSON.
+* `--no-json-shorthand-payloads` (bool) - Always show all payloads as raw payloads even if they are JSON.
 
 ### temporal activity: Complete or fail an Activity.
 
@@ -568,7 +568,7 @@ To persist Workflows across runs, use:
 * `--ui-codec-endpoint` (string) - UI remote codec HTTP endpoint.
 * `--sqlite-pragma` (string[]) - Specify SQLite pragma statements in pragma=value format.
 * `--dynamic-config-value` (string[]) - Dynamic config value, as KEY=JSON_VALUE (string values need quotes).
-* `--log-config` (bool) - Log the server config being used in stderr.
+* `--log-config` (bool) - Log the server config being used to stderr.
 * `--log-level-server` (string-enum) - Log level for the server only. Options: debug, info, warn, error, never. Default:
   warn.
 
@@ -605,7 +605,7 @@ Use the options listed below to modify what this command returns.
 
 ### temporal task-queue get-build-id-reachability: Retrieves information about the reachability of Build IDs on one or more Task Queues.
 
-This command can tell you whether or not Build IDs may be used for for new, existing, or closed workflows. Both the '--build-id' and '--task-queue' flags may be specified multiple times. If you do not provide a task queue, reachability for the provided Build IDs will be checked against all task queues.
+This command can tell you whether or not Build IDs may be used for new, existing, or closed workflows. Both the '--build-id' and '--task-queue' flags may be specified multiple times. If you do not provide a task queue, reachability for the provided Build IDs will be checked against all task queues.
 
 #### Options
 
@@ -656,7 +656,7 @@ Creates a new build id set which will become the new overall default for the que
 
 ### temporal task-queue update-build-ids promote-id-in-set: Promote an existing build ID to become the default for its containing set.
 
-New tasks compatible with the the set will be dispatched to the default id.
+New tasks compatible with the set will be dispatched to the default id.
 
 #### Options
 


### PR DESCRIPTION
Adds minor typo changes to the commands Markdown source.

✅ go build ./temporalcli/
✅ go run ./temporalcli/internal/cmd/gen-commands

Issue: https://github.com/temporalio/cli/issues/513

