### PR TITLE
Add global `context-rpc-timeout` option

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -247,7 +247,7 @@ type TemporalCommand struct {
 	TimeFormat              StringEnum
 	Color                   StringEnum
 	NoJsonShorthandPayloads bool
-	RpcTimeout              Duration
+	CommandTimeout          Duration
 }
 
 func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
@@ -281,8 +281,8 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Color = NewStringEnum([]string{"always", "never", "auto"}, "auto")
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Output coloring. Accepted values: always, never, auto.")
 	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Raw payload output, even if they are JSON.")
-	s.RpcTimeout = Duration(10000 * time.Millisecond)
-	s.Command.PersistentFlags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for all underlying RPC calls for the CLI.")
+	s.CommandTimeout = 0
+	s.Command.PersistentFlags().Var(&s.CommandTimeout, "command-timeout", "Timeout for the span of a command.")
 	s.initCommand(cctx)
 	return &s
 }

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -245,7 +245,7 @@ type TemporalCommand struct {
 	TimeFormat              StringEnum
 	Color                   StringEnum
 	NoJsonShorthandPayloads bool
-	ContextRpcTimeout       Duration
+	RpcTimeout              Duration
 }
 
 func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
@@ -279,8 +279,8 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Color = NewStringEnum([]string{"always", "never", "auto"}, "auto")
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Output coloring. Accepted values: always, never, auto.")
 	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Raw payload output, even if they are JSON.")
-	s.ContextRpcTimeout = Duration(20000 * time.Millisecond)
-	s.Command.PersistentFlags().Var(&s.ContextRpcTimeout, "context-rpc-timeout", "Timeout for the underlying RPC call for a context call.")
+	s.RpcTimeout = Duration(10000 * time.Millisecond)
+	s.Command.PersistentFlags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for the underlying RPC call for a context call.")
 	s.initCommand(cctx)
 	return &s
 }

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -2673,8 +2673,9 @@ type TemporalWorkflowShowCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	Follow   bool
-	Detailed bool
+	Follow     bool
+	Detailed   bool
+	RpcTimeout Duration
 }
 
 func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowShowCommand {
@@ -2691,6 +2692,8 @@ func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkfl
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().BoolVarP(&s.Follow, "follow", "f", false, "Follow the Workflow Execution progress in real time. Does not apply to JSON output.")
 	s.Command.Flags().BoolVar(&s.Detailed, "detailed", false, "Display events as detailed sections instead of table. Does not apply to JSON output.")
+	s.RpcTimeout = 0
+	s.Command.Flags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for gRPC calls.")
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -245,6 +245,7 @@ type TemporalCommand struct {
 	TimeFormat              StringEnum
 	Color                   StringEnum
 	NoJsonShorthandPayloads bool
+	ContextRpcTimeout       Duration
 }
 
 func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
@@ -278,6 +279,8 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Color = NewStringEnum([]string{"always", "never", "auto"}, "auto")
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Output coloring. Accepted values: always, never, auto.")
 	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Raw payload output, even if they are JSON.")
+	s.ContextRpcTimeout = Duration(20000 * time.Millisecond)
+	s.Command.PersistentFlags().Var(&s.ContextRpcTimeout, "context-rpc-timeout", "Timeout for the underlying RPC call for a context call.")
 	s.initCommand(cctx)
 	return &s
 }
@@ -2673,9 +2676,8 @@ type TemporalWorkflowShowCommand struct {
 	Parent  *TemporalWorkflowCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	Follow     bool
-	Detailed   bool
-	RpcTimeout Duration
+	Follow   bool
+	Detailed bool
 }
 
 func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkflowCommand) *TemporalWorkflowShowCommand {
@@ -2692,8 +2694,6 @@ func NewTemporalWorkflowShowCommand(cctx *CommandContext, parent *TemporalWorkfl
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().BoolVarP(&s.Follow, "follow", "f", false, "Follow the Workflow Execution progress in real time. Does not apply to JSON output.")
 	s.Command.Flags().BoolVar(&s.Detailed, "detailed", false, "Display events as detailed sections instead of table. Does not apply to JSON output.")
-	s.RpcTimeout = 0
-	s.Command.Flags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for gRPC calls.")
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -280,7 +280,7 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Output coloring. Accepted values: always, never, auto.")
 	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Raw payload output, even if they are JSON.")
 	s.RpcTimeout = Duration(10000 * time.Millisecond)
-	s.Command.PersistentFlags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for the underlying RPC call for a context call.")
+	s.Command.PersistentFlags().Var(&s.RpcTimeout, "rpc-timeout", "Timeout for all underlying RPC calls for the CLI.")
 	s.initCommand(cctx)
 	return &s
 }

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -52,7 +52,7 @@ type CommandContext struct {
 
 	// Cancel function that comes from manually adding a deadline for RPC
 	// timeout within a context call
-	ContextRpcTimeoutCancel context.CancelFunc
+	RpcTimeoutCancel context.CancelFunc
 
 	// Is set to true if any command actually started running. This is a hack to workaround the fact
 	// that cobra does not properly exit nonzero if an unknown command/subcommand is given.
@@ -357,8 +357,8 @@ func Execute(ctx context.Context, options CommandOptions) {
 	}
 
 	// Clean up resources from setting a context RPC timeout (context-rpc-timeout)
-	if cctx.ContextRpcTimeoutCancel != nil {
-		cctx.ContextRpcTimeoutCancel()
+	if cctx.RpcTimeoutCancel != nil {
+		cctx.RpcTimeoutCancel()
 	}
 
 	// If no command ever actually got run, exit nonzero with an error.  This is
@@ -505,7 +505,12 @@ func (c *TemporalCommand) preRun(cctx *CommandContext) error {
 	}
 	cctx.JSONShorthandPayloads = !c.NoJsonShorthandPayloads
 
-	cctx.Context, cctx.ContextRpcTimeoutCancel = context.WithDeadline(cctx.Context, time.Now().Add(c.ContextRpcTimeout.Duration()))
+	if c.RpcTimeout.Duration() != time.Second*10 {
+		// We multiply the timeout by 2 because the client SDK sets the RPC timeout
+		// to half of the Deadline
+		newDeadline := time.Now().Add(c.RpcTimeout.Duration() * 2)
+		cctx.Context, cctx.RpcTimeoutCancel = context.WithDeadline(cctx.Context, newDeadline)
+	}
 
 	return nil
 }

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -495,7 +495,13 @@ func (c *TemporalCommand) preRun(cctx *CommandContext) error {
 		}
 	}
 	cctx.JSONShorthandPayloads = !c.NoJsonShorthandPayloads
-	cctx.Context, _ = context.WithDeadline(cctx.Context, time.Now().Add(c.CommandTimeout.Duration()))
+	if c.CommandTimeout.Duration() > 0 {
+		cctx.Context, _ = context.WithTimeoutCause(
+			cctx.Context,
+			c.CommandTimeout.Duration(),
+			fmt.Errorf("command timed out after %v", c.CommandTimeout.Duration()),
+		)
+	}
 
 	return nil
 }

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -495,7 +495,6 @@ func (c *TemporalCommand) preRun(cctx *CommandContext) error {
 		}
 	}
 	cctx.JSONShorthandPayloads = !c.NoJsonShorthandPayloads
-	fmt.Println("rpcTimeout", c.CommandTimeout.Duration())
 	cctx.Context, _ = context.WithDeadline(cctx.Context, time.Now().Add(c.CommandTimeout.Duration()))
 
 	return nil

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -1,7 +1,6 @@
 package temporalcli
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -448,12 +447,6 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) erro
 		return err
 	}
 	defer cl.Close()
-
-	if c.RpcTimeout > 0 {
-		var cancel context.CancelFunc
-		cctx.Context, cancel = context.WithDeadline(cctx.Context, time.Now().Add(c.RpcTimeout.Duration()))
-		defer cancel()
-	}
 
 	// Print history
 	iter := &structuredHistoryIter{

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -1,6 +1,7 @@
 package temporalcli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -447,6 +448,12 @@ func (c *TemporalWorkflowShowCommand) run(cctx *CommandContext, _ []string) erro
 		return err
 	}
 	defer cl.Close()
+
+	if c.RpcTimeout > 0 {
+		var cancel context.CancelFunc
+		cctx.Context, cancel = context.WithDeadline(cctx.Context, time.Now().Add(c.RpcTimeout.Duration()))
+		defer cancel()
+	}
 
 	// Print history
 	iter := &structuredHistoryIter{

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -195,6 +195,10 @@ commands:
       - name: no-json-shorthand-payloads
         type: bool
         description: Raw payload output, even if they are JSON.
+      - name: context-rpc-timeout
+        type: duration
+        description: Timeout for the underlying RPC call for a context call.
+        default: 20s
 
   - name: temporal activity
     summary: Complete or fail an Activity
@@ -2503,9 +2507,6 @@ commands:
         description: |
           Display events as detailed sections instead of table.
           Does not apply to JSON output.
-      - name: rpc-timeout
-        type: duration
-        description: Timeout for gRPC calls.
     option-sets:
       - workflow-reference
 

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -195,10 +195,9 @@ commands:
       - name: no-json-shorthand-payloads
         type: bool
         description: Raw payload output, even if they are JSON.
-      - name: rpc-timeout
+      - name: command-timeout
         type: duration
-        description: Timeout for all underlying RPC calls for the CLI.
-        default: 10s
+        description: Timeout for the span of a command.
 
   - name: temporal activity
     summary: Complete or fail an Activity

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -195,10 +195,10 @@ commands:
       - name: no-json-shorthand-payloads
         type: bool
         description: Raw payload output, even if they are JSON.
-      - name: context-rpc-timeout
+      - name: rpc-timeout
         type: duration
-        description: Timeout for the underlying RPC call for a context call.
-        default: 20s
+        description: Timeout for all underlying RPC calls for the CLI.
+        default: 10s
 
   - name: temporal activity
     summary: Complete or fail an Activity

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -2503,6 +2503,9 @@ commands:
         description: |
           Display events as detailed sections instead of table.
           Does not apply to JSON output.
+      - name: rpc-timeout
+        type: duration
+        description: Timeout for gRPC calls.
     option-sets:
       - workflow-reference
 


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added a new global RPC timeout for within a context.

## Why?
<!-- Tell your future self why have you made these changes -->
A slow remote codec can cause timeouts

## Checklist
<!--- add/delete as needed --->

1. Closes #648

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
