### PR TITLE
Add `workflow update start` and `workflow update execute` subcommands

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -2667,6 +2667,7 @@ type TemporalWorkflowUpdateStartCommand struct {
 	Command cobra.Command
 	UpdateOptions
 	PayloadInputOptions
+	WaitForStage StringEnum
 }
 
 func NewTemporalWorkflowUpdateStartCommand(cctx *CommandContext, parent *TemporalWorkflowUpdateCommand) *TemporalWorkflowUpdateStartCommand {
@@ -2674,7 +2675,7 @@ func NewTemporalWorkflowUpdateStartCommand(cctx *CommandContext, parent *Tempora
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "start [flags]"
-	s.Command.Short = "Send an Update and wait for it to be accepted"
+	s.Command.Short = "Send an Update and wait for it to be accepted or rejected"
 	if hasHighlighting {
 		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to be accepted or rejected. You can subsequently wait for the update\nto complete by using \x1b[1mtemporal workflow update execute\x1b[0m.\n\n\x1b[1mtemporal workflow update start \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\x1b[0m"
 	} else {
@@ -2683,6 +2684,9 @@ func NewTemporalWorkflowUpdateStartCommand(cctx *CommandContext, parent *Tempora
 	s.Command.Args = cobra.NoArgs
 	s.UpdateOptions.buildFlags(cctx, s.Command.Flags())
 	s.PayloadInputOptions.buildFlags(cctx, s.Command.Flags())
+	s.WaitForStage = NewStringEnum([]string{"accepted"}, "")
+	s.Command.Flags().Var(&s.WaitForStage, "wait-for-stage", "Update stage to wait for. The only option is `accepted`, but this option is  required. This is to allow a future version of the CLI to choose a default value. Accepted values: accepted. Required.")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "wait-for-stage")
 	s.Command.Flags().SetNormalizeFunc(aliasNormalizer(map[string]string{
 		"type": "name",
 	}))

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -2604,8 +2604,8 @@ func NewTemporalWorkflowUpdateCommand(cctx *CommandContext, parent *TemporalWork
 	var s TemporalWorkflowUpdateCommand
 	s.Parent = parent
 	s.Command.Use = "update"
-	s.Command.Short = "Start and wait for Updates"
-	s.Command.Long = "An Update is a synchronous call to a Workflow Execution that can change its\nstate, control its flow, and return a result."
+	s.Command.Short = "Start and wait for Updates (Experimental)"
+	s.Command.Long = "An Update is a synchronous call to a Workflow Execution that can change its\nstate, control its flow, and return a result.\n\nExperimental."
 	s.Command.Args = cobra.NoArgs
 	s.Command.AddCommand(&NewTemporalWorkflowUpdateExecuteCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalWorkflowUpdateStartCommand(cctx, &s).Command)
@@ -2642,11 +2642,11 @@ func NewTemporalWorkflowUpdateExecuteCommand(cctx *CommandContext, parent *Tempo
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "execute [flags]"
-	s.Command.Short = "Send an Update and wait for it to complete"
+	s.Command.Short = "Send an Update and wait for it to complete (Experimental)"
 	if hasHighlighting {
-		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to complete or fail. You can also use this to wait for an existing\nupdate to complete, by submitting an existing update ID.\n\n\x1b[1mtemporal workflow update execute \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\x1b[0m"
+		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to complete or fail. You can also use this to wait for an existing\nupdate to complete, by submitting an existing update ID.\n\nExperimental.\n\n\x1b[1mtemporal workflow update execute \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\x1b[0m"
 	} else {
-		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to complete or fail. You can also use this to wait for an existing\nupdate to complete, by submitting an existing update ID.\n\n```\ntemporal workflow update execute \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\n```"
+		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to complete or fail. You can also use this to wait for an existing\nupdate to complete, by submitting an existing update ID.\n\nExperimental.\n\n```\ntemporal workflow update execute \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.UpdateOptions.buildFlags(cctx, s.Command.Flags())
@@ -2675,11 +2675,11 @@ func NewTemporalWorkflowUpdateStartCommand(cctx *CommandContext, parent *Tempora
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "start [flags]"
-	s.Command.Short = "Send an Update and wait for it to be accepted or rejected"
+	s.Command.Short = "Send an Update and wait for it to be accepted or rejected (Experimental)"
 	if hasHighlighting {
-		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to be accepted or rejected. You can subsequently wait for the update\nto complete by using \x1b[1mtemporal workflow update execute\x1b[0m.\n\n\x1b[1mtemporal workflow update start \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\x1b[0m"
+		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to be accepted or rejected. You can subsequently wait for the update\nto complete by using \x1b[1mtemporal workflow update execute\x1b[0m.\n\nExperimental.\n\n\x1b[1mtemporal workflow update start \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\x1b[0m"
 	} else {
-		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to be accepted or rejected. You can subsequently wait for the update\nto complete by using `temporal workflow update execute`.\n\n```\ntemporal workflow update start \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\n```"
+		s.Command.Long = "Send a message to a Workflow Execution to invoke an Update handler, and wait for\nthe update to be accepted or rejected. You can subsequently wait for the update\nto complete by using `temporal workflow update execute`.\n\nExperimental.\n\n```\ntemporal workflow update start \\\n    --workflow-id YourWorkflowId \\\n    --name YourUpdate \\\n    --input '{\"some-key\": \"some-value\"}'\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.UpdateOptions.buildFlags(cctx, s.Command.Flags())

--- a/temporalcli/commands.workflow.go
+++ b/temporalcli/commands.workflow.go
@@ -187,7 +187,15 @@ func (c *TemporalWorkflowTerminateCommand) run(cctx *CommandContext, _ []string)
 }
 
 func (c *TemporalWorkflowUpdateStartCommand) run(cctx *CommandContext, args []string) error {
-	return workflowUpdateHelper(cctx, c.Parent.Parent.ClientOptions, c.PayloadInputOptions, c.UpdateOptions, client.WorkflowUpdateStageAccepted)
+	waitForStage := client.WorkflowUpdateStageUnspecified
+	switch c.WaitForStage.Value {
+	case "accepted":
+		waitForStage = client.WorkflowUpdateStageAccepted
+	}
+	if waitForStage != client.WorkflowUpdateStageAccepted {
+		return fmt.Errorf("invalid wait for stage: %v, valid values are: 'accepted'", c.WaitForStage)
+	}
+	return workflowUpdateHelper(cctx, c.Parent.Parent.ClientOptions, c.PayloadInputOptions, c.UpdateOptions, waitForStage)
 }
 
 func (c *TemporalWorkflowUpdateExecuteCommand) run(cctx *CommandContext, args []string) error {

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -473,7 +473,9 @@ func (t workflowUpdateTest) testWorkflowUpdateHelper() {
 		res = t.s.Execute("workflow", "update", "start", "--wait-for-stage", "accepted", "--address", t.s.Address(), "-w", "nonexistent-wf-id", "--name", updateName, "-i", strconv.Itoa(input))
 		t.s.ErrorContains(res.Err, "unable to update workflow")
 
-		// TODO: wrong update name is not currently an error when using `update start` (?!)
+		// update rejected, wrong update name
+		res = t.s.Execute("workflow", "update", "start", "--wait-for-stage", "accepted", "--address", t.s.Address(), "-w", run.GetID(), "--name", "nonexistent-update-name", "-i", strconv.Itoa(input))
+		t.s.ErrorContains(res.Err, "unable to update workflow")
 	} else {
 		// update rejected, name not supplied
 		res = t.s.Execute("workflow", "update", "execute", "--address", t.s.Address(), "-w", run.GetID(), "-i", strconv.Itoa(input))
@@ -484,7 +486,6 @@ func (t workflowUpdateTest) testWorkflowUpdateHelper() {
 		t.s.ErrorContains(res.Err, "unable to update workflow")
 
 		// update rejected, wrong update name
-		// This is not currently an error when using `update start`: the SDK accepts the update before checking whether a handler exists.
 		res = t.s.Execute("workflow", "update", "execute", "--address", t.s.Address(), "-w", run.GetID(), "--name", "nonexistent-update-name", "-i", strconv.Itoa(input))
 		t.s.ErrorContains(res.Err, "unable to update workflow")
 	}

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -183,6 +183,7 @@ func (s *SharedServerSuite) SetupSuite() {
 			// Enable for operator cluster commands
 			EnableGlobalNamespace: true,
 			DynamicConfigValues: map[string]any{
+				"frontend.enableUpdateWorkflowExecutionAsyncAccepted": true,
 				// Allow a high rate of change to namespaces, particularly
 				// for the task-queue command tests.
 				"frontend.namespaceRPS.visibility": 10000,

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -2576,5 +2576,12 @@ temporal workflow update start \
 
 #### Options
 
+* `--wait-for-stage` (string-enum) - 
+  Update stage to wait for.
+  The only option is `accepted`, but this option is  required. This is to allow
+  a future version of the CLI to choose a default value.
+  Options: accepted.
+  Required.
+
 Includes options set for [update](#options-set-for-update).
 Includes options set for [payload input](#options-set-for-payload-input).

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -2521,14 +2521,19 @@ temporal workflow trace \
 
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 
-### temporal workflow update: Start and wait for Updates
+### temporal workflow update: Start and wait for Updates (Experimental)
 An Update is a synchronous call to a Workflow Execution that can change its
 state, control its flow, and return a result.
 
-### temporal workflow update execute: Send an Update and wait for it to complete
+Experimental.
+
+
+### temporal workflow update execute: Send an Update and wait for it to complete (Experimental)
 Send a message to a Workflow Execution to invoke an Update handler, and wait for
 the update to complete or fail. You can also use this to wait for an existing
 update to complete, by submitting an existing update ID.
+
+Experimental.
 
 ```
 temporal workflow update execute \
@@ -2562,10 +2567,12 @@ temporal workflow update execute \
 
 Includes options set for [payload input](#options-set-for-payload-input).
 
-### temporal workflow update start: Send an Update and wait for it to be accepted or rejected
+### temporal workflow update start: Send an Update and wait for it to be accepted or rejected (Experimental)
 Send a message to a Workflow Execution to invoke an Update handler, and wait for
 the update to be accepted or rejected. You can subsequently wait for the update
 to complete by using `temporal workflow update execute`.
+
+Experimental.
 
 ```
 temporal workflow update start \

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -2122,7 +2122,7 @@ temporal workflow execute
     --workflow-id YourWorkflowId \
     --type YourWorkflow \
     --task-queue YourTaskQueue \
-    --input '{"Input": "As-JSON"}'
+    --input '{"some-key": "some-value"}'
 ```
 
 Use `--event-details` to relay updates to the command-line output in JSON
@@ -2373,7 +2373,7 @@ temporal workflow start \
 		--workflow-id YourWorkflowId \
 		--type YourWorkflow \
 		--task-queue YourTaskQueue \
-		--input '{"Input": "As-JSON"}'
+		--input '{"some-key": "some-value"}'
 ```
 
 #### Options set for shared workflow start:
@@ -2521,19 +2521,23 @@ temporal workflow trace \
 
 Includes options set for [workflow reference](#options-set-for-workflow-reference).
 
-### temporal workflow update: Synchronously run a Workflow update handler
+### temporal workflow update: Start and wait for Updates
+An Update is a synchronous call to a Workflow Execution that can change its
+state, control its flow, and return a result.
 
-Send a message to a Workflow Execution to invoke an update handler. An update
-can change the state of a Workflow Execution and return a response:
+### temporal workflow update execute: Send an Update and wait for it to complete
+Send a message to a Workflow Execution to invoke an Update handler, and wait for
+the update to complete or fail. You can also use this to wait for an existing
+update to complete, by submitting an existing update ID.
 
 ```
-temporal workflow update \
+temporal workflow update execute \
     --workflow-id YourWorkflowId \
     --name YourUpdate \
-    --input '{"Input": "As-JSON"}'
+    --input '{"some-key": "some-value"}'
 ```
 
-#### Options
+#### Options set for update
 
 * `--name` (string) -
   Handler method name.
@@ -2554,4 +2558,23 @@ temporal workflow update \
   The update is sent to the last Workflow Execution in the chain started
   with this Run ID.
 
+#### Options
+
+Includes options set for [payload input](#options-set-for-payload-input).
+
+### temporal workflow update start: Send an Update and wait for it to be accepted or rejected
+Send a message to a Workflow Execution to invoke an Update handler, and wait for
+the update to be accepted or rejected. You can subsequently wait for the update
+to complete by using `temporal workflow update execute`.
+
+```
+temporal workflow update start \
+    --workflow-id YourWorkflowId \
+    --name YourUpdate \
+    --input '{"some-key": "some-value"}'
+```
+
+#### Options
+
+Includes options set for [update](#options-set-for-update).
 Includes options set for [payload input](#options-set-for-payload-input).


### PR DESCRIPTION
Closes https://github.com/temporalio/cli/issues/597

This PR changes the CLI API so that `workflow update` is not itself a leaf command, but has two leaf subcommands: `start` and `execute`. Previously, `workflow update` had the behavior of what is now `workflow update`, so this is a breaking change to the not-yet-GA workflow update feature.

`workflow update start` will output the update ID. In order to block and fetch the result of the update, users can do `workflow update execute` passing the started update ID. See https://github.com/temporalio/cli/issues/647 for relevant plans to evolve the CLI update API, creating a new way to fetch the result.

### How this was tested

- Manually against a Python sample
- PR adds integration tests
