### PR TITLE
add --public-path option to the command

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1285,6 +1285,7 @@ type TemporalServerStartDevCommand struct {
 	Headless           bool
 	Ip                 string
 	UiIp               string
+	UiPublicPath       string
 	UiAssetPath        string
 	UiCodecEndpoint    string
 	SqlitePragma       []string
@@ -1314,6 +1315,7 @@ func NewTemporalServerStartDevCommand(cctx *CommandContext, parent *TemporalServ
 	s.Command.Flags().BoolVar(&s.Headless, "headless", false, "Disable the Web UI.")
 	s.Command.Flags().StringVar(&s.Ip, "ip", "localhost", "IP address bound to the frontend Service.")
 	s.Command.Flags().StringVar(&s.UiIp, "ui-ip", "", "IP address bound to the WebUI. Default is same as '--ip' value.")
+	s.Command.Flags().StringVar(&s.UiPublicPath, "ui-public-path", "", "The public base path for the Web UI. Default is `/`.")
 	s.Command.Flags().StringVar(&s.UiAssetPath, "ui-asset-path", "", "UI custom assets path.")
 	s.Command.Flags().StringVar(&s.UiCodecEndpoint, "ui-codec-endpoint", "", "UI remote codec HTTP endpoint.")
 	s.Command.Flags().StringArrayVar(&s.SqlitePragma, "sqlite-pragma", nil, "SQLite pragma statements in \"PRAGMA=VALUE\" format.")

--- a/temporalcli/commands.server.go
+++ b/temporalcli/commands.server.go
@@ -81,7 +81,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 				return fmt.Errorf("can't set UI port %d: %w", opts.UIPort, err)
 			}
 		}
-		opts.UIAssetPath, opts.UICodecEndpoint = t.UiAssetPath, t.UiCodecEndpoint
+		opts.UIAssetPath, opts.UICodecEndpoint, opts.PublicPath = t.UiAssetPath, t.UiCodecEndpoint, t.UiPublicPath
 	}
 	// Pragmas and dyn config
 	var err error
@@ -157,7 +157,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 	cctx.Printer.Printlnf("CLI %v\n", VersionString())
 	cctx.Printer.Printlnf("%-8s %v:%v", "Server:", toFriendlyIp(opts.FrontendIP), opts.FrontendPort)
 	if !t.Headless {
-		cctx.Printer.Printlnf("%-8s http://%v:%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort)
+		cctx.Printer.Printlnf("%-8s http://%v:%v%v", "UI:", toFriendlyIp(opts.UIIP), opts.UIPort, opts.PublicPath)
 	}
 	cctx.Printer.Printlnf("%-8s http://%v:%v/metrics", "Metrics:", toFriendlyIp(opts.FrontendIP), opts.MetricsPort)
 	<-cctx.Done()

--- a/temporalcli/commandsmd/commands.md
+++ b/temporalcli/commandsmd/commands.md
@@ -1311,6 +1311,9 @@ temporal server start-dev \
 * `--ui-ip` (string) -
   IP address bound to the WebUI.
   Default is same as '--ip' value.
+* `--ui-public-path` (string) -
+  The public base path for the Web UI.
+  Default is `/`.
 * `--ui-asset-path` (string) -
   UI custom assets path.
 * `--ui-codec-endpoint` (string) -

--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -74,6 +74,7 @@ type StartOptions struct {
 	UIPort                int    // Required if UIIP is non-empty
 	UIAssetPath           string
 	UICodecEndpoint       string
+	PublicPath            string
 	DatabaseFile          string
 	MetricsPort           int
 	PProfPort             int
@@ -156,6 +157,7 @@ func (s *StartOptions) buildUIServer() *uiserver.Server {
 		Port:                s.UIPort,
 		TemporalGRPCAddress: fmt.Sprintf("%v:%v", MaybeEscapeIPv6(s.FrontendIP), s.FrontendPort),
 		EnableUI:            true,
+		PublicPath:          s.PublicPath,
 		UIAssetPath:         s.UIAssetPath,
 		Codec:               uiconfig.Codec{Endpoint: s.UICodecEndpoint},
 		CORS:                uiconfig.CORS{CookieInsecure: true},


### PR DESCRIPTION
add an option in the cli to configure the public path for the UI in dev mode

<!--- For ALL Contributors 👇 -->

## What was changed

add `--public-path` option to the command

## Why?

 * creating a quarkus extension for temporal
 * add an easy way to proxify the temporal devservice (`/q/temporal`)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
