### PR TITLE
Make `--reapply-type All` reapply updates in addition to signals

### DIFF
--- a/temporalcli/commands.workflow_reset.go
+++ b/temporalcli/commands.workflow_reset.go
@@ -98,7 +98,7 @@ func (c *TemporalWorkflowResetCommand) doWorkflowReset(cctx *CommandContext, cl 
 	reapplyType := enums.RESET_REAPPLY_TYPE_SIGNAL
 	if c.ReapplyType.Value != "All" {
 		if len(c.ReapplyExclude.Values) > 0 {
-			return errors.New("cannot specify --reapply-type and --reapply-exclude at the same time")
+			return errors.New("--reapply-type cannot be used with --reapply-exclude. Use --reapply-exclude.")
 		}
 		reapplyType, err = enums.ResetReapplyTypeFromString(c.ReapplyType.Value)
 		if err != nil {

--- a/temporalcli/commands.workflow_reset.go
+++ b/temporalcli/commands.workflow_reset.go
@@ -95,7 +95,7 @@ func (c *TemporalWorkflowResetCommand) doWorkflowReset(cctx *CommandContext, cl 
 		reapplyExcludes = append(reapplyExcludes, excludeType)
 	}
 
-	reapplyType := enums.RESET_REAPPLY_TYPE_SIGNAL
+	reapplyType := enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
 	if c.ReapplyType.Value != "All" {
 		if len(c.ReapplyExclude.Values) > 0 {
 			return errors.New("--reapply-type cannot be used with --reapply-exclude. Use --reapply-exclude.")


### PR DESCRIPTION
- Fixes #679: we should have been reapplying updates by default but we were not
- Refactor and clean-up test
- Add missing test coverage

