### PR TITLE
Update the docker-builds repo when releases are published

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -1,0 +1,38 @@
+name: 'Trigger Docker image build'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger:
+    name: 'trigger Docker image build'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Get git branch name
+        id: get_branch
+        run: |
+          echo branch="${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private_key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
+      - name: Dispatch docker builds Github Action
+        env:
+          PAT: ${{ steps.generate_token.outputs.token }}
+          PARENT_REPO: temporalio/docker-builds
+          PARENT_BRANCH: ${{ toJSON('main') }}
+          WORKFLOW_ID: update-submodules.yml
+          REPO: ${{ toJSON('cli') }}
+          BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
+        run: |
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$GITHUB_SHA"' }}'


### PR DESCRIPTION
## What was changed
I added a GitHub workflow that will keep the CLI submodule in [temporalio/docker-builds](https://github.com/temporalio/docker-builds) up to date with new CLI releases.

As part of this change we're updating our internal release processes to include releasing a new version of `temporalio/admin-tools` whenever a release to the CLI is made.

## Why?
So that we always use the most recent CLI when building containers.
