### PR TITLE
Use static membership for devserver

### DIFF
--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -42,13 +42,19 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/membership/static"
 	"go.temporal.io/server/common/metrics"
 	sqliteplugin "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/schema/sqlite"
 	sqliteschema "go.temporal.io/server/schema/sqlite"
 	"go.temporal.io/server/temporal"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	localhost = "127.0.0.1"
 )
 
 type StartOptions struct {
@@ -195,6 +201,16 @@ func (s *StartOptions) buildServerOptions() ([]temporal.ServerOption, error) {
 	opts := []temporal.ServerOption{
 		temporal.WithConfig(conf),
 		temporal.ForServices(temporal.DefaultServices),
+		temporal.WithStaticHosts(map[primitives.ServiceName]static.Hosts{
+			primitives.FrontendService: static.SingleLocalHost(
+				fmt.Sprintf("%v:%v", localhost, conf.Services[string(primitives.FrontendService)].RPC.GRPCPort)),
+			primitives.MatchingService: static.SingleLocalHost(
+				fmt.Sprintf("%v:%v", localhost, conf.Services[string(primitives.MatchingService)].RPC.GRPCPort)),
+			primitives.HistoryService: static.SingleLocalHost(
+				fmt.Sprintf("%v:%v", localhost, conf.Services[string(primitives.HistoryService)].RPC.GRPCPort)),
+			primitives.WorkerService: static.SingleLocalHost(
+				fmt.Sprintf("%v:%v", localhost, conf.Services[string(primitives.WorkerService)].RPC.GRPCPort)),
+		}),
 		temporal.WithLogger(logger),
 		temporal.WithAuthorizer(authorizer),
 		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return claimMapper }),
@@ -332,6 +348,5 @@ func (s *StartOptions) buildServiceConfig(frontend bool) config.Service {
 		conf.RPC.GRPCPort = MustGetFreePort(s.FrontendIP)
 		conf.RPC.BindOnIP = s.FrontendIP
 	}
-	conf.RPC.MembershipPort = MustGetFreePort(s.FrontendIP)
 	return conf
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Use static membership assignment for server services.

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes https://github.com/temporalio/cli/issues/632 and https://github.com/temporalio/cli/issues/633.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

**(1) used a script to verify the behavior**

Before change:
```
go build ./cmd/temporal
Iteration 1/10
Error: 'Frontend is not healthy yet' found.
Killing the Temporal server with PID 21433...
```

```
go build ./cmd/temporal
Iteration 1/10
Killing the Temporal server with PID 21600...
Iteration 2/10
Error: 'Not enough hosts to serve the request' found.
Killing the Temporal server with PID 21613...
```

After change:
```
go build ./cmd/temporal
Iteration 1/10
Killing the Temporal server with PID 21190...
Iteration 2/10
Killing the Temporal server with PID 21198...
Iteration 3/10
Killing the Temporal server with PID 21206...
Iteration 4/10
Killing the Temporal server with PID 21214...
Iteration 5/10
Killing the Temporal server with PID 21222...
Iteration 6/10
Killing the Temporal server with PID 21230...
Iteration 7/10
Killing the Temporal server with PID 21237...
Iteration 8/10
Killing the Temporal server with PID 21243...
Iteration 9/10
Killing the Temporal server with PID 21251...
Iteration 10/10
Killing the Temporal server with PID 21257...
```

<details>
<summary>Script</summary>

```bash
#!/bin/bash

make build

SERVER_PID=0
kill_server() {
    if [ $SERVER_PID -ne 0 ]; then
        echo "Killing the Temporal server with PID $SERVER_PID..."
        kill $SERVER_PID
        wait $SERVER_PID 2>/dev/null
        SERVER_PID=0
        rm -rf server_output.log
    fi
}
trap kill_server EXIT

# Loop to run the start-stop sequence 10 times
for i in {1..10}; do
    echo "Iteration $i/10"

    ./temporal server start-dev --db-filename=/tmp/db > server_output.log 2>&1 &
    SERVER_PID=$!

    sleep 2

    if grep -q "Not enough hosts to serve the request" server_output.log; then
        echo "Error: 'Not enough hosts to serve the request' found."
        kill $SERVER_PID
        exit 1
    fi

    if grep -q "Frontend is not healthy yet" server_output.log; then
        echo "Error: 'Frontend is not healthy yet' found."
        kill $SERVER_PID
        exit 1
    fi

    kill_server

    sleep 1
done
```
</details>

**(2) ran sdk-go integration tests against dev server**

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
