### PR TITLE
Supported flattened event detail view on workflow show/execute

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -2048,7 +2048,7 @@ type TemporalWorkflowExecuteCommand struct {
 	SharedWorkflowStartOptions
 	WorkflowStartOptions
 	PayloadInputOptions
-	EventDetails bool
+	Detailed bool
 }
 
 func NewTemporalWorkflowExecuteCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowExecuteCommand {
@@ -2066,7 +2066,7 @@ func NewTemporalWorkflowExecuteCommand(cctx *CommandContext, parent *TemporalWor
 	s.SharedWorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.WorkflowStartOptions.buildFlags(cctx, s.Command.Flags())
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
-	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, include event details JSON in printed output. If set when using JSON output, this will include the entire \"history\" JSON key of the started run (does not follow runs).")
+	s.Command.Flags().BoolVar(&s.Detailed, "detailed", false, "If set when using text output, display events as sections with detail instead of simple table. If set when using JSON output, this will include the entire \"history\" JSON key of the started run (does not follow runs).")
 	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
 		"name": "type",
 	}))
@@ -2229,8 +2229,8 @@ type TemporalWorkflowShowCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	Follow       bool
-	EventDetails bool
+	Follow   bool
+	Detailed bool
 }
 
 func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowShowCommand {
@@ -2247,7 +2247,7 @@ func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkfl
 	s.Command.Args = cobra.NoArgs
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Flags().BoolVarP(&s.Follow, "follow", "f", false, "Follow the progress of a Workflow Execution in real time (does not apply to JSON output).")
-	s.Command.Flags().BoolVar(&s.EventDetails, "event-details", false, "If set when using text output, include event details JSON in printed output.")
+	s.Command.Flags().BoolVar(&s.Detailed, "detailed", false, "If set when using text output, display events as sections with detail instead of simple table.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -1,11 +1,13 @@
 package temporalcli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,9 +16,8 @@ import (
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"
+	"go.temporal.io/api/temporalproto"
 	"go.temporal.io/sdk/client"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 func (c *TemporalWorkflowStartCommand) run(cctx *CommandContext, args []string) error {
@@ -51,10 +52,10 @@ func (c *TemporalWorkflowExecuteCommand) run(cctx *CommandContext, args []string
 			client:         cl,
 			workflowID:     run.GetID(),
 			runID:          run.GetRunID(),
-			includeDetails: c.EventDetails,
+			includeDetails: c.Detailed,
 			follow:         true,
 		}
-		if err := iter.print(cctx.Printer); err != nil && cctx.Err() == nil {
+		if err := iter.print(cctx); err != nil && cctx.Err() == nil {
 			return fmt.Errorf("displaying history failed: %w", err)
 		}
 		// Separate newline
@@ -140,7 +141,7 @@ func (c *TemporalWorkflowExecuteCommand) printJSONResult(
 	}
 
 	// Build history if requested
-	if c.EventDetails {
+	if c.Detailed {
 		var histProto history.History
 		iter := client.GetWorkflowHistory(cctx, run.GetID(), run.GetRunID(), false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 		for iter.HasNext() {
@@ -382,12 +383,40 @@ type structuredHistoryIter struct {
 	iter client.HistoryEventIterator
 }
 
-func (s *structuredHistoryIter) print(p *printer.Printer) error {
-	options := printer.StructuredOptions{Table: &printer.TableOptions{}}
+func (s *structuredHistoryIter) print(cctx *CommandContext) error {
+	// If we're not including details, just print the streaming table
 	if !s.includeDetails {
-		options.ExcludeFields = []string{"Details"}
+		return cctx.Printer.PrintStructuredTableIter(
+			structuredHistoryEventType,
+			s,
+			printer.StructuredOptions{Table: &printer.TableOptions{}},
+		)
 	}
-	return p.PrintStructuredIter(structuredHistoryEventType, s, options)
+
+	// Since details are wanted, we are going to do each event as a section
+	first := true
+	for {
+		event, err := s.NextRawEvent()
+		if event == nil || err != nil {
+			return err
+		}
+		// Add blank line if not first
+		if !first {
+			cctx.Printer.Println()
+		}
+		first = false
+
+		// Print section heading
+		cctx.Printer.Printlnf("--------------- [%v] %v ---------------", event.EventId, event.EventType)
+		// Convert the event to dot-delimited-field/value and print one per line
+		fields, err := s.flattenFields(cctx, event)
+		if err != nil {
+			return fmt.Errorf("failed flattening event fields: %w", err)
+		}
+		for _, field := range fields {
+			cctx.Printer.Printlnf("%v: %v", field.field, field.value)
+		}
+	}
 }
 
 type structuredHistoryEvent struct {
@@ -399,8 +428,7 @@ type structuredHistoryEvent struct {
 	Time string `cli:",width=20"`
 	// We're going to set width to a semi-reasonable number for good header
 	// placement, but we expect it to extend past for larger
-	Type    string `cli:",width=26"`
-	Details string `cli:",width=20"`
+	Type string `cli:",width=26"`
 }
 
 var structuredHistoryEventType = reflect.TypeOf(structuredHistoryEvent{})
@@ -418,15 +446,6 @@ func (s *structuredHistoryIter) Next() (any, error) {
 		ID:   event.EventId,
 		Time: event.EventTime.AsTime().Format(time.RFC3339),
 		Type: coloredEventType(event.EventType),
-	}
-	if s.includeDetails {
-		// First field in the attributes
-		attrs := reflect.ValueOf(event.Attributes).Elem().Field(0).Interface().(proto.Message)
-		if b, err := protojson.Marshal(attrs); err != nil {
-			data.Details = "<failed serializing details>"
-		} else {
-			data.Details = string(b)
-		}
 	}
 
 	// Follow continue as new
@@ -454,6 +473,91 @@ func (s *structuredHistoryIter) NextRawEvent() (*history.HistoryEvent, error) {
 		s.wfResult = event
 	}
 	return event, nil
+}
+
+type eventFieldValue struct {
+	field string
+	value string
+}
+
+func (s *structuredHistoryIter) flattenFields(
+	cctx *CommandContext,
+	event *history.HistoryEvent,
+) ([]eventFieldValue, error) {
+	// We want all event fields and all attribute fields converted to the same
+	// top-level JSON object. First do the proto conversion.
+	opts := temporalproto.CustomJSONMarshalOptions{}
+	if cctx.JSONShorthandPayloads {
+		opts.Metadata = map[string]any{common.EnablePayloadShorthandMetadataKey: true}
+	}
+	protoJSON, err := opts.Marshal(event)
+	if err != nil {
+		return nil, fmt.Errorf("failed marshaling event: %w", err)
+	}
+	// Convert from string back to JSON
+	dec := json.NewDecoder(bytes.NewReader(protoJSON))
+	// We want json.Number
+	dec.UseNumber()
+	fieldsMap := map[string]any{}
+	if err := dec.Decode(&fieldsMap); err != nil {
+		return nil, fmt.Errorf("failed unmarshaling event proto: %w", err)
+	}
+	// Exclude eventId and eventType
+	delete(fieldsMap, "eventId")
+	delete(fieldsMap, "eventType")
+	// Lift any "Attributes"-suffixed fields up to the top level
+	for k, v := range fieldsMap {
+		if strings.HasSuffix(k, "Attributes") {
+			subMap, ok := v.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("unexpectedly invalid attribute map")
+			}
+			for subK, subV := range subMap {
+				fieldsMap[subK] = subV
+			}
+			delete(fieldsMap, k)
+		}
+	}
+	// Flatten JSON map and sort
+	fields, err := s.flattenJSONValue(nil, "", fieldsMap)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].field < fields[j].field })
+	return fields, nil
+}
+
+func (s *structuredHistoryIter) flattenJSONValue(
+	to []eventFieldValue,
+	field string,
+	value any,
+) ([]eventFieldValue, error) {
+	var err error
+	switch value := value.(type) {
+	case bool, string, json.Number, nil:
+		// Note, empty values should not occur
+		to = append(to, eventFieldValue{field, fmt.Sprintf("%v", value)})
+	case []any:
+		for i, subValue := range value {
+			if to, err = s.flattenJSONValue(to, fmt.Sprintf("%v[%v]", field, i), subValue); err != nil {
+				return nil, err
+			}
+		}
+	case map[string]any:
+		// Only add a dot if existing field not empty (i.e. not first)
+		prefix := field
+		if prefix != "" {
+			prefix += "."
+		}
+		for subField, subValue := range value {
+			if to, err = s.flattenJSONValue(to, prefix+subField, subValue); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("failed converting field %v, unknown type %T", field, value)
+	}
+	return to, nil
 }
 
 func isWorkflowTerminatingEvent(t enums.EventType) bool {

--- a/temporalcli/commands.workflow_exec_test.go
+++ b/temporalcli/commands.workflow_exec_test.go
@@ -570,7 +570,7 @@ func (s *SharedServerSuite) TestWorkflow_Execute_CodecEndpoint() {
 	// actually decoded for the user
 	res = s.Execute(
 		"workflow", "execute",
-		"-o", "json", "--event-details",
+		"-o", "json", "--detailed",
 		"--codec-endpoint", "http://"+srv.Listener.Addr().String(),
 		"--address", s.Address(),
 		"--task-queue", taskQueue,

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -189,7 +189,7 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 	return nil
 }
 
-func (c *TemporalWorkflowListCommand) run(cctx *CommandContext, args []string) error {
+func (c *TemporalWorkflowListCommand) run(cctx *CommandContext, _ []string) error {
 	cl, err := c.Parent.ClientOptions.dialClient(cctx)
 	if err != nil {
 		return err
@@ -268,7 +268,7 @@ func (c *TemporalWorkflowListCommand) pageFetcher(
 	}
 }
 
-func (c *TemporalWorkflowCountCommand) run(cctx *CommandContext, _ []string) error {
+func (c *TemporalWorkflowCountCommand) run(cctx *CommandContext, args []string) error {
 	cl, err := c.Parent.ClientOptions.dialClient(cctx)
 	if err != nil {
 		return err
@@ -329,12 +329,12 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) erro
 		client:         cl,
 		workflowID:     c.WorkflowId,
 		runID:          c.RunId,
-		includeDetails: c.EventDetails,
+		includeDetails: c.Detailed,
 		follow:         c.Follow,
 	}
 	if !cctx.JSONOutput {
 		cctx.Printer.Println(color.MagentaString("Progress:"))
-		if err := iter.print(cctx.Printer); err != nil {
+		if err := iter.print(cctx); err != nil {
 			return fmt.Errorf("displaying history failed: %w", err)
 		}
 		cctx.Printer.Println()

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -943,8 +943,9 @@ temporal workflow execute
 
 #### Options
 
-* `--event-details` (bool) - If set when using text output, include event details JSON in printed output. If set when
-  using JSON output, this will include the entire "history" JSON key of the started run (does not follow runs).
+* `--detailed` (bool) - If set when using text output, display events as sections with detail instead of simple table.
+  If set when using JSON output, this will include the entire "history" JSON key of the started run (does not follow
+  runs).
 
 Includes options set for [shared workflow start](#options-set-for-shared-workflow-start).
 Includes options set for [workflow start](#options-set-for-workflow-start).
@@ -1054,7 +1055,7 @@ Use the options listed below to change the command's behavior.
 
 * `--follow`, `-f` (bool) - Follow the progress of a Workflow Execution in real time (does not apply
   to JSON output).
-* `--event-details` (bool) - If set when using text output, include event details JSON in printed output.
+* `--detailed` (bool) - If set when using text output, display events as sections with detail instead of simple table.
 
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 


### PR DESCRIPTION
## What was changed

* Removed `--event-details` from `workflow show` and `workflow execute` that, in text mode, blindly dumped full event in table column in an unreadable way
  * 💥 BREAKING CHANGE
* Added `--detailed` to `workflow show` and `workflow execute` that, for text output, dumps events as sections
  * Live streaming (i.e. `--follow` for `workflow show`) still supported

Before with something like `temporal workflow show -w my-wf --event-details`:

```
Progress:
  ID           Time                     Type                   Details
    1  2024-07-03T16:48:06Z  WorkflowExecutionStarted    {"workflowType":{"name":"DevWorkflow"}, "taskQueue":{"name":"54937496-3012-40f1-8803-667c93c99ac5", "kind":"TASK_QUEUE_KIND_NORMAL"}, "input":{"payloads":[{"metadata":{"encoding":"anNvbi9wbGFpbg=="}, "data":"Imlnbm9yZWQi"}]}, "workflowExecutionTimeout":"0s", "workflowRunTimeout":"0s", "workflowTaskTimeout":"10s", "originalExecutionRunId":"ed8999e4-7cb9-44ad-8fac-40724c9a9a58", "identity":"cli-test-client", "firstExecutionRunId":"ed8999e4-7cb9-44ad-8fac-40724c9a9a58", "attempt":1, "firstWorkflowTaskBackoff":"0s", "header":{}, "workflowId":"15cda007-b4b2-40cc-9b6f-6cd06e1ac4e6"}
    2  2024-07-03T16:48:06Z  WorkflowTaskScheduled       {"taskQueue":{"name":"54937496-3012-40f1-8803-667c93c99ac5", "kind":"TASK_QUEUE_KIND_NORMAL"}, "startToCloseTimeout":"10s", "attempt":1}
    3  2024-07-03T16:48:06Z  WorkflowExecutionSignaled   {"signalName":"my-signal", "input":{"payloads":[{"metadata":{"encoding":"YmluYXJ5L251bGw="}}]}, "identity":"cli-test-client", "header":{}}
    4  2024-07-03T16:48:06Z  WorkflowExecutionSignaled   {"signalName":"my-signal", "input":{"payloads":[{"metadata":{"encoding":"YmluYXJ5L251bGw="}}]}, "identity":"cli-test-client", "header":{}}
    5  2024-07-03T16:48:06Z  WorkflowTaskStarted         {"scheduledEventId":"2", "identity":"cli-test-client", "requestId":"7ed83f01-5598-40b2-9e18-f92e9111d3b5", "historySizeBytes":"520", "workerVersion":{"buildId":"178aaa53a048affa90c8eb23330cc70e"}}
    6  2024-07-03T16:48:06Z  WorkflowTaskCompleted       {"scheduledEventId":"2", "startedEventId":"5", "identity":"cli-test-client", "workerVersion":{"buildId":"178aaa53a048affa90c8eb23330cc70e"}, "sdkMetadata":{"langUsedFlags":[3], "sdkName":"temporal-go", "sdkVersion":"1.27.0"}, "meteringMetadata":{}}
    7  2024-07-03T16:48:06Z  WorkflowExecutionCompleted  {"result":{"payloads":[{"metadata":{"encoding":"anNvbi9wbGFpbg=="}, "data":"ImhpISI="}]}, "workflowTaskCompletedEventId":"6"}

Results:
  Status          COMPLETED
  Result          "hi!"
  ResultEncoding  json/plain
```

(note how bad this would be wrapping in a terminal)

After with something like `temporal workflow show -w my-wf --detailed`:

```
Progress:
--------------- [1] WorkflowExecutionStarted ---------------
attempt: 1
eventTime: 2024-07-03T16:50:18.601465300Z
firstExecutionRunId: 93aed421-dd11-47a7-88d3-fcabfd80cf06
firstWorkflowTaskBackoff: 0s
identity: cli-test-client
input[0]: ignored
originalExecutionRunId: 93aed421-dd11-47a7-88d3-fcabfd80cf06
taskId: 1048592
taskQueue.kind: TASK_QUEUE_KIND_NORMAL
taskQueue.name: d598a582-102c-4ece-b33b-0b4993c623b4
workflowExecutionTimeout: 0s
workflowId: ce7c1d27-e7d2-4ec0-ae37-03baa805d002
workflowRunTimeout: 0s
workflowTaskTimeout: 10s
workflowType.name: DevWorkflow

--------------- [2] WorkflowTaskScheduled ---------------
attempt: 1
eventTime: 2024-07-03T16:50:18.601465300Z
startToCloseTimeout: 10s
taskId: 1048593
taskQueue.kind: TASK_QUEUE_KIND_NORMAL
taskQueue.name: d598a582-102c-4ece-b33b-0b4993c623b4

--------------- [3] WorkflowExecutionSignaled ---------------
eventTime: 2024-07-03T16:50:18.601971400Z
identity: cli-test-client
input[0].metadata.encoding: YmluYXJ5L251bGw=
signalName: my-signal
taskId: 1048598

--------------- [4] WorkflowExecutionSignaled ---------------
eventTime: 2024-07-03T16:50:18.603642500Z
identity: cli-test-client
input[0].metadata.encoding: YmluYXJ5L251bGw=
signalName: my-signal
taskId: 1048600

--------------- [5] WorkflowTaskStarted ---------------
eventTime: 2024-07-03T16:50:18.603642500Z
historySizeBytes: 520
identity: cli-test-client
requestId: c511d110-c37a-4198-b7bd-e35c1953fcd9
scheduledEventId: 2
taskId: 1048602
workerVersion.buildId: e534651359743d27d180ef44397135ef

--------------- [6] WorkflowTaskCompleted ---------------
eventTime: 2024-07-03T16:50:18.603642500Z
identity: cli-test-client
scheduledEventId: 2
sdkMetadata.langUsedFlags[0]: 3
sdkMetadata.sdkName: temporal-go
sdkMetadata.sdkVersion: 1.27.0
startedEventId: 5
taskId: 1048606
workerVersion.buildId: e534651359743d27d180ef44397135ef

--------------- [7] WorkflowExecutionCompleted ---------------
eventTime: 2024-07-03T16:50:18.603642500Z
result[0]: hi!
taskId: 1048607
workflowTaskCompletedEventId: 6

Results:
  Status          COMPLETED
  Result          "hi!"
  ResultEncoding  json/plain
```

Note, the table form still exists for non `--detailed`. Also note that we can continually tweak this post-merge, don't need to block merge for little pieces.

## Checklist

1. Closes #546