### PR TITLE
dev-server: Properly deal with IPv6

### DIFF
--- a/temporalcli/devserver/freeport.go
+++ b/temporalcli/devserver/freeport.go
@@ -21,6 +21,7 @@ import (
 // in this regard; on that platform, `SO_REUSEADDR` has a different meaning and
 // should not be set (setting it may have unpredictable consequences).
 func GetFreePort(host string) (int, error) {
+	host = MaybeEscapeIpv6(host)
 	l, err := net.Listen("tcp", host+":0")
 	if err != nil {
 		return 0, fmt.Errorf("failed to assign a free port: %v", err)
@@ -44,7 +45,14 @@ func GetFreePort(host string) (int, error) {
 	// ports, making an extra connection just to reserve a port might actually
 	// be harmful (by hastening ephemeral port exhaustion).
 	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
-		r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
+		// DialTCP(..., l.Addr()) might fail if machine has IPv6 support, but
+		// isn't fully configured (e.g. doesn't have a loopback interface bound
+		// to ::1). For safety, rebuild address form the original host instead.
+		tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", host, port))
+		if err != nil {
+			return 0, fmt.Errorf("error resolving address: %v", err)
+		}
+		r, err := net.DialTCP("tcp", nil, tcpAddr)
 		if err != nil {
 			return 0, fmt.Errorf("failed to assign a free port: %v", err)
 		}
@@ -86,10 +94,18 @@ func MustGetFreePort(host string) int {
 // Asserts that the given TCP port is available to listen on, for the given
 // (local) host; return an error if it is not.
 func CheckPortFree(host string, port int) error {
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", MaybeEscapeIpv6(host), port))
 	if err != nil {
 		return err
 	}
 	l.Close()
 	return nil
+}
+
+// Escapes an IPv6 address with square brackets, if it is an IPv6 address.
+func MaybeEscapeIpv6(host string) string {
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return "[" + host + "]"
+	}
+	return host
 }

--- a/temporalcli/devserver/freeport_test.go
+++ b/temporalcli/devserver/freeport_test.go
@@ -53,7 +53,11 @@ func tryListenAndDialOn(host string, port int) error {
 	}
 	defer l.Close()
 
-	r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
+	tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		panic(err)
+	}
+	r, err := net.DialTCP("tcp", nil, tcpAddr)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## What was changed

- Correctly handle binding to `--ip 0.0.0.0` on machines that have IPv6 support but isn't fully configured (e.g. doesn't have a loopback interface bound to `::1`). Fix #595.
- Allow binding to IPv6 (e.g. `--ip ::1` or `--ui-ip ::`).
- Correctly honor values of arguments `--ui-ip` and `--ui-port`. Fix #602.
- Gives proper error message in all cases where `ip:port` is already in use. Fix #242.
- Correctly handle binding on addresses that do not encompass 127.0.0.1 (e.g. `--ip 127.0.0.2`).

## How this was tested

All cases fixed in this PR relates to specific network configuration, which can't easily be reproduced in CI or on developer machines. These changes were therefore only validated by manual testing.

For future reference, this is what I did on my Mac.

```
# Add two more loopback IPs
sudo ifconfig lo0 alias 127.0.0.2 up
sudo ifconfig lo0 alias 127.0.0.3 up

# Make sure that loopback has IPv6
ifconfig lo0 | grep ::1

# Test various cases
./temporal server start-dev --port 7235 --ui-port 7236 --http-port 7237 --metrics-port 7238 --ip :: --ui-ip ::1
./temporal server start-dev --port 7235 --ui-port 7236 --http-port 7237 --metrics-port 7238 --ip 127.0.0.2 --ui-ip 127.0.0.3
./temporal server start-dev --port 7235 --ui-port 7236 --http-port 7237 --metrics-port 7238 --ip 0.0.0.0 --ui-ip 127.0.0.1

# For each of the preceeding commands, assert:

# 1. That ports were bounded correctly
lsof -n -p $( ps | grep "temporal[ ]server" | cut -f 1 -d " " ) | grep LISTEN

# 2. That UI interface opens without issue
# 3. The prometheus metrics page opens  without issue
# 4. No error in server logs
```

To test in Docker, I had to use Rancher Desktop, with Kubernetes support enabled. The important thing for testing #595 is that the kernel of the virtual machine used by Docker must be compiled with IPv6 support (e.g. `/proc/sys/net/ipv6` exists), but the container image must not be configured for IPv6 (e.g. `ip addr show dev lo` doesn't show any IPv6 address, and `ping6 ::1` fails). The VM used by Docker Desktop won't work, apparently because it configures container's IPv6 correctly.