### PR TITLE
Make `workflow show` details more readable

### DIFF
--- a/temporalcli/commands.taskqueue_versioning_rules.go
+++ b/temporalcli/commands.taskqueue_versioning_rules.go
@@ -177,7 +177,7 @@ func (c *TemporalTaskQueueVersioningAddRedirectRuleCommand) run(cctx *CommandCon
 func (c *TemporalTaskQueueVersioningCommitBuildIdCommand) run(cctx *CommandContext, args []string) error {
 	token, err := c.Parent.getConflictToken(cctx, &getConflictTokenOptions{
 		safeMode:        !c.Yes,
-		safeModeMessage: "commiting a redirect rule",
+		safeModeMessage: "committing a Build ID",
 		taskQueue:       c.Parent.TaskQueue,
 		showAssignment:  true,
 	})

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -1,6 +1,7 @@
 package temporalcli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -425,7 +426,13 @@ func (s *structuredHistoryIter) Next() (any, error) {
 		if b, err := protojson.Marshal(attrs); err != nil {
 			data.Details = "<failed serializing details>"
 		} else {
-			data.Details = string(b)
+			var out bytes.Buffer
+			err := json.Indent(&out, b, "", "  ")
+			if err != nil {
+					data.Details = "<failed json formatting details>"
+			} else {
+				data.Details = "\n" + out.String() + "\n----------------------------"
+			}
 		}
 	}
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
 `workflow show` details are displayed with json but now we pretty-print it, properly align it to the left, and use a clear separator to indicate the next row. Note that trying to align indented json within a (narrow) last column was not easy to read...
Also, an unrelated typo in a confirmation message was corrected.
```
Progress:
  ID           Time                     Type                   Details       
    1  2024-06-27T23:42:00Z  WorkflowExecutionStarted    
{
  "workflowType": {
    "name": "example"
  },
  "taskQueue": {
    "name": "hello-world",
    "kind": "TASK_QUEUE_KIND_NORMAL"
  },
  "input": {
    "payloads": [
      {
        "metadata": {
          "encoding": "anNvbi9wbGFpbg=="
        },
        "data": "IlRlbXBvcmFsIg=="
      }
    ]
  },
  "workflowTaskTimeout": "10s",
  "originalExecutionRunId": "6b8b1127-af83-4329-a327-2a22ec88c4a7",
  "identity": "904724@antlai-tp1",
  "firstExecutionRunId": "6b8b1127-af83-4329-a327-2a22ec88c4a7",
  "attempt": 1,
  "firstWorkflowTaskBackoff": "0s",
  "header": {},
  "workflowId": "workflow-RdV-QSRE-Ls9zQosf80cw"
}
----------------------------
    2  2024-06-27T23:42:00Z  WorkflowTaskScheduled       
{
  "taskQueue": {
    "name": "hello-world",
    "kind": "TASK_QUEUE_KIND_NORMAL"
  },
  "startToCloseTimeout": "10s",
  "attempt": 1
}
----------------------------
    3  2024-06-27T23:42:00Z  WorkflowTaskStarted         
{
  "scheduledEventId": "2",
  "identity": "904134@antlai-tp1",
  "requestId": "836dd605-2c75-4f11-b9ec-22387ed3dbf9",
  "historySizeBytes": "285",
  "workerVersion": {
    "buildId": "@temporalio/worker@1.10.1+e89347260f1727cf484da18008718f6532352a9e08d46719a9df0aadd063ac30"
  }
}
----------------------------
```


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#546 
