### PR TITLE
Add AssignedBuildId to workflow describe

### DIFF
--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -108,6 +108,7 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		Type                 string
 		Namespace            string
 		TaskQueue            string
+		AssignedBuildId      string
 		StartTime            time.Time
 		CloseTime            time.Time                  `cli:",cardOmitEmpty"`
 		ExecutionTime        time.Time                  `cli:",cardOmitEmpty"`
@@ -122,6 +123,7 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		Type:                 info.Type.GetName(),
 		Namespace:            c.Parent.Namespace,
 		TaskQueue:            info.TaskQueue,
+		AssignedBuildId:      info.GetAssignedBuildId(),
 		StartTime:            timestampToTime(info.StartTime),
 		CloseTime:            timestampToTime(info.CloseTime),
 		ExecutionTime:        timestampToTime(info.ExecutionTime),

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -142,7 +142,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_Versioned() {
 			)
 			s.NoError(res.Err)
 			out := res.Stdout.String()
-			return AssertContainsOnSameLine(out, "AssignedBuildId", buildId) != nil
+			return AssertContainsOnSameLine(out, "AssignedBuildId", buildId) == nil
 		}, 10 * time.Second, 100 * time.Millisecond)
 
 		// JSON

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -113,7 +113,7 @@ func (s *SharedServerSuite) TestWorkflow_Describe_Versioned() {
 
 	buildId := "id1"
 	res := s.Execute(
-		"task-queue", "update-build-id-rules", "insert-assignment-rule",
+		"task-queue", "versioning", "insert-assignment-rule",
 		"--build-id", buildId,
 		"-y",
 		"--address", s.Address(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
`workflow describe` now shows WF's assigned build ID as follows:
```
$temporal --env shahab-test4 workflow describe --workflow-id b72b1a82-7a83-4cc9-9bde-6ad8d411a47c      
Execution Info:
  WorkflowId            b72b1a82-7a83-4cc9-9bde-6ad8d411a47c
  RunId                 c81a42c2-efc1-4c41-9088-a0123c0d1034
  Type                  MyWorkflow
  Namespace             shahab-test4.temporal-dev
  TaskQueue             my-tq
  AssignedBuildId       BUILD_ID_HERE
  StartTime             4 hours ago
  ExecutionTime         4 hours ago
  SearchAttributes      map[BuildIds:metadata:{key:"encoding" value:"json/plain"} metadata:{key:"type" value:"KeywordList"} data:"[\"assigned:C\",\"versioned:C\"]"]
  StateTransitionCount  2
  HistoryLength         2
  HistorySize           263
```

## Why?
<!-- Tell your future self why have you made these changes -->
This is an important attribute for WFs running on versioned workers.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit test added.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No.