### PR TITLE
Specify go compiler minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/cli
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/alitto/pond v1.8.3


### PR DESCRIPTION
## What was changed?
Specify minor version of Go compiler

## Why?
It's now required. See https://github.com/golang/go/issues/65568. Without it on MacOS I get
```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

## How did you test it?
`go mod tidy && go build -o temporal ./cmd/temporal/main.go`
