### PR TITLE
Setting host level mutable state cache size to 8k

### DIFF
--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -200,14 +200,15 @@ func (s *StartOptions) buildServerOptions() ([]temporal.ServerOption, error) {
 		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return claimMapper }),
 	}
 
+	// Setting host level mutable state cache size to 8k.
+	dynConf := make(dynamicconfig.StaticClient, len(s.DynamicConfigValues)+1)
+	dynConf[dynamicconfig.HistoryCacheHostLevelMaxSize] = 8096
+
 	// Dynamic config if set
-	if len(s.DynamicConfigValues) > 0 {
-		dynConf := make(dynamicconfig.StaticClient, len(s.DynamicConfigValues))
-		for k, v := range s.DynamicConfigValues {
-			dynConf[dynamicconfig.Key(k)] = v
-		}
-		opts = append(opts, temporal.WithDynamicConfigClient(dynConf))
+	for k, v := range s.DynamicConfigValues {
+		dynConf[dynamicconfig.Key(k)] = v
 	}
+	opts = append(opts, temporal.WithDynamicConfigClient(dynConf))
 
 	// gRPC interceptors if set
 	if len(s.GRPCInterceptors) > 0 {


### PR DESCRIPTION
## What was changed
Setting the size of host level mutable state cache to 8k.

## Why?
There is a pending change is server repo(https://github.com/temporalio/temporal/pull/5894) that will enable host-level mutable state cache. This cache was shard-level with a size of 512. Cli server will only have one shard. Host level cache has a default size of 128k to accomodate for all shards. But this size is too big a cluster with 1 shard. Setting this size to more reasonable 8k for server started from cli command.

## Checklist

1. Closes

2. How was this tested:

3. Any docs updates needed?
