### PR TITLE
Fix racy batch test

### DIFF
--- a/temporalcli/commands.batch_test.go
+++ b/temporalcli/commands.batch_test.go
@@ -47,7 +47,7 @@ func (s *SharedServerSuite) TestBatchJob_Describe() {
 			s.Empty(res.Stderr.String())
 
 			out := res.Stdout.String()
-			s.ContainsOnSameLine(out, "State", "Running")
+			s.AnyLineMatchesRegexp(out, "State\\s+(Running|Completed)")
 			s.ContainsOnSameLine(out, "Type", "Terminate")
 			s.ContainsOnSameLine(out, "CompletedCount", "0/0")
 			s.ContainsOnSameLine(out, "FailureCount", "0/0")

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -61,6 +61,10 @@ func (h *CommandHarness) ContainsOnSameLine(text string, pieces ...string) {
 	h.NoError(AssertContainsOnSameLine(text, pieces...))
 }
 
+func (h *CommandHarness) AnyLineMatchesRegexp(text string, pattern string) {
+	h.NoError(AssertAnyLineMatchesRegexp(text, pattern))
+}
+
 func AssertContainsOnSameLine(text string, pieces ...string) error {
 	// Build regex pattern based on pieces
 	pattern := ""
@@ -70,6 +74,11 @@ func AssertContainsOnSameLine(text string, pieces ...string) error {
 		}
 		pattern += regexp.QuoteMeta(piece)
 	}
+
+	return AssertAnyLineMatchesRegexp(text, pattern)
+}
+
+func AssertAnyLineMatchesRegexp(text string, pattern string) error {
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return err
@@ -81,7 +90,7 @@ func AssertContainsOnSameLine(text string, pieces ...string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("pieces not found in order on any line together")
+	return fmt.Errorf("no line matches the expected pattern: %v", pattern)
 }
 
 func TestAssertContainsOnSameLine(t *testing.T) {


### PR DESCRIPTION
This test occasionally fails because the batch job completes before the test has a chance to check its status. Allow for this case in the test.