### PR TITLE
fix(sqlite): support all sqlite pragma statement

### DIFF
--- a/temporalcli/devserver/server.go
+++ b/temporalcli/devserver/server.go
@@ -321,13 +321,7 @@ func (s *StartOptions) buildSQLConfig() (*config.SQL, error) {
 		conf.DatabaseName = s.DatabaseFile
 	}
 	for k, v := range s.SqlitePragmas {
-		// Only some pragmas allowed
-		switch k {
-		case "journal_mode", "synchronous":
-		default:
-			return nil, fmt.Errorf("unrecognized pragma %q, only 'journal_mode' and 'synchronous' allowed", k)
-		}
-		conf.ConnectAttributes["_"+k] = v
+		conf.ConnectAttributes[k] = v
 	}
 
 	// Apply migrations to sqlite if using file but it does not exist


### PR DESCRIPTION
## What was changed

- I removed the extra underscore in the key
- I removed the pragma key check

## Why?

- the extra underscore was breaking the pragma support, because sqlite couldn't recognise the pragma key
- the pragma key check was too restricting, users should be able to configure any pragma statement from https://www.sqlite.org/pragma.html - removing the check all to use any pragma, without adding more work to maintain an hardcoded list

## Checklist

1. Closes https://github.com/temporalio/cli/issues/681

2. How was this tested:

manually:
- by running `./temporal server start-dev --db-filename temporal.sqlite --sqlite-pragma journal_mode=WAL --sqlite-pragma synchronous=NORMAL --sqlite-pragma busy_timeout=5000`
- and ensuring that 3 files have been created: `temporal.sqlite`, `temporal.sqlite-shm` and `temporal.sqlite-wal`

3. Any docs updates needed?

no, because it's just a bug fix. the docs are already there.
