### PR TITLE
Fix setting env name with a property

### DIFF
--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -89,6 +89,8 @@ func NewCommandContext(ctx context.Context, options CommandOptions) (*CommandCon
 	return cctx, stop, nil
 }
 
+const temporalEnv = "TEMPORAL_ENV"
+
 func (c *CommandContext) preprocessOptions() error {
 	if len(c.Options.Args) == 0 {
 		c.Options.Args = os.Args[1:]
@@ -123,6 +125,9 @@ func (c *CommandContext) preprocessOptions() error {
 
 		if c.Options.EnvConfigName == "" {
 			c.Options.EnvConfigName = "default"
+			if envVal, ok := c.Options.LookupEnv(temporalEnv); ok {
+				c.Options.EnvConfigName = envVal
+			}
 			// Default to --env, prefetched from CLI args
 			for i, arg := range c.Options.Args {
 				if arg == "--env" && i+1 < len(c.Options.Args) {

--- a/temporalcli/commands.workflow_exec_test.go
+++ b/temporalcli/commands.workflow_exec_test.go
@@ -489,6 +489,21 @@ func (s *SharedServerSuite) TestWorkflow_Execute_EnvConfig() {
 	)
 	s.NoError(res.Err)
 	s.ContainsOnSameLine(res.Stdout.String(), "Result", `"env-conf-input"`)
+
+	// And we can specify `env` with a property
+	s.NoError(os.Setenv("TEMPORAL_ENV", "myenv"))
+	defer os.Unsetenv("TEMPORAL_ENV")
+	res = s.Execute(
+		"workflow", "execute",
+		"--env-file", tmpFile.Name(),
+		"--address", s.Address(),
+		"--task-queue", s.Worker().Options.TaskQueue,
+		"--type", "DevWorkflow",
+		"--workflow-id", "my-id3",
+	)
+	s.NoError(res.Err)
+	s.ContainsOnSameLine(res.Stdout.String(), "Result", `"env-conf-input"`)
+
 }
 
 func (s *SharedServerSuite) TestWorkflow_Execute_CodecEndpoint() {

--- a/temporalcli/commands.workflow_exec_test.go
+++ b/temporalcli/commands.workflow_exec_test.go
@@ -491,8 +491,12 @@ func (s *SharedServerSuite) TestWorkflow_Execute_EnvConfig() {
 	s.ContainsOnSameLine(res.Stdout.String(), "Result", `"env-conf-input"`)
 
 	// And we can specify `env` with a property
-	s.NoError(os.Setenv("TEMPORAL_ENV", "myenv"))
-	defer os.Unsetenv("TEMPORAL_ENV")
+	s.CommandHarness.Options.LookupEnv = func(key string) (string, bool) {
+		if key == "TEMPORAL_ENV" {
+			return "myenv", true
+		}
+		return "", false
+	}
 	res = s.Execute(
 		"workflow", "execute",
 		"--env-file", tmpFile.Name(),


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Ensure that we read the property `TEMPORAL_ENV`, which sets then env name,
early on, i.e., in `preprocessOptions`.
## Why?
Otherwise it is too late to have an effect...

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#541 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added a system test
3. Any docs updates needed?
No
