### PR TITLE
Normalize --name and --type flags on workflow commands

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -100,10 +100,10 @@ func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalAc
 	}
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().StringVar(&s.ActivityId, "activity-id", "", "The Activity to be completed.")
+	s.Command.Flags().StringVar(&s.ActivityId, "activity-id", "", "The Activity to be completed. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of user submitting this request.")
-	s.Command.Flags().StringVar(&s.Result, "result", "", "The result with which to complete the Activity (JSON).")
+	s.Command.Flags().StringVar(&s.Result, "result", "", "The result with which to complete the Activity (JSON). Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "result")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -136,7 +136,7 @@ func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivi
 	}
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().StringVar(&s.ActivityId, "activity-id", "", "The Activity to be failed.")
+	s.Command.Flags().StringVar(&s.ActivityId, "activity-id", "", "The Activity to be failed. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVar(&s.Detail, "detail", "", "JSON data describing reason for failing the Activity.")
 	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of user submitting this request.")
@@ -187,7 +187,7 @@ func NewTemporalBatchDescribeCommand(cctx *CommandContext, parent *TemporalBatch
 		s.Command.Long = "The temporal batch describe command shows the progress of an ongoing Batch Job.\n\n`temporal batch describe --job-id=MyJobId`"
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.JobId, "job-id", "", "The Batch Job Id to describe.")
+	s.Command.Flags().StringVar(&s.JobId, "job-id", "", "The Batch Job Id to describe. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "job-id")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -243,9 +243,9 @@ func NewTemporalBatchTerminateCommand(cctx *CommandContext, parent *TemporalBatc
 		s.Command.Long = "The temporal batch terminate command terminates a Batch Job with the provided Job Id.\nFor future reference, provide a reason for terminating the Batch Job.\n\n`temporal batch terminate --job-id=MyJobId --reason=JobReason`"
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.JobId, "job-id", "", "The Batch Job Id to terminate.")
+	s.Command.Flags().StringVar(&s.JobId, "job-id", "", "The Batch Job Id to terminate. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "job-id")
-	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason for terminating the Batch Job.")
+	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Reason for terminating the Batch Job. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "reason")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -528,7 +528,7 @@ func NewTemporalOperatorClusterRemoveCommand(cctx *CommandContext, parent *Tempo
 		s.Command.Long = "`temporal operator cluster remove` command removes a remote Cluster from the system."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.Name, "name", "", "Name of cluster.")
+	s.Command.Flags().StringVar(&s.Name, "name", "", "Name of cluster. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -582,7 +582,7 @@ func NewTemporalOperatorClusterUpsertCommand(cctx *CommandContext, parent *Tempo
 		s.Command.Long = "`temporal operator cluster upsert` command allows the user to add or update a remote Cluster."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.FrontendAddress, "frontend-address", "", "IP address to bind the frontend service to.")
+	s.Command.Flags().StringVar(&s.FrontendAddress, "frontend-address", "", "IP address to bind the frontend service to. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "frontend-address")
 	s.Command.Flags().BoolVar(&s.EnableConnection, "enable-connection", false, "enable cross cluster connection.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -825,9 +825,9 @@ func NewTemporalOperatorSearchAttributeCreateCommand(cctx *CommandContext, paren
 		s.Command.Long = "`temporal operator search-attribute create` command adds one or more custom Search Attributes."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringArrayVar(&s.Name, "name", nil, "Search Attribute name.")
+	s.Command.Flags().StringArrayVar(&s.Name, "name", nil, "Search Attribute name. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
-	s.Command.Flags().StringArrayVar(&s.Type, "type", nil, "Search Attribute type. Accepted values: Text, Keyword, Int, Double, Bool, Datetime, KeywordList.")
+	s.Command.Flags().StringArrayVar(&s.Type, "type", nil, "Search Attribute type. Accepted values: Text, Keyword, Int, Double, Bool, Datetime, KeywordList. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "type")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -881,7 +881,7 @@ func NewTemporalOperatorSearchAttributeRemoveCommand(cctx *CommandContext, paren
 		s.Command.Long = "`temporal operator search-attribute remove` command removes custom Search Attribute metadata."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringArrayVar(&s.Name, "name", nil, "Search Attribute name.")
+	s.Command.Flags().StringArrayVar(&s.Name, "name", nil, "Search Attribute name. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
 	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Confirm prompt to perform deletion.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -931,7 +931,7 @@ type ScheduleIdOptions struct {
 }
 
 func (v *ScheduleIdOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
-	f.StringVarP(&v.ScheduleId, "schedule-id", "s", "", "Schedule id.")
+	f.StringVarP(&v.ScheduleId, "schedule-id", "s", "", "Schedule id. Required.")
 	_ = cobra.MarkFlagRequired(f, "schedule-id")
 }
 
@@ -958,9 +958,9 @@ func NewTemporalScheduleBackfillCommand(cctx *CommandContext, parent *TemporalSc
 	s.Command.Args = cobra.NoArgs
 	s.OverlapPolicyOptions.buildFlags(cctx, s.Command.Flags())
 	s.ScheduleIdOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().Var(&s.EndTime, "end-time", "Backfill end time.")
+	s.Command.Flags().Var(&s.EndTime, "end-time", "Backfill end time. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "end-time")
-	s.Command.Flags().Var(&s.StartTime, "start-time", "Backfill start time.")
+	s.Command.Flags().Var(&s.StartTime, "start-time", "Backfill start time. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "start-time")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -1332,7 +1332,7 @@ func NewTemporalTaskQueueDescribeCommand(cctx *CommandContext, parent *TemporalT
 		s.Command.Long = "The `temporal task-queue describe` command provides poller\ninformation for a given Task Queue.\n\nThe Server records the last time of each poll request. A `LastAccessTime` value\nin excess of one minute can indicate the Worker is at capacity (all Workflow and Activity slots are full) or that the\nWorker has shut down. Workers are removed if 5 minutes have passed since the last poll\nrequest.\n\nInformation about the Task Queue can be returned to troubleshoot server issues.\n\n`temporal task-queue describe --task-queue=MyTaskQueue --task-queue-type=\"activity\"`\n\nUse the options listed below to modify what this command returns."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.TaskQueueType = NewStringEnum([]string{"workflow", "activity"}, "workflow")
 	s.Command.Flags().Var(&s.TaskQueueType, "task-queue-type", "Task Queue type. Accepted values: workflow, activity.")
@@ -1388,7 +1388,7 @@ func NewTemporalTaskQueueGetBuildIdsCommand(cctx *CommandContext, parent *Tempor
 	s.Command.Short = "Fetch the sets of worker Build ID versions on the Task Queue."
 	s.Command.Long = "Fetch the sets of compatible build IDs associated with a Task Queue and associated information."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.Command.Flags().IntVar(&s.MaxSets, "max-sets", 0, "Limits how many compatible sets will be returned. Specify 1 to only return the current default major version set. 0 returns all sets. (default: 0).")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -1413,7 +1413,7 @@ func NewTemporalTaskQueueListPartitionCommand(cctx *CommandContext, parent *Temp
 	s.Command.Short = "Lists the Task Queue's partitions and the matching nodes they are assigned to."
 	s.Command.Long = "The temporal task-queue list-partition command displays the partitions of a Task Queue, along with the matching node they are assigned to."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Task queue name. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -1459,11 +1459,11 @@ func NewTemporalTaskQueueUpdateBuildIdsAddNewCompatibleCommand(cctx *CommandCont
 	s.Command.Short = "Add a new build ID compatible with an existing ID to the Task Queue version sets."
 	s.Command.Long = "The new build ID will become the default for the set containing the existing ID. See per-flag help for more."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "The new build id to be added.")
+	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "The new build id to be added. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "build-id")
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
-	s.Command.Flags().StringVar(&s.ExistingCompatibleBuildId, "existing-compatible-build-id", "", "A build id which must already exist in the version sets known by the task queue. The new id will be stored in the set containing this id, marking it as compatible with the versions within.")
+	s.Command.Flags().StringVar(&s.ExistingCompatibleBuildId, "existing-compatible-build-id", "", "A build id which must already exist in the version sets known by the task queue. The new id will be stored in the set containing this id, marking it as compatible with the versions within. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "existing-compatible-build-id")
 	s.Command.Flags().BoolVar(&s.SetAsDefault, "set-as-default", false, "When set, establishes the compatible set being targeted as the overall default for the queue. If a different set was the current default, the targeted set will replace it as the new default. Defaults to false.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -1489,9 +1489,9 @@ func NewTemporalTaskQueueUpdateBuildIdsAddNewDefaultCommand(cctx *CommandContext
 	s.Command.Short = "Add a new default (incompatible) build ID to the Task Queue version sets."
 	s.Command.Long = "Creates a new build id set which will become the new overall default for the queue with the provided build id as its only member. This new set is incompatible with all previous sets/versions."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "The new build id to be added.")
+	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "The new build id to be added. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "build-id")
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -1516,9 +1516,9 @@ func NewTemporalTaskQueueUpdateBuildIdsPromoteIdInSetCommand(cctx *CommandContex
 	s.Command.Short = "Promote an existing build ID to become the default for its containing set."
 	s.Command.Long = "New tasks compatible with the set will be dispatched to the default id."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "An existing build id which will be promoted to be the default inside its containing set.")
+	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "An existing build id which will be promoted to be the default inside its containing set. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "build-id")
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -1543,9 +1543,9 @@ func NewTemporalTaskQueueUpdateBuildIdsPromoteSetCommand(cctx *CommandContext, p
 	s.Command.Short = "Promote an existing build ID set to become the default for the Task Queue."
 	s.Command.Long = "If the set is already the default, this command has no effect."
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "An existing build id whose containing set will be promoted.")
+	s.Command.Flags().StringVar(&s.BuildId, "build-id", "", "An existing build id whose containing set will be promoted. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "build-id")
-	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue.")
+	s.Command.Flags().StringVarP(&s.TaskQueue, "task-queue", "t", "", "Name of the Task Queue. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "task-queue")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
@@ -1729,7 +1729,7 @@ type WorkflowReferenceOptions struct {
 }
 
 func (v *WorkflowReferenceOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
-	f.StringVarP(&v.WorkflowId, "workflow-id", "w", "", "Workflow Id.")
+	f.StringVarP(&v.WorkflowId, "workflow-id", "w", "", "Workflow Id. Required.")
 	_ = cobra.MarkFlagRequired(f, "workflow-id")
 	f.StringVarP(&v.RunId, "run-id", "r", "", "Run Id.")
 }
@@ -1817,7 +1817,7 @@ func NewTemporalWorkflowFixHistoryJsonCommand(cctx *CommandContext, parent *Temp
 		s.Command.Long = "```\ntemporal workflow fix-history-json \\\n\t--source original.json \\\n\t--target reserialized.json\n```\n\nUse the options listed below to change the command's behavior."
 	}
 	s.Command.Args = cobra.NoArgs
-	s.Command.Flags().StringVarP(&s.Source, "source", "s", "", "Path to the input file.")
+	s.Command.Flags().StringVarP(&s.Source, "source", "s", "", "Path to the input file. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "source")
 	s.Command.Flags().StringVarP(&s.Target, "target", "t", "", "Path to the output file, or standard output if not set.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -1864,7 +1864,7 @@ type TemporalWorkflowQueryCommand struct {
 	Command cobra.Command
 	PayloadInputOptions
 	WorkflowReferenceOptions
-	Type            string
+	Name            string
 	RejectCondition StringEnum
 }
 
@@ -1882,10 +1882,13 @@ func NewTemporalWorkflowQueryCommand(cctx *CommandContext, parent *TemporalWorkf
 	s.Command.Args = cobra.NoArgs
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().StringVar(&s.Type, "type", "", "Query Type/Name.")
-	_ = cobra.MarkFlagRequired(s.Command.Flags(), "type")
+	s.Command.Flags().StringVar(&s.Name, "name", "", "Query Type/Name. Required. Aliased as \"--type\".")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
 	s.RejectCondition = NewStringEnum([]string{"not_open", "not_completed_cleanly"}, "")
 	s.Command.Flags().Var(&s.RejectCondition, "reject-condition", "Optional flag for rejecting Queries based on Workflow state. Accepted values: not_open, not_completed_cleanly.")
+	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
+		"type": "name",
+	}))
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -1923,7 +1926,7 @@ func NewTemporalWorkflowResetCommand(cctx *CommandContext, parent *TemporalWorkf
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow Id. Required for non-batch reset operations.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run Id.")
 	s.Command.Flags().IntVarP(&s.EventId, "event-id", "e", 0, "The Event Id for any Event after `WorkflowTaskStarted` you want to reset to (exclusive). It can be `WorkflowTaskCompleted`, `WorkflowTaskFailed` or others.")
-	s.Command.Flags().StringVar(&s.Reason, "reason", "", "The reason why this workflow is being reset.")
+	s.Command.Flags().StringVar(&s.Reason, "reason", "", "The reason why this workflow is being reset. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "reason")
 	s.ReapplyType = NewStringEnum([]string{"All", "Signal", "None"}, "All")
 	s.Command.Flags().Var(&s.ReapplyType, "reapply-type", "Event types to reapply after the reset point. Accepted values: All, Signal, None.")
@@ -2008,9 +2011,12 @@ func NewTemporalWorkflowSignalCommand(cctx *CommandContext, parent *TemporalWork
 	}
 	s.Command.Args = cobra.NoArgs
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().StringVar(&s.Name, "name", "", "Signal Name.")
+	s.Command.Flags().StringVar(&s.Name, "name", "", "Signal Name. Required. Aliased as \"--type\".")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
 	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
+	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
+		"type": "name",
+	}))
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -2062,9 +2068,9 @@ type SharedWorkflowStartOptions struct {
 
 func (v *SharedWorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
 	f.StringVarP(&v.WorkflowId, "workflow-id", "w", "", "Workflow Id.")
-	f.StringVar(&v.Type, "type", "", "Workflow Type name.")
+	f.StringVar(&v.Type, "type", "", "Workflow Type name. Required. Aliased as \"--name\".")
 	_ = cobra.MarkFlagRequired(f, "type")
-	f.StringVarP(&v.TaskQueue, "task-queue", "t", "", "Workflow Task queue.")
+	f.StringVarP(&v.TaskQueue, "task-queue", "t", "", "Workflow Task queue. Required.")
 	_ = cobra.MarkFlagRequired(f, "task-queue")
 	v.RunTimeout = 0
 	f.Var(&v.RunTimeout, "run-timeout", "Timeout of a Workflow Run.")
@@ -2230,13 +2236,16 @@ func NewTemporalWorkflowUpdateCommand(cctx *CommandContext, parent *TemporalWork
 	}
 	s.Command.Args = cobra.NoArgs
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().StringVar(&s.Name, "name", "", "Update Name.")
+	s.Command.Flags().StringVar(&s.Name, "name", "", "Update Name. Required. Aliased as \"--type\".")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "name")
-	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow Id.")
+	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow Id. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "workflow-id")
 	s.Command.Flags().StringVar(&s.UpdateId, "update-id", "", "Update ID. If unset, default to a UUID.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run Id. If unset, the currently running Workflow Execution receives the Update.")
 	s.Command.Flags().StringVar(&s.FirstExecutionRunId, "first-execution-run-id", "", "Send the Update to the last Workflow Execution in the chain that started with this Run Id.")
+	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
+		"type": "name",
+	}))
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1790,6 +1790,9 @@ func NewTemporalWorkflowExecuteCommand(cctx *CommandContext, parent *TemporalWor
 	s.WorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, include event details JSON in printed output. If set when using JSON output, this will include the entire \"history\" JSON key of the started run (does not follow runs).")
+	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
+		"name": "type",
+	}))
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -2134,6 +2137,9 @@ func NewTemporalWorkflowStartCommand(cctx *CommandContext, parent *TemporalWorkf
 	s.SharedWorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.WorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
+	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
+		"name": "type",
+	}))
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -499,6 +499,15 @@ func writeEnvConfigFile(file string, env map[string]map[string]string) error {
 	return nil
 }
 
+func aliasNormalizer(aliases map[string]string) func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	return func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		if actual := aliases[name]; actual != "" {
+			name = actual
+		}
+		return pflag.NormalizedName(name)
+	}
+}
+
 func newNopLogger() *slog.Logger { return slog.New(discardLogHandler{}) }
 
 type discardLogHandler struct{}

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -84,7 +84,7 @@ func (c *TemporalWorkflowDeleteCommand) run(cctx *CommandContext, args []string)
 
 func (c *TemporalWorkflowQueryCommand) run(cctx *CommandContext, args []string) error {
 	return queryHelper(cctx, c.Parent, c.PayloadInputOptions,
-		c.Type, c.RejectCondition, c.WorkflowReferenceOptions)
+		c.Name, c.RejectCondition, c.WorkflowReferenceOptions)
 }
 
 func (c *TemporalWorkflowSignalCommand) run(cctx *CommandContext, args []string) error {

--- a/temporalcli/commands.workflow_exec_test.go
+++ b/temporalcli/commands.workflow_exec_test.go
@@ -55,7 +55,8 @@ func (s *SharedServerSuite) TestWorkflow_Start_SimpleSuccess() {
 		"-o", "json",
 		"--address", s.Address(),
 		"--task-queue", s.Worker().Options.TaskQueue,
-		"--type", "DevWorkflow",
+		// Use --name here to make sure the alias works
+		"--name", "DevWorkflow",
 		"--workflow-id", "my-id2",
 	)
 	s.NoError(res.Err)

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -99,7 +99,8 @@ func (s *SharedServerSuite) testSignalBatchWorkflow(json bool) *CommandResult {
 		"workflow", "signal",
 		"--address", s.Address(),
 		"--query", "CustomKeywordField = '" + searchAttr + "'",
-		"--name", "my-signal",
+		// Use --type here to make sure the alias works
+		"--type", "my-signal",
 		"-i", `{"key": "val"}`,
 	}
 	if json {
@@ -421,12 +422,15 @@ func (s *SharedServerSuite) TestWorkflow_Update() {
 	}()
 
 	// successful update, should show the result
-	res := s.Execute("workflow", "update", "--address", s.Address(), "-w", run.GetID(), "--name", updateName, "-i", strconv.Itoa(input))
+	res := s.Execute("workflow", "update", "--address", s.Address(), "-w", run.GetID(),
+		"--name", updateName, "-i", strconv.Itoa(input))
 	s.NoError(res.Err)
 	s.Contains(res.Stdout.String(), strconv.Itoa(input))
 
 	// successful update passing first-execution-run-id
-	res = s.Execute("workflow", "update", "--address", s.Address(), "-w", run.GetID(), "--name", updateName, "-i", strconv.Itoa(input), "--first-execution-run-id", run.GetRunID())
+	res = s.Execute("workflow", "update", "--address", s.Address(), "-w", run.GetID(),
+		// Use --type here to make sure the alias works
+		"--type", updateName, "-i", strconv.Itoa(input), "--first-execution-run-id", run.GetRunID())
 	s.NoError(res.Err)
 
 	// successful update passing update-id
@@ -556,7 +560,7 @@ func (s *SharedServerSuite) testQueryWorkflow(json bool) {
 		"workflow", "query",
 		"--address", s.Address(),
 		"-w", run.GetID(),
-		"--type", "my-query",
+		"--name", "my-query",
 		"-i", `"hi"`,
 	}
 	if json {
@@ -580,6 +584,7 @@ func (s *SharedServerSuite) testQueryWorkflow(json bool) {
 		"workflow", "query",
 		"--address", s.Address(),
 		"-w", run.GetID(),
+		// Use --type here to make sure the alias works
 		"--type", "my-query",
 		"-i", `"hi"`,
 		"--reject-condition", "not_open",

--- a/temporalcli/commandsmd/code.go
+++ b/temporalcli/commandsmd/code.go
@@ -208,6 +208,7 @@ func (c *Command) writeCode(w *codeWriter) error {
 		// If there are subcommands, this needs to be persistent flags
 		flagVar = "s.Command.PersistentFlags()"
 	}
+	var flagAliases [][]string
 	for _, optSet := range c.OptionsSets {
 		// If there's a name, this is done in the method
 		if optSet.SetName != "" {
@@ -218,6 +219,20 @@ func (c *Command) writeCode(w *codeWriter) error {
 		if err := optSet.writeFlagBuilding("s", flagVar, w); err != nil {
 			return fmt.Errorf("failed building option flags: %w", err)
 		}
+		for _, opt := range optSet.Options {
+			for _, alias := range opt.Aliases {
+				flagAliases = append(flagAliases, []string{alias, opt.Name})
+			}
+		}
+	}
+	// Generate normalize
+	if len(flagAliases) > 0 {
+		sort.Slice(flagAliases, func(i, j int) bool { return flagAliases[i][0] < flagAliases[j][0] })
+		w.writeLinef("%v.SetNormalizeFunc(aliasNormalizer(map[string]string{", flagVar)
+		for _, aliases := range flagAliases {
+			w.writeLinef("%q: %q,", aliases[0], aliases[1])
+		}
+		w.writeLinef("}))")
 	}
 	// If there are no subcommands, we need a run function
 	if len(subCommands) == 0 {
@@ -339,17 +354,25 @@ func (c *CommandOption) writeFlagBuilding(selfVar, flagVar string, w *codeWriter
 	if len(c.EnumValues) > 0 {
 		desc += fmt.Sprintf(" Accepted values: %s.", strings.Join(c.EnumValues, ", "))
 	}
+	// If required, append to desc
+	if c.Required {
+		desc += " Required."
+	}
+	// If there are aliases, append to desc
+	for _, alias := range c.Aliases {
+		desc += fmt.Sprintf(` Aliased as "--%v".`, alias)
+	}
 
 	if setDefault != "" {
 		// set default before calling Var so that it stores thedefault value into the flag
 		w.writeLinef("%v.%v = %v", selfVar, c.fieldName(), setDefault)
 	}
-	if c.Alias == "" {
+	if c.Shorthand == "" {
 		w.writeLinef("%v.%v(&%v.%v, %q%v, %q)",
 			flagVar, flagMeth, selfVar, c.fieldName(), c.Name, defaultLit, desc)
 	} else {
 		w.writeLinef("%v.%vP(&%v.%v, %q, %q%v, %q)",
-			flagVar, flagMeth, selfVar, c.fieldName(), c.Name, c.Alias, defaultLit, desc)
+			flagVar, flagMeth, selfVar, c.fieldName(), c.Name, c.Shorthand, defaultLit, desc)
 	}
 	if c.Required {
 		w.writeLinef("_ = %v.MarkFlagRequired(%v, %q)", w.importCobra(), flagVar, c.Name)

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -28,6 +28,7 @@ This document has a specific structure used by a parser. Here are the rules:
         * `Default: <default-value>.` - Sets the default value of the option. No default means zero value of the type.
         * `Options: <option>, <option>.` - Sets the possible options for a string enum type.
         * `Env: <env-var>.` - Binds the environment variable to this flag.
+        * ``Alias: `--<alias>`.`` - Sets a flag as an alias of this one. The flag should not be separately defined.
       * Options should be in order of most commonly used.
     * Also can have single lines below options that say
       `Includes options set for [<options-set-name>](#options-set-for-<options-set-link-name>).` which is the equivalent
@@ -879,7 +880,7 @@ Use the options listed below to change the command's behavior.
 
 #### Options
 
-* `--type` (string) - Query Type/Name. Required.
+* `--name` (string) - Query Type/Name. Required. Alias: `--type`.
 * `--reject-condition` (string-enum) - Optional flag for rejecting Queries based on Workflow state.
   Options: not_open, not_completed_cleanly.
 
@@ -950,7 +951,7 @@ Use the options listed below to change the command's behavior.
 
 #### Options
 
-* `--name` (string) - Signal Name. Required.
+* `--name` (string) - Signal Name. Required. Alias: `--type`.
 
 Includes options set for [payload input](#options-set-for-payload-input).
 
@@ -1000,7 +1001,7 @@ temporal workflow start \
 #### Options set for shared workflow start:
 
 * `--workflow-id`, `-w` (string) - Workflow Id.
-* `--type` (string) - Workflow Type name. Required.
+* `--type` (string) - Workflow Type name. Required. Alias: `--name`.
 * `--task-queue`, `-t` (string) - Workflow Task queue. Required.
 * `--run-timeout` (duration) - Timeout of a Workflow Run.
 * `--execution-timeout` (duration) - Timeout for a WorkflowExecution, including retries and ContinueAsNew tasks.
@@ -1087,7 +1088,7 @@ Use the options listed below to change the command's behavior.
 
 #### Options
 
-* `--name` (string) - Update Name. Required.
+* `--name` (string) - Update Name. Required. Alias: `--type`.
 * `--workflow-id`, `-w` (string) - Workflow Id. Required.
 * `--update-id` (string) - Update ID. If unset, default to a UUID.
 * `--run-id`, `-r` (string) - Run Id. If unset, the currently running Workflow Execution receives the Update.

--- a/temporalcli/commandsmd/parse.go
+++ b/temporalcli/commandsmd/parse.go
@@ -37,13 +37,14 @@ type CommandOptions struct {
 
 type CommandOption struct {
 	Name         string
-	Alias        string
+	Shorthand    string
 	DataType     string
 	Desc         string
 	Required     bool
 	DefaultValue string
 	EnumValues   []string
 	EnvVar       string
+	Aliases      []string
 }
 
 func ParseMarkdownCommands() ([]*Command, error) {
@@ -229,16 +230,16 @@ func (c *CommandOption) parseBulletLine(bullet string) error {
 	c.Name = strings.TrimPrefix(bullet[:tickEnd], "--")
 	bullet = strings.TrimSpace(bullet[tickEnd+1:])
 
-	// Alias
+	// Shorthand
 	if strings.HasPrefix(bullet, ", `") {
 		bullet = strings.TrimPrefix(bullet, ", `")
 		tickEnd = strings.Index(bullet, "`")
 		if tickEnd == -1 {
 			return fmt.Errorf("missing ending backtick")
 		} else if !strings.HasPrefix(bullet, "-") {
-			return fmt.Errorf("option alias %q does not have leading '-'", bullet[:tickEnd])
+			return fmt.Errorf("option shorthand %q does not have leading '-'", bullet[:tickEnd])
 		}
-		c.Alias = strings.TrimPrefix(bullet[:tickEnd], "-")
+		c.Shorthand = strings.TrimPrefix(bullet[:tickEnd], "-")
 		bullet = strings.TrimSpace(bullet[tickEnd+1:])
 	}
 
@@ -276,6 +277,8 @@ func (c *CommandOption) parseBulletLine(bullet string) error {
 			c.EnumValues = strings.Split(strings.TrimPrefix(lastSentence, "Options: "), ", ")
 		case strings.HasPrefix(lastSentence, "Env: "):
 			c.EnvVar = strings.TrimPrefix(lastSentence, "Env: ")
+		case strings.HasPrefix(lastSentence, "Alias: `--"):
+			c.Aliases = append(c.Aliases, strings.TrimSuffix(strings.TrimPrefix(lastSentence, "Alias: `--"), "`"))
 		default:
 			return nil
 		}


### PR DESCRIPTION
## What was changed

* Added support new `Alias` option for command options
* Added `--name` as an alias for `--type` for all workflow start/execute commands. `--type` is clearer for workflow start IMO.
* Added `--type` as an alias for `--name` for all workflow interaction commands (signal, query, update). `--name` is clearer for these IMO.
* Made sure option descriptions mention if they are required and what their aliases are.

## Checklist

1. Closes #475
