### PR TITLE
Upgrade server with endpoint regexp validation to allow "-" and deny "_"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/nexus-rpc/sdk-go v0.0.9
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -80,7 +81,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/nexus-rpc/sdk-go v0.0.9 // indirect
 	github.com/olivere/elastic/v7 v7.0.32 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	github.com/temporalio/ui-server/v2 v2.29.2
-	go.temporal.io/api v1.36.0
+	go.temporal.io/api v1.37.0
 	go.temporal.io/sdk v1.28.2-0.20240816033637-2a02c483658a
-	go.temporal.io/server v1.25.0-rc.0
+	go.temporal.io/server v1.25.0-rc.1
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -348,12 +348,12 @@ go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
-go.temporal.io/api v1.36.0 h1:WdntOw9m38lFvMdMXuOO+3BQ0R8HpVLgtk9+f+FwiDk=
-go.temporal.io/api v1.36.0/go.mod h1:0nWIrFRVPlcrkopXqxir/UWOtz/NZCo+EE9IX4UwVxw=
+go.temporal.io/api v1.37.0 h1:s3kMcqx6QOXMrbh7F2sNtczMPE+GGqigA7j+saKB+6E=
+go.temporal.io/api v1.37.0/go.mod h1:P1gXI4RZ9TEcNcgrWUiT2QNPOV4ZOSiGlBvu9TniuDk=
 go.temporal.io/sdk v1.28.2-0.20240816033637-2a02c483658a h1:tEyTb3JMJBizsSWJtt+WGhqyYzjShjWimXGr8g7xixA=
 go.temporal.io/sdk v1.28.2-0.20240816033637-2a02c483658a/go.mod h1:CdymduY4ZHemDLLYn2fuQ+znqMYD2uNKtqWKaP63jcI=
-go.temporal.io/server v1.25.0-rc.0 h1:nLji9pO/83yvflB8sJwarI5xY33jOSLf9QTAaa7MZH0=
-go.temporal.io/server v1.25.0-rc.0/go.mod h1:W2ts+WuKqAEDMpCU6qDAdRvW8gY892dQYOpl+Dmxn14=
+go.temporal.io/server v1.25.0-rc.1 h1:8HYBHdEOhs+fdpSvrdqg0B2RUwckbL72ttr7PcBNFxo=
+go.temporal.io/server v1.25.0-rc.1/go.mod h1:+8eYt3bSdHzPDMyEW3RgtsbAJRblhUEH0PVRSPiMyUs=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/temporalcli/commands.operator_nexus_test.go
+++ b/temporalcli/commands.operator_nexus_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -331,7 +331,7 @@ func (s *SharedServerSuite) TestListNexusEndpoints() {
 	// Create a couple of endpoints.
 	res := s.Execute("operator", "nexus", "endpoint", "create",
 		"--address", s.Address(),
-		"--name", validEndpointName(s.T())+"_1",
+		"--name", validEndpointName(s.T())+"-1",
 		"--description", "markdown-1",
 		"--target-namespace", "default",
 		"--target-task-queue", "tq-1")
@@ -339,7 +339,7 @@ func (s *SharedServerSuite) TestListNexusEndpoints() {
 
 	res = s.Execute("operator", "nexus", "endpoint", "create",
 		"--address", s.Address(),
-		"--name", validEndpointName(s.T())+"_2",
+		"--name", validEndpointName(s.T())+"-2",
 		"--description", "markdown-2",
 		"--target-namespace", "default",
 		"--target-task-queue", "tq-2")
@@ -349,12 +349,12 @@ func (s *SharedServerSuite) TestListNexusEndpoints() {
 		res = s.Execute("operator", "nexus", "endpoint", "list", "--address", s.Address())
 		require.NoError(t, res.Err)
 
-		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Name", validEndpointName(s.T())+"_1"))
+		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Name", validEndpointName(s.T())+"-1"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Target.Worker.Namespace", "default"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Target.Worker.TaskQueue", "tq-1"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Description", "markdown-1"))
 
-		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Name", validEndpointName(s.T())+"_2"))
+		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Name", validEndpointName(s.T())+"-2"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Target.Worker.Namespace", "default"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Target.Worker.TaskQueue", "tq-2"))
 		require.NoError(t, AssertContainsOnSameLine(res.Stdout.String(), "Description", "markdown-2"))
@@ -374,10 +374,10 @@ func (s *SharedServerSuite) TestListNexusEndpoints() {
 		require.GreaterOrEqual(t, len(endpoints), 2)
 
 		ep1Idx := slices.IndexFunc(endpoints, func(e *nexus.Endpoint) bool {
-			return e.Spec.Name == validEndpointName(s.T())+"_1"
+			return e.Spec.Name == validEndpointName(s.T())+"-1"
 		})
 		ep2Idx := slices.IndexFunc(endpoints, func(e *nexus.Endpoint) bool {
-			return e.Spec.Name == validEndpointName(s.T())+"_2"
+			return e.Spec.Name == validEndpointName(s.T())+"-2"
 		})
 		require.Equal(t, "default", endpoints[ep1Idx].Spec.Target.GetWorker().Namespace)
 		require.Equal(t, "tq-1", endpoints[ep1Idx].Spec.Target.GetWorker().TaskQueue)
@@ -403,5 +403,6 @@ func (s *SharedServerSuite) getNexusEndpointByName(name string) *nexus.Endpoint 
 }
 
 func validEndpointName(t *testing.T) string {
-	return strings.ReplaceAll(t.Name(), "/", "_")
+	re := regexp.MustCompile("[/_]")
+	return re.ReplaceAllString(t.Name(), "-")
 }

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -12,10 +12,15 @@ import (
 	"go.temporal.io/api/common/v1"
 
 	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/temporalio/cli/temporalcli"
 	"go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/temporalnexus"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -539,4 +544,134 @@ func (s *SharedServerSuite) TestWorkflow_Count() {
 	s.Contains(out, `"count":"5"`)
 	s.Contains(out, `{"groupValues":["Running"],"count":"2"}`)
 	s.Contains(out, `{"groupValues":["Completed"],"count":"3"}`)
+}
+
+func (s *SharedServerSuite) TestWorkflow_Describe_NexusOperationAndCallback() {
+	handlerWorkflowID := uuid.NewString()
+	endpointName := validEndpointName(s.T())
+
+	// Workflow that waits to be canceled.
+	handlerWorkflow := func(ctx workflow.Context, input nexus.NoValue) (nexus.NoValue, error) {
+		ctx.Done().Receive(ctx, nil)
+		return nil, ctx.Err()
+	}
+
+	// Expose the workflow above as an operation.
+	op := temporalnexus.NewWorkflowRunOperation("test-op", handlerWorkflow, func(ctx context.Context, _ nexus.NoValue, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+		return client.StartWorkflowOptions{ID: handlerWorkflowID}, nil
+	})
+	service := nexus.NewService("test-service")
+	s.NoError(service.Register(op))
+
+	// Call the operation from this workflow.
+	callerWorkflow := func(ctx workflow.Context) error {
+		client := workflow.NewNexusClient(endpointName, service.Name)
+		opCtx, cancel := workflow.WithCancel(ctx)
+		fut := client.ExecuteOperation(opCtx, op, nil, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return err
+		}
+		// Cancel the operation on this signal.
+		ch := workflow.GetSignalChannel(ctx, "cancel-op")
+		ch.Receive(ctx, nil)
+		cancel()
+		// Wait for the operation to be canceled.
+		return fut.Get(ctx, nil)
+	}
+
+	w := s.DevServer.StartDevWorker(s.Suite.T(), DevWorkerOptions{
+		Workflows:     []any{handlerWorkflow, callerWorkflow},
+		NexusServices: []*nexus.Service{service},
+	})
+	defer w.Stop()
+
+	// Create an endpoint for this test.
+	_, err := s.Client.OperatorService().CreateNexusEndpoint(s.Context, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: s.Namespace(),
+						TaskQueue: w.Options.TaskQueue,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Start the workflow and wait until the operation is started.
+	run, err := s.Client.ExecuteWorkflow(
+		s.Context,
+		client.StartWorkflowOptions{TaskQueue: w.Options.TaskQueue},
+		callerWorkflow,
+	)
+	s.NoError(err)
+
+	// Wait for the operation to be started.
+	s.Eventually(func() bool {
+		resp, err := s.Client.DescribeWorkflowExecution(s.Context, run.GetID(), run.GetRunID())
+		s.NoError(err)
+		return len(resp.PendingNexusOperations) > 0 && resp.PendingNexusOperations[0].State == enums.PENDING_NEXUS_OPERATION_STATE_STARTED
+	}, 30*time.Second, 100*time.Millisecond)
+
+	// Operations - Text
+	res := s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", run.GetID(),
+	)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.ContainsOnSameLine(out, "WorkflowId", run.GetID())
+	s.Contains(out, "Pending Nexus Operations: 1")
+	s.ContainsOnSameLine(out, "Endpoint", endpointName)
+	s.ContainsOnSameLine(out, "Service", "test-service")
+	s.ContainsOnSameLine(out, "Operation", "test-op")
+
+	// Operations - JSON
+	res = s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", run.GetID(),
+		"--output", "json",
+	)
+	s.NoError(res.Err)
+	var callerDesc workflowservice.DescribeWorkflowExecutionResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &callerDesc, true))
+	s.Equal(endpointName, callerDesc.PendingNexusOperations[0].Endpoint)
+	s.Equal("test-service", callerDesc.PendingNexusOperations[0].Service)
+	s.Equal("test-op", callerDesc.PendingNexusOperations[0].Operation)
+
+	// Cancel the operation and check the callback on the handler workflow.
+	s.NoError(s.Client.SignalWorkflow(s.Context, run.GetID(), run.GetRunID(), "cancel-op", nil))
+	s.ErrorAs(run.Get(s.Context, nil), new(*temporal.CanceledError))
+
+	// Callbacks - Text
+	res = s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", handlerWorkflowID,
+	)
+	s.NoError(res.Err)
+	out = res.Stdout.String()
+	s.ContainsOnSameLine(out, "WorkflowId", handlerWorkflowID)
+	s.Contains(out, "Callbacks: 1")
+	s.ContainsOnSameLine(out, "URL", "http://"+s.DevServer.Options.FrontendIP)
+	s.ContainsOnSameLine(out, "Trigger", "WorkflowClosed")
+	s.ContainsOnSameLine(out, "State", "Succeeded")
+
+	// Callbacks - JSON
+	res = s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", handlerWorkflowID,
+		"--output", "json",
+	)
+	s.NoError(res.Err)
+	var handlerDesc workflowservice.DescribeWorkflowExecutionResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &handlerDesc, true))
+	s.Equal(enums.CALLBACK_STATE_SUCCEEDED, handlerDesc.Callbacks[0].State)
 }

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -475,6 +476,8 @@ type DevWorkerOptions struct {
 	Workflows []any
 	// Optional, no default, but DevActivity is always registered
 	Activities []any
+	// Optional, no default
+	NexusServices []*nexus.Service
 }
 
 // Simply a stub for client use
@@ -506,6 +509,9 @@ func (d *DevServer) StartDevWorker(t *testing.T, options DevWorkerOptions) *DevW
 	ops := &devOperations{w}
 	w.Worker.RegisterWorkflowWithOptions(ops.DevWorkflow, workflow.RegisterOptions{Name: "DevWorkflow"})
 	w.Worker.RegisterActivity(ops.DevActivity)
+	for _, s := range options.NexusServices {
+		w.Worker.RegisterNexusService(s)
+	}
 	// Start worker or fail
 	require.NoError(t, w.Worker.Start(), "failed starting worker")
 	return w


### PR DESCRIPTION
Also [Bring back nexus workflow view tests](https://github.com/temporalio/cli/pull/641/commits/83b70c2c6320b8942cbf013dc182a7e28c413c61) now that the SDK is released.

Note that since #638 was merged into the nexus branch, it is no longer in a releasable state since `go.mod` is referencing an unreleased Go SDK.