### PR TITLE
Reduce test suite time

### DIFF
--- a/temporalcli/commands.operator_cluster_test.go
+++ b/temporalcli/commands.operator_cluster_test.go
@@ -159,7 +159,7 @@ func (s *SharedServerSuite) TestOperator_Cluster_Operations() {
 	s.ContainsOnSameLine(out, fmt.Sprintf("\"clusterId\": \"%s\"", standbyCluster2.Options.ClusterID))
 
 	// Need to wait for the cluster cache to be updated
-	time.Sleep(90 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// Remove the clusters
 
@@ -182,4 +182,5 @@ func (s *SharedServerSuite) TestOperator_Cluster_Operations() {
 	jsonOut = make(map[string]string)
 	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &jsonOut))
 	s.Equal(jsonOut["clusterName"], standbyCluster2.Options.CurrentClusterName)
+	// assert.Equal(t, 1, 2)
 }

--- a/temporalcli/commands.operator_cluster_test.go
+++ b/temporalcli/commands.operator_cluster_test.go
@@ -182,5 +182,4 @@ func (s *SharedServerSuite) TestOperator_Cluster_Operations() {
 	jsonOut = make(map[string]string)
 	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &jsonOut))
 	s.Equal(jsonOut["clusterName"], standbyCluster2.Options.CurrentClusterName)
-	// assert.Equal(t, 1, 2)
 }

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -336,6 +336,7 @@ func StartDevServer(t *testing.T, options DevServerOptions) *DevServer {
 	d.Options.DynamicConfigValues["frontend.enableUpdateWorkflowExecution"] = true
 	d.Options.DynamicConfigValues["frontend.MaxConcurrentBatchOperationPerNamespace"] = 1000
 	d.Options.DynamicConfigValues["frontend.namespaceRPS.visibility"] = 100
+	d.Options.DynamicConfigValues["system.clusterMetadataRefreshInterval"] = time.Second
 
 	d.Options.GRPCInterceptors = append(
 		d.Options.GRPCInterceptors,


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Set cluster cache refresh rate to seconds instead of minutes. Now our test doesn't need to wait 60+ seconds for the cache to refresh

## Why?
<!-- Tell your future self why have you made these changes -->
Speed up tests

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

#645
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran test locally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
