### PR TITLE
New flag: `workflow show --event-details`

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1781,7 +1781,7 @@ func NewTemporalWorkflowExecuteCommand(cctx *CommandContext, parent *TemporalWor
 	s.SharedWorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.WorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, this will print the event details instead of just the event during workflow progress. If set when using JSON output, this will include the entire \"history\" JSON key of the started run (does not follow runs).")
+	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, include event details JSON in printed output. If set when using JSON output, this will include the entire \"history\" JSON key of the started run (does not follow runs).")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -1936,7 +1936,8 @@ type TemporalWorkflowShowCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	Follow bool
+	Follow       bool
+	EventDetails bool
 }
 
 func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowShowCommand {
@@ -1953,6 +1954,7 @@ func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkfl
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Flags().BoolVarP(&s.Follow, "follow", "f", false, "Follow the progress of a Workflow Execution in real time (does not apply to JSON output).")
+	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, include event details JSON in printed output.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -327,7 +327,7 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) erro
 		client:         cl,
 		workflowID:     c.WorkflowId,
 		runID:          c.RunId,
-		includeDetails: true,
+		includeDetails: c.EventDetails,
 		follow:         c.Follow,
 	}
 	if !cctx.JSONOutput {

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -815,9 +815,8 @@ temporal workflow execute
 
 #### Options
 
-* `--event-details` (bool) - If set when using text output, this will print the event details instead of just the event
-  during workflow progress. If set when using JSON output, this will include the entire "history" JSON key of the
-  started run (does not follow runs).
+* `--event-details` (bool) - If set when using text output, include event details JSON in printed output. If set when
+  using JSON output, this will include the entire "history" JSON key of the started run (does not follow runs).
 
 Includes options set for [shared workflow start](#options-set-for-shared-workflow-start).
 Includes options set for [workflow start](#options-set-for-workflow-start).
@@ -926,6 +925,7 @@ Use the options listed below to change the command's behavior.
 
 * `--follow`, `-f` (bool) - Follow the progress of a Workflow Execution in real time (does not apply
   to JSON output).
+* `--event-details` (bool) - If set when using text output, include event details JSON in printed output.
 
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 


### PR DESCRIPTION
Fixes #545. Remove details JSON from `workflow show` output by default.

#### Before
```
cli(main) temporal workflow show -w hello-activity-workflow-id
Progress:
  ID           Time                     Type                   Details
    1  2024-05-09T15:53:37Z  WorkflowExecutionStarted    {"workflowType":{"name":"GreetingWorkflow"}, "taskQueue":{"name":"hello-activity-task-queue", "kind":"TASK_QUEUE_KIND_NORMAL"}, "input":{"payloads":[{"metada
ta":{"encoding":"anNvbi9wbGFpbg=="}, "data":"IldvcmxkIg=="}]}, "workflowTaskTimeout":"10s", "originalExecutionRunId":"b2174d63-f219-43b5-983f-391eac38a439", "identity":"45578@dan-2.local", "firstExecutionRunId":"b2
174d63-f219-43b5-983f-391eac38a439", "attempt":1, "firstWorkflowTaskBackoff":"0s", "workflowId":"hello-activity-workflow-id"}
    2  2024-05-09T15:53:37Z  WorkflowTaskScheduled       {"taskQueue":{"name":"hello-activity-task-queue", "kind":"TASK_QUEUE_KIND_NORMAL"}, "startToCloseTimeout":"10s", "attempt":1}
    3  2024-05-09T15:53:37Z  WorkflowTaskStarted         {"scheduledEventId":"2", "identity":"45578@dan-2.local", "requestId":"d68881c9-3b89-4329-8ef4-06483b65c312", "historySizeBytes":"314"}
    4  2024-05-09T15:53:37Z  WorkflowTaskCompleted       {"scheduledEventId":"2", "startedEventId":"3", "identity":"45578@dan-2.local", "workerVersion":{"buildId":"a8e1284553e035c44548066db56b7dde"}, "sdkMetadata":
{"coreUsedFlags":[2, 1]}, "meteringMetadata":{}}
    5  2024-05-09T15:53:37Z  ActivityTaskScheduled       {"activityId":"1", "activityType":{"name":"compose_greeting"}, "taskQueue":{"name":"hello-activity-task-queue", "kind":"TASK_QUEUE_KIND_NORMAL"}, "header":{}
, "input":{"payloads":[{"metadata":{"encoding":"anNvbi9wbGFpbg=="}, "data":"eyJncmVldGluZyI6IkhlbGxvIiwibmFtZSI6IldvcmxkIn0="}]}, "scheduleToCloseTimeout":"0s", "scheduleToStartTimeout":"0s", "startToCloseTimeout":
"10s", "heartbeatTimeout":"0s", "workflowTaskCompletedEventId":"4", "retryPolicy":{"initialInterval":"1s", "backoffCoefficient":2, "maximumInterval":"100s"}, "useCompatibleVersion":true}
    6  2024-05-09T15:53:37Z  ActivityTaskStarted         {"scheduledEventId":"5", "identity":"45578@dan-2.local", "requestId":"c6505ce4-62d9-402b-a6b8-a5931ac372ce", "attempt":1}
    7  2024-05-09T15:53:37Z  ActivityTaskCompleted       {"result":{"payloads":[{"metadata":{"encoding":"anNvbi9wbGFpbg=="}, "data":"IkhlbGxvLCBXb3JsZCEi"}]}, "scheduledEventId":"5", "startedEventId":"6", "identity
":"45578@dan-2.local"}
    8  2024-05-09T15:53:37Z  WorkflowTaskScheduled       {"taskQueue":{"name":"45578@dan-2.local-134d9c8495a5461e82e9b92f7ed943ce", "kind":"TASK_QUEUE_KIND_STICKY", "normalName":"hello-activity-task-queue"}, "start
ToCloseTimeout":"10s", "attempt":1}
    9  2024-05-09T15:53:37Z  WorkflowTaskStarted         {"scheduledEventId":"8", "identity":"45578@dan-2.local", "requestId":"8044cf60-5145-4fea-90eb-340390f30569", "historySizeBytes":"975"}
   10  2024-05-09T15:53:37Z  WorkflowTaskCompleted       {"scheduledEventId":"8", "startedEventId":"9", "identity":"45578@dan-2.local", "workerVersion":{"buildId":"a8e1284553e035c44548066db56b7dde"}, "sdkMetadata":
{}, "meteringMetadata":{}}
   11  2024-05-09T15:53:37Z  WorkflowExecutionCompleted  {"result":{"payloads":[{"metadata":{"encoding":"anNvbi9wbGFpbg=="}, "data":"IkhlbGxvLCBXb3JsZCEi"}]}, "workflowTaskCompletedEventId":"10"}
Results:
  Status  COMPLETED
  Result  "Hello, World!"
```

#### After
```
cli(545-workflow-show-details) temporal workflow show -w hello-activity-workflow-id
Progress:
  ID           Time                     Type
    1  2024-05-09T15:53:37Z  WorkflowExecutionStarted
    2  2024-05-09T15:53:37Z  WorkflowTaskScheduled
    3  2024-05-09T15:53:37Z  WorkflowTaskStarted
    4  2024-05-09T15:53:37Z  WorkflowTaskCompleted
    5  2024-05-09T15:53:37Z  ActivityTaskScheduled
    6  2024-05-09T15:53:37Z  ActivityTaskStarted
    7  2024-05-09T15:53:37Z  ActivityTaskCompleted
    8  2024-05-09T15:53:37Z  WorkflowTaskScheduled
    9  2024-05-09T15:53:37Z  WorkflowTaskStarted
   10  2024-05-09T15:53:37Z  WorkflowTaskCompleted
   11  2024-05-09T15:53:37Z  WorkflowExecutionCompleted
Results:
  Status  COMPLETED
  Result  "Hello, World!"
```