### PR TITLE
Publish only non-RC releases

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger:
+    if: ${{ ! contains(github.ref, '-rc.') }}
     name: 'trigger Docker image build'
     runs-on: ubuntu-latest
 
@@ -15,11 +16,6 @@ jobs:
         shell: bash
 
     steps:
-      - name: Get git branch name
-        id: get_branch
-        run: |
-          echo branch="${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
-
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
@@ -34,7 +30,7 @@ jobs:
           PARENT_BRANCH: ${{ toJSON('main') }}
           WORKFLOW_ID: update-submodules.yml
           REPO: ${{ toJSON('cli') }}
-          BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
+          BRANCH: ${{ toJSON('main') }}
           COMMIT: ${{ toJSON(github.sha) }}
         run: |
           curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"', "commit": '"$COMMIT"' }}'


### PR DESCRIPTION
## What was changed
 Change GitHub action for publishing releases so it only updates docker images with releases that are NOT release candidates.

## Why?
<!-- Tell your future self why have you made these changes -->
Avoid publishing OSS server docker images with RC cli dependencies.
