### PR TITLE
Tweak server start-up text

### DIFF
--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -349,7 +349,7 @@ func Execute(ctx context.Context, options CommandOptions) {
 }
 
 func (c *TemporalCommand) initCommand(cctx *CommandContext) {
-	c.Command.Version = fmt.Sprintf("%s (server %s) (ui %s)", Version, headers.ServerVersion, version.UIVersion)
+	c.Command.Version = VersionString()
 	// Unfortunately color is a global option, so we can set in pre-run but we
 	// must unset in post-run
 	origNoColor := color.NoColor
@@ -392,6 +392,10 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	c.Command.PersistentPostRun = func(*cobra.Command, []string) {
 		color.NoColor = origNoColor
 	}
+}
+
+func VersionString() string {
+	return fmt.Sprintf("CLI %s (Server %s, UI %s)", Version, headers.ServerVersion, version.UIVersion)
 }
 
 func (c *TemporalCommand) preRun(cctx *CommandContext) error {

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -395,7 +395,7 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 }
 
 func VersionString() string {
-	return fmt.Sprintf("CLI %s (Server %s, UI %s)", Version, headers.ServerVersion, version.UIVersion)
+	return fmt.Sprintf("%s (Server %s, UI %s)", Version, headers.ServerVersion, version.UIVersion)
 }
 
 func (c *TemporalCommand) preRun(cctx *CommandContext) error {

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -144,11 +144,11 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 		return err
 	}
 
-	cctx.Printer.Printlnf("%-16s %v:%v", "Temporal server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
+	cctx.Printer.Printlnf("%-8s %v:%v", "Server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
 	if !t.Headless {
-		cctx.Printer.Printlnf("%-16s http://%v:%v", "Web UI:", toFriendlyIp(opts.UIIP), opts.UIPort)
+		cctx.Printer.Printlnf("%-8s http://%v:%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort)
 	}
-	cctx.Printer.Printlnf("%-16s http://%v:%v/metrics", "Metrics:", toFriendlyIp(opts.FrontendIP), opts.MetricsPort)
+	cctx.Printer.Printlnf("%-8s http://%v:%v/metrics", "Metrics:", toFriendlyIp(opts.FrontendIP), opts.MetricsPort)
 	<-cctx.Done()
 	cctx.Printer.Println("Stopping server...")
 	return nil

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -144,7 +144,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 		return err
 	}
 
-	cctx.Printer.Printlnf("CLI " + VersionString() + "\n")
+	cctx.Printer.Printlnf("CLI %v\n", VersionString())
 	cctx.Printer.Printlnf("%-8s %v:%v", "Server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
 	if !t.Headless {
 		cctx.Printer.Printlnf("%-8s http://%v:%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort)

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -144,6 +144,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 		return err
 	}
 
+	cctx.Printer.Printlnf(VersionString() + "\n")
 	cctx.Printer.Printlnf("%-8s %v:%v", "Server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
 	if !t.Headless {
 		cctx.Printer.Printlnf("%-8s http://%v:%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort)

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -144,7 +144,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 		return err
 	}
 
-	cctx.Printer.Printlnf(VersionString() + "\n")
+	cctx.Printer.Printlnf("CLI " + VersionString() + "\n")
 	cctx.Printer.Printlnf("%-8s %v:%v", "Server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
 	if !t.Headless {
 		cctx.Printer.Printlnf("%-8s http://%v:%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort)


### PR DESCRIPTION
Another iteration of tweaking the start-up message:

**Was**:

```
$ temporal server start-dev
Temporal server: localhost:7233
Web UI:          http://localhost:8233/
Metrics:         http://localhost:53881/metrics
```

**Becomes**:


```
$ temporal server start-dev
CLI 0.0.0-DEV (Server 1.24.1, UI 2.28.0)

Server:  localhost:7233
UI:      http://localhost:8233
Metrics: http://localhost:58550/metrics
```
