### PR TITLE
Use server's timestamp.ParseDuration for all durations

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -650,8 +650,8 @@ func NewTemporalOperatorNamespaceCreateCommand(cctx *CommandContext, parent *Tem
 	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.HistoryArchivalState, "history-archival-state", "History archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.HistoryUri, "history-uri", "", "Optionally specify history archival URI (cannot be changed after first time archival is enabled).")
-	s.Command.Flags().Var(&s.Retention, "retention", "Length of time a closed Workflow is preserved before deletion.")
 	s.Retention = Duration(259200000 * time.Millisecond)
+	s.Command.Flags().Var(&s.Retention, "retention", "Length of time a closed Workflow is preserved before deletion.")
 	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "disabled")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
@@ -771,8 +771,8 @@ func NewTemporalOperatorNamespaceUpdateCommand(cctx *CommandContext, parent *Tem
 	s.HistoryArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "")
 	s.Command.Flags().Var(&s.HistoryArchivalState, "history-archival-state", "History archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.HistoryUri, "history-uri", "", "Optionally specify history archival URI (cannot be changed after first time archival is enabled).")
-	s.Command.Flags().Var(&s.Retention, "retention", "Length of time a closed Workflow is preserved before deletion.")
 	s.Retention = 0
+	s.Command.Flags().Var(&s.Retention, "retention", "Length of time a closed Workflow is preserved before deletion.")
 	s.VisibilityArchivalState = NewStringEnum([]string{"disabled", "enabled"}, "")
 	s.Command.Flags().Var(&s.VisibilityArchivalState, "visibility-archival-state", "Visibility archival state. Accepted values: disabled, enabled.")
 	s.Command.Flags().StringVar(&s.VisibilityUri, "visibility-uri", "", "Optionally specify visibility archival URI (cannot be changed after first time archival is enabled).")
@@ -985,13 +985,13 @@ type ScheduleConfigurationOptions struct {
 
 func (v *ScheduleConfigurationOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
 	f.StringArrayVar(&v.Calendar, "calendar", nil, "Calendar specification in JSON, e.g. `{\"dayOfWeek\":\"Fri\",\"hour\":\"17\",\"minute\":\"5\"}`.")
-	f.Var(&v.CatchupWindow, "catchup-window", "Maximum allowed catch-up time if server is down.")
 	v.CatchupWindow = 0
+	f.Var(&v.CatchupWindow, "catchup-window", "Maximum allowed catch-up time if server is down.")
 	f.StringArrayVar(&v.Cron, "cron", nil, "Calendar spec in cron string format, e.g. `3 11 * * Fri`.")
 	f.Var(&v.EndTime, "end-time", "Overall schedule end time.")
 	f.StringArrayVar(&v.Interval, "interval", nil, "Interval duration, e.g. 90m, or 90m/13m to include phase offset.")
-	f.Var(&v.Jitter, "jitter", "Per-action jitter range.")
 	v.Jitter = 0
+	f.Var(&v.Jitter, "jitter", "Per-action jitter range.")
 	f.StringVar(&v.Notes, "notes", "", "Initial value of notes field.")
 	f.BoolVar(&v.Paused, "paused", false, "Initial value of paused state.")
 	f.BoolVar(&v.PauseOnFailure, "pause-on-failure", false, "Pause schedule after any workflow failure.")
@@ -2062,12 +2062,12 @@ func (v *SharedWorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.F
 	_ = cobra.MarkFlagRequired(f, "type")
 	f.StringVarP(&v.TaskQueue, "task-queue", "t", "", "Workflow Task queue.")
 	_ = cobra.MarkFlagRequired(f, "task-queue")
-	f.Var(&v.RunTimeout, "run-timeout", "Timeout of a Workflow Run.")
 	v.RunTimeout = 0
-	f.Var(&v.ExecutionTimeout, "execution-timeout", "Timeout for a WorkflowExecution, including retries and ContinueAsNew tasks.")
+	f.Var(&v.RunTimeout, "run-timeout", "Timeout of a Workflow Run.")
 	v.ExecutionTimeout = 0
-	f.Var(&v.TaskTimeout, "task-timeout", "Start-to-close timeout for a Workflow Task.")
+	f.Var(&v.ExecutionTimeout, "execution-timeout", "Timeout for a WorkflowExecution, including retries and ContinueAsNew tasks.")
 	v.TaskTimeout = Duration(10000 * time.Millisecond)
+	f.Var(&v.TaskTimeout, "task-timeout", "Start-to-close timeout for a Workflow Task.")
 	f.StringArrayVar(&v.SearchAttribute, "search-attribute", nil, "Passes Search Attribute in key=value format. Use valid JSON formats for value.")
 	f.StringArrayVar(&v.Memo, "memo", nil, "Passes Memo in key=value format. Use valid JSON formats for value.")
 }
@@ -2082,8 +2082,8 @@ type WorkflowStartOptions struct {
 func (v *WorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
 	f.StringVar(&v.Cron, "cron", "", "Cron schedule for the workflow. Deprecated - use schedules instead.")
 	f.BoolVar(&v.FailExisting, "fail-existing", false, "Fail if the workflow already exists.")
-	f.Var(&v.StartDelay, "start-delay", "Specify a delay before the workflow starts. Cannot be used with a cron schedule. If the workflow receives a signal or update before the delay has elapsed, it will begin immediately.")
 	v.StartDelay = 0
+	f.Var(&v.StartDelay, "start-delay", "Specify a delay before the workflow starts. Cannot be used with a cron schedule. If the workflow receives a signal or update before the delay has elapsed, it will begin immediately.")
 	f.StringVar(&v.IdReusePolicy, "id-reuse-policy", "", "Allows the same Workflow Id to be used in a new Workflow Execution. Accepted values: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning.")
 }
 

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -57,7 +57,7 @@ func (c *TemporalOperatorNamespaceCreateCommand) run(cctx *CommandContext, args 
 		Namespace:                        nsName,
 		Description:                      c.Description,
 		OwnerEmail:                       c.Email,
-		WorkflowExecutionRetentionPeriod: durationpb.New(c.Retention),
+		WorkflowExecutionRetentionPeriod: durationpb.New(c.Retention.Duration()),
 		Clusters:                         clusters,
 		ActiveClusterName:                c.ActiveCluster,
 		Data:                             data,
@@ -255,7 +255,7 @@ func (c *TemporalOperatorNamespaceUpdateCommand) run(cctx *CommandContext, args 
 		}
 
 		if c.Retention > 0 {
-			retention = durationpb.New(c.Retention)
+			retention = durationpb.New(c.Retention.Duration())
 		}
 
 		var clusters []*replication.ClusterReplicationConfig

--- a/temporalcli/commands.operator_namespace_test.go
+++ b/temporalcli/commands.operator_namespace_test.go
@@ -78,7 +78,7 @@ func (s *SharedServerSuite) TestNamespaceUpdate() {
 		"--address", s.Address(),
 		"--description", "description after",
 		"--email", "email@after",
-		"--retention", "48h",
+		"--retention", "2d",
 		"--data", "k1=v1",
 		"--data", "k2=v2",
 		"--output", "json",

--- a/temporalcli/commands.schedule.go
+++ b/temporalcli/commands.schedule.go
@@ -223,7 +223,7 @@ func toIntervalSpec(str string) (client.ScheduleIntervalSpec, error) {
 func (c *ScheduleConfigurationOptions) toScheduleSpec(spec *client.ScheduleSpec) error {
 	spec.CronExpressions = c.Cron
 	// Skip not supported
-	spec.Jitter = c.Jitter
+	spec.Jitter = c.Jitter.Duration()
 	spec.TimeZoneName = c.TimeZone
 	spec.StartAt = c.StartTime.Time()
 	spec.EndAt = c.EndTime.Time()
@@ -289,7 +289,7 @@ func (c *TemporalScheduleCreateCommand) run(cctx *CommandContext, args []string)
 		PauseOnFailure:   c.PauseOnFailure,
 		Note:             c.Notes,
 		Paused:           c.Paused,
-		CatchupWindow:    c.CatchupWindow,
+		CatchupWindow:    c.CatchupWindow.Duration(),
 		RemainingActions: c.RemainingActions,
 		// TriggerImmediately not supported
 		// ScheduleBackfill not supported
@@ -517,7 +517,7 @@ func (c *TemporalScheduleUpdateCommand) run(cctx *CommandContext, args []string)
 	newSchedule := client.Schedule{
 		Spec: &client.ScheduleSpec{},
 		Policy: &client.SchedulePolicies{
-			CatchupWindow:  c.CatchupWindow,
+			CatchupWindow:  c.CatchupWindow.Duration(),
 			PauseOnFailure: c.PauseOnFailure,
 		},
 		State: &client.ScheduleState{

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -248,12 +248,12 @@ func buildStartOptions(sw *SharedWorkflowStartOptions, w *WorkflowStartOptions) 
 	o := client.StartWorkflowOptions{
 		ID:                                       sw.WorkflowId,
 		TaskQueue:                                sw.TaskQueue,
-		WorkflowRunTimeout:                       sw.RunTimeout,
-		WorkflowExecutionTimeout:                 sw.ExecutionTimeout,
-		WorkflowTaskTimeout:                      sw.TaskTimeout,
+		WorkflowRunTimeout:                       sw.RunTimeout.Duration(),
+		WorkflowExecutionTimeout:                 sw.ExecutionTimeout.Duration(),
+		WorkflowTaskTimeout:                      sw.TaskTimeout.Duration(),
 		CronSchedule:                             w.Cron,
 		WorkflowExecutionErrorWhenAlreadyStarted: w.FailExisting,
-		StartDelay:                               w.StartDelay,
+		StartDelay:                               w.StartDelay.Duration(),
 	}
 	if w.IdReusePolicy != "" {
 		var err error

--- a/temporalcli/commandsmd/code.go
+++ b/temporalcli/commandsmd/code.go
@@ -336,15 +336,16 @@ func (c *CommandOption) writeFlagBuilding(selfVar, flagVar string, w *codeWriter
 		desc += fmt.Sprintf(" Accepted values: %s.", strings.Join(c.EnumValues, ", "))
 	}
 
+	if setDefault != "" {
+		// set default before calling Var so that it stores thedefault value into the flag
+		w.writeLinef("%v.%v = %v", selfVar, c.fieldName(), setDefault)
+	}
 	if c.Alias == "" {
 		w.writeLinef("%v.%v(&%v.%v, %q%v, %q)",
 			flagVar, flagMeth, selfVar, c.fieldName(), c.Name, defaultLit, desc)
 	} else {
 		w.writeLinef("%v.%vP(&%v.%v, %q, %q%v, %q)",
 			flagVar, flagMeth, selfVar, c.fieldName(), c.Name, c.Alias, defaultLit, desc)
-	}
-	if setDefault != "" {
-		w.writeLinef("%v.%v = %v", selfVar, c.fieldName(), setDefault)
 	}
 	if c.Required {
 		w.writeLinef("_ = %v.MarkFlagRequired(%v, %q)", w.importCobra(), flagVar, c.Name)

--- a/temporalcli/duration.go
+++ b/temporalcli/duration.go
@@ -1,0 +1,30 @@
+package temporalcli
+
+import (
+	"time"
+
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+type Duration time.Duration
+
+func (d Duration) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+func (d *Duration) String() string {
+	return d.Duration().String()
+}
+
+func (d *Duration) Set(s string) error {
+	p, err := timestamp.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(p)
+	return nil
+}
+
+func (d *Duration) Type() string {
+	return "duration"
+}


### PR DESCRIPTION
## What was changed
Use server `timestamp.ParseDuration` for parsing durations in flags. This supports a `d` suffix for multiples of 24 hours.

## Why?
Convenience and compatibility.

## Checklist
2. How was this tested:
Modified namespace test.
