### PR TITLE
Dump junit.xml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
-      - run: mkdir junit-xml
+      - name: Create junit-xml directory
+        run: mkdir junit-xml
 
       - name: Test
         run: gotestsum --junitfile junit-xml/${{matrix.os}}.xml -- ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
       - run: mkdir junit-xml
 
       - name: Test
+        shell: bash
         run: go test ./... 2>&1 | tee >(go-junit-report -set-exit-code > junit-xml/${{matrix.os}}.xml)
 
       - name: 'Upload junit-xml artifacts'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,21 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Install go-junit-report
+        run: go install github.com/jstemmer/go-junit-report/v2@latest
+
+      - run: mkdir junit-xml
+
       - name: Test
-        run: go test ./...
+        run: go test ./... 2>&1 | tee >(go-junit-report -set-exit-code > junit-xml/${{matrix.os}}.xml)
+
+      - name: 'Upload junit-xml artifacts'
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.os}}
+          path: junit-xml
+          retention-days: 14
 
       - name: Regen code, confirm unchanged
         if: ${{ matrix.checkGenCodeTarget }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,14 +29,13 @@ jobs:
         with:
           go-version: '1.22'
 
-      - name: Install go-junit-report
-        run: go install github.com/jstemmer/go-junit-report/v2@latest
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
 
       - run: mkdir junit-xml
 
       - name: Test
-        shell: bash
-        run: go test ./... 2>&1 | tee >(go-junit-report -set-exit-code > junit-xml/${{matrix.os}}.xml)
+        run: gotestsum --junitfile junit-xml/${{matrix.os}}.xml -- ./...
 
       - name: 'Upload junit-xml artifacts'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: '1.22'
 
       - name: Test
         run: go test ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,14 @@ jobs:
       - run: mkdir junit-xml
 
       - name: Test
+        if: runner.os != 'Windows'
         shell: bash
         run: go test ./... 2>&1 | tee >(go-junit-report -set-exit-code > junit-xml/${{matrix.os}}.xml)
+
+      - name: Test (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: go test ./... 2>&1 | Tee-Object output.log; go-junit-report -set-exit-code < output.log > junit-xml/${{matrix.os}}.xml
 
       - name: 'Upload junit-xml artifacts'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,14 +35,8 @@ jobs:
       - run: mkdir junit-xml
 
       - name: Test
-        if: runner.os != 'Windows'
         shell: bash
         run: go test ./... 2>&1 | tee >(go-junit-report -set-exit-code > junit-xml/${{matrix.os}}.xml)
-
-      - name: Test (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: go test ./... 2>&1 | Tee-Object output.log; go-junit-report -set-exit-code < output.log > junit-xml/${{matrix.os}}.xml
 
       - name: 'Upload junit-xml artifacts'
         uses: actions/upload-artifact@v4

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -444,7 +444,7 @@ func (t workflowUpdateTest) testWorkflowUpdateHelper() {
 	// successful update, output should contain the result
 	res := t.execute("workflow", "update", "execute", "--address", t.s.Address(), "-w", run.GetID(), "--name", updateName, "-i", strconv.Itoa(input))
 	t.s.NoError(res.Err)
-	t.s.ContainsOnSameLine(res.Stdout.String(), "Result", strconv.Itoa(1*input))
+	t.s.ContainsOnSameLine(res.Stdout.String(), "Resultx", strconv.Itoa(1*input))
 
 	// successful update passing first-execution-run-id
 	// Use --type here to make sure the alias works

--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -444,7 +444,7 @@ func (t workflowUpdateTest) testWorkflowUpdateHelper() {
 	// successful update, output should contain the result
 	res := t.execute("workflow", "update", "execute", "--address", t.s.Address(), "-w", run.GetID(), "--name", updateName, "-i", strconv.Itoa(input))
 	t.s.NoError(res.Err)
-	t.s.ContainsOnSameLine(res.Stdout.String(), "Resultx", strconv.Itoa(1*input))
+	t.s.ContainsOnSameLine(res.Stdout.String(), "Result", strconv.Itoa(1*input))
 
 	// successful update passing first-execution-run-id
 	// Use --type here to make sure the alias works


### PR DESCRIPTION
This PR switches the tests in CI to dump junit XML files. To do so, it switches to use https://github.com/gotestyourself/gotestsum as the test runner. (This is what the server repo uses also). An example of a build with test failures is here: https://github.com/temporalio/cli/actions/runs/10631569269/job/29472736222

As in https://github.com/temporalio/sdk-python/pull/617, the motivation for this is that, given appropriate tools, it will make it easier for us to study patterns of flakiness, test timings etc, across matrix builds within a run, and across runs.