### PR TITLE
Normalize semantic of --data args

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -622,7 +622,7 @@ type TemporalOperatorNamespaceCreateCommand struct {
 	Command                 cobra.Command
 	ActiveCluster           string
 	Cluster                 []string
-	Data                    string
+	Data                    []string
 	Description             string
 	Email                   string
 	Global                  bool
@@ -647,7 +647,7 @@ func NewTemporalOperatorNamespaceCreateCommand(cctx *CommandContext, parent *Tem
 	s.Command.Args = cobra.MaximumNArgs(1)
 	s.Command.Flags().StringVar(&s.ActiveCluster, "active-cluster", "", "Active cluster name.")
 	s.Command.Flags().StringArrayVar(&s.Cluster, "cluster", nil, "Cluster names.")
-	s.Command.Flags().StringVar(&s.Data, "data", "", "Namespace data in key=value format. Use JSON for values.")
+	s.Command.Flags().StringArrayVar(&s.Data, "data", nil, "Namespace data in key=value format. Use JSON for values.")
 	s.Command.Flags().StringVar(&s.Description, "description", "", "Namespace description.")
 	s.Command.Flags().StringVar(&s.Email, "email", "", "Owner email.")
 	s.Command.Flags().BoolVar(&s.Global, "global", false, "Whether the namespace is a global namespace.")

--- a/temporalcli/commands.operator_namespace.go
+++ b/temporalcli/commands.operator_namespace.go
@@ -2,7 +2,6 @@ package temporalcli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/temporalio/cli/temporalcli/internal/printer"
@@ -47,7 +46,7 @@ func (c *TemporalOperatorNamespaceCreateCommand) run(cctx *CommandContext, args 
 
 	var data map[string]string
 	if len(c.Data) > 0 {
-		data, err = stringKeysValues(strings.Split(c.Data, ","))
+		data, err = stringKeysValues(c.Data)
 		if err != nil {
 			return err
 		}

--- a/temporalcli/commands.operator_namespace_test.go
+++ b/temporalcli/commands.operator_namespace_test.go
@@ -69,6 +69,8 @@ func (s *SharedServerSuite) TestNamespaceUpdate() {
 		"--description", "description before",
 		"--email", "email@before",
 		"--retention", "24h",
+		"--data", "k1=v0",
+		"--data", "k3=v3",
 		"-n", nsName,
 	)
 	s.NoError(res.Err)
@@ -101,6 +103,7 @@ func (s *SharedServerSuite) TestNamespaceUpdate() {
 	s.Equal(48*time.Hour, describeResp.Config.WorkflowExecutionRetentionTtl.AsDuration())
 	s.Equal("v1", describeResp.NamespaceInfo.Data["k1"])
 	s.Equal("v2", describeResp.NamespaceInfo.Data["k2"])
+	s.Equal("v3", describeResp.NamespaceInfo.Data["k3"])
 }
 
 func (s *SharedServerSuite) TestNamespaceUpdate_NamespaceDontExist() {

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -310,7 +310,7 @@ For example, the Visibility Archive can be set on a separate URI.
 
 * `--active-cluster` (string) - Active cluster name.
 * `--cluster` (string[]) - Cluster names.
-* `--data` (string) - Namespace data in key=value format. Use JSON for values.
+* `--data` (string[]) - Namespace data in key=value format. Use JSON for values.
 * `--description` (string) - Namespace description.
 * `--email` (string) - Owner email.
 * `--global` (bool) - Whether the namespace is a global namespace.
@@ -1065,7 +1065,7 @@ Use the options listed below to change the behavior of this command.
 #### Options
 
 * `--fold` (string[]) - Statuses for which Child Workflows will be folded in (this will reduce the number of information fetched and displayed). Case-insensitive and ignored if no-fold supplied. Available values: running, completed, failed, canceled, terminated, timedout, continueasnew.
-* `--no-fold` (bool) - Disable folding. All Child Workflows within the set depth will be fetched and displayed. 
+* `--no-fold` (bool) - Disable folding. All Child Workflows within the set depth will be fetched and displayed.
 * `--depth` (int) - Depth of child workflows to fetch. Use -1 to fetch child workflows at any depth. Default: -1.
 * `--concurrency` (int) - Number of concurrent workflow histories that will be requested at any given time. Default: 10.
 


### PR DESCRIPTION
## What was changed

* The `--data` option on `temporal operator namespace create` now behave the same way as on `temporal operator namespace update`. That is, multiple key-value pairs can be provided by repeating the `--data` flag, like this:

  ```
  temporal operator namespace create -n foo --data key1=value1 --data key2=value2`
  ```

* 💥 **BREAKING** 💥: The former syntax allowed by the `--data` option, i.e. `--data key1=value1,key2=value2`, is no longer supported. That specific command is not frequent enough to justify soft deprecation.

## Checklist

1. Closes #552 
