### PR TITLE
Fix trigger-publish.yml to quote the commit hash

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,6 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
-          COMMIT: ${{ toJSON( ${{ github.sha }} ) }}
+          COMMIT: ${{ toJSON(github.sha) }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,6 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
-          COMMIT: ${{ toJSON(GITHUB_SHA) }}
+          COMMIT: ${{ toJSON('"$GITHUB_SHA"') }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,6 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
-          COMMIT: ${{ toJSON($GITHUB_SHA) }}
+          COMMIT: ${{ toJSON(${{ env.GITHUB_SHA }}) }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,5 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
+          COMMIT: ${{ toJSON($GITHUB_SHA) }}
         run: |
-          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$GITHUB_SHA"' }}'
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,6 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
-          COMMIT: ${{ toJSON('"$GITHUB_SHA"') }}
+          COMMIT: ${{ toJSON( ${{ github.sha }} ) }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -1,6 +1,7 @@
 name: 'Trigger Docker image build'
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -35,6 +35,6 @@ jobs:
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
           BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
-          COMMIT: ${{ toJSON(${{ env.GITHUB_SHA }}) }}
+          COMMIT: ${{ toJSON(GITHUB_SHA) }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
The github action to publish the release was not quoting the commit hash properly, creating invalid json, and making the request to fail.

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Triggering the workflow manually