### PR TITLE
Exit zero if help/version is explicitly requested

### DIFF
--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -322,8 +322,23 @@ func Execute(ctx context.Context, options CommandOptions) {
 	if err != nil {
 		cctx.Options.Fail(err)
 	}
-	// If no command ever actually got run, exit nonzero
+
+	// If no command ever actually got run, exit nonzero with an error.  This is
+	// an ugly hack to make sure that iff the user explicitly asked for help, we
+	// exit with a zero error code.  (The other situation in which help is
+	// printed is when the user invokes an unknown command--we still want a
+	// non-zero exit in that case.)  We should revisit this if/when the
+	// following Cobra issues get fixed:
+	//
+	// - https://github.com/spf13/cobra/issues/1156
+	// - https://github.com/spf13/cobra/issues/706
 	if !cctx.ActuallyRanCommand {
+		zeroExitArgs := []string{"--help", "-h", "--version", "-v", "help"}
+		if slices.ContainsFunc(cctx.Options.Args, func(a string) bool {
+			return slices.Contains(zeroExitArgs, a)
+		}) {
+			return
+		}
 		cctx.Options.Fail(fmt.Errorf("unknown command"))
 	}
 }
@@ -361,25 +376,6 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	c.Command.PersistentPostRun = func(*cobra.Command, []string) {
 		color.NoColor = origNoColor
 	}
-
-	// Ugly hack to make sure that iff the user explicitly asked for help, we
-	// exit with a zero error code.  (The other situation in which help is
-	// printed is when the user invokes an unknown command--we still want a
-	// non-zero exit in that case.)  We should revisit this if/when the
-	// following Cobra issues get fixed:
-	//
-	// - https://github.com/spf13/cobra/issues/1156
-	// - https://github.com/spf13/cobra/issues/706
-	inner_help := c.Command.HelpFunc()
-	c.Command.SetHelpFunc(func(c *cobra.Command, args []string) {
-		if slices.ContainsFunc(args, func(a string) bool {
-			return a == "--help" || a == "-h" || a == "help"
-		}) {
-			cctx.ActuallyRanCommand = true
-		}
-
-		inner_help(c, args)
-	})
 }
 
 func (c *TemporalCommand) preRun(cctx *CommandContext) error {


### PR DESCRIPTION
We want a non-zero exit when the user invokes `temporal` with an unknown command/subcommand, or when invoked with no arguments.  But if the user explicitly asks for help or version information, we should print it and return success.

Closes #495.