### PR TITLE
fixes signalling typo

### DIFF
--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -116,7 +116,7 @@ func (c *TemporalWorkflowSignalCommand) run(cctx *CommandContext, args []string)
 			Identity:          clientIdentity(),
 		})
 		if err != nil {
-			return fmt.Errorf("failed signalling workflow: %w", err)
+			return fmt.Errorf("failed signaling workflow: %w", err)
 		}
 		cctx.Printer.Println("Signal workflow succeeded")
 	} else { // batchReq != nil


### PR DESCRIPTION
This PR fixes a simple typo I see in the CLI. It should be "signaling workflow" instead of "signalling workflow"