### PR TITLE
`workflow show`: Add blank line above `Results:`

### DIFF
--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -337,6 +337,7 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) erro
 		if err := iter.print(cctx.Printer); err != nil {
 			return fmt.Errorf("displaying history failed: %w", err)
 		}
+		cctx.Printer.Println()
 		if err := printTextResult(cctx, iter.wfResult, 0); err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #548.