### PR TITLE
Include additional build-time information in the version string

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ This will expect every non-parent command to have a `run` method, so for new com
 ## Inject additional build-time information
 To add build-time information to the version string printed by the binary, use
 
-    go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
+    go build -ldflags "-X github.com/temporalio/cli/temporalcli.BuildInfo=<MyString>"
 
 This can be useful if, for example, you've used a `replace` statement in go.mod pointing to a local directory.
 Note that inclusion of space characters in the value supplied via `-ldflags` is tricky.
 Here's an example that adds branch info from a local repo to the version string, and includes a space character:
 
-    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.buildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go
+    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.BuildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ This will expect every non-parent command to have a `run` method, so for new com
 ## Inject additional build-time information
 To add build-time information to the version string printed by the binary, use
 
-    go build -ldflags "-X github.com/temporalio/cli/temporalcli.BuildInfo=<MyString>"
+    go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
 
 This can be useful if, for example, you've used a `replace` statement in go.mod pointing to a local directory.
 Note that inclusion of space characters in the value supplied via `-ldflags` is tricky.
 Here's an example that adds branch info from a local repo to the version string, and includes a space character:
 
-    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.BuildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go
+    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.buildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,14 @@ First, update [commands.md](temporalcli/commandsmd/commands.md) following the ru
 
 This will expect every non-parent command to have a `run` method, so for new commands developers will have to implement
 `run` on the new command in a separate file before it will compile.
+
+## Inject additional build-time information
+To add build-time information to the version string printed by the binary, use
+
+    go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
+
+This can be useful if, for example, you've used a `replace` statement in go.mod pointing to a local directory.
+Note that inclusion of space characters in the value supplied via `-ldflags` is tricky.
+Here's an example that adds branch info from a local repo to the version string, and includes a space character:
+
+    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.buildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,4 @@ This can be useful if, for example, you've used a `replace` statement in go.mod 
 Note that inclusion of space characters in the value supplied via `-ldflags` is tricky.
 Here's an example that adds branch info from a local repo to the version string, and includes a space character:
 
-    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.buildInfo=ServerBranch $(cd ../temporal && git rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go
+    go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.buildInfo=ServerBranch $(git -C ../temporal rev-parse --abbrev-ref HEAD)'" -o temporal ./cmd/temporal/main.go

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -416,12 +416,12 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	}
 }
 
-var buildInfo string
+var BuildInfo string
 
 func VersionString() string {
 	// To add build-time information to the version string, use
-	// go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
-	var bi = buildInfo
+	// go build -ldflags "-X github.com/temporalio/cli/temporalcli.BuildInfo=<MyString>"
+	var bi = BuildInfo
 	if bi != "" {
 		bi = fmt.Sprintf(", %s", bi)
 	}

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -416,12 +416,12 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	}
 }
 
-var BuildInfo string
+var buildInfo string
 
 func VersionString() string {
 	// To add build-time information to the version string, use
-	// go build -ldflags "-X github.com/temporalio/cli/temporalcli.BuildInfo=<MyString>"
-	var bi = BuildInfo
+	// go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
+	var bi = buildInfo
 	if bi != "" {
 		bi = fmt.Sprintf(", %s", bi)
 	}

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -416,8 +416,16 @@ func (c *TemporalCommand) initCommand(cctx *CommandContext) {
 	}
 }
 
+var buildInfo string
+
 func VersionString() string {
-	return fmt.Sprintf("%s (Server %s, UI %s)", Version, headers.ServerVersion, version.UIVersion)
+	// To add build-time information to the version string, use
+	// go build -ldflags "-X github.com/temporalio/cli/temporalcli.buildInfo=<MyString>"
+	var bi = buildInfo
+	if bi != "" {
+		bi = fmt.Sprintf(", %s", bi)
+	}
+	return fmt.Sprintf("%s (Server %s, UI %s%s)", Version, headers.ServerVersion, version.UIVersion, bi)
 }
 
 func (c *TemporalCommand) preRun(cctx *CommandContext) error {


### PR DESCRIPTION
Fixes #635

Support injection of build-time information into the version string printed by the binary on startup and via `--version`. See code comments and docs for further explanation.