### PR TITLE
Adjust dev-server tunables to avoid persistence rate-limiting

### DIFF
--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -14,7 +14,17 @@ import (
 )
 
 var defaultDynamicConfigValues = map[string]any{
+	// Make search attributes immediately visible on creation, so users don't
+	// have to wait for eventual consistency to happen when testing against the
+	// dev-server.  Since it's a very rare thing to create search attributes,
+	// we're comfortable that this is very unlikely to mask bugs in user code.
 	"system.forceSearchAttributesCacheRefreshOnRead": true,
+
+	// Since we disable the SA cache, we need to bump max QPS accordingly.
+	// These numbers were chosen to maintain the ratio between the two that's
+	// established in the defaults.
+	"frontend.persistenceMaxQPS": 10000,
+	"history.persistenceMaxQPS": 45000,
 }
 
 func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string) error {


### PR DESCRIPTION
Rationale is explained in the code comments.

Closes #621.