### PR TITLE
EDU-3157: Add instructions on how to remove Search Attributes

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -1252,9 +1252,9 @@ func NewTemporalOperatorSearchAttributeCommand(cctx *CommandContext, parent *Tem
 	s.Command.Use = "search-attribute"
 	s.Command.Short = "Search Attribute operations"
 	if hasHighlighting {
-		s.Command.Long = "Create, list, or remove Search Attributes fields stored in a Workflow\nExecution's metadata:\n\n\x1b[1mtemporal operator search-attribute create \\\n    --name YourAttributeName \\\n    --type Keyword\x1b[0m\n\nSupported types include: Text, Keyword, Int, Double, Bool, Datetime, and\nKeywordList."
+		s.Command.Long = "Create, list, or remove Search Attributes fields stored in a Workflow\nExecution's metadata:\n\n\x1b[1mtemporal operator search-attribute create \\\n    --name YourAttributeName \\\n    --type Keyword\x1b[0m\n\nSupported types include: Text, Keyword, Int, Double, Bool, Datetime, and\nKeywordList.\n\nIf you wish to delete a Search Attribute, please contact support\nat https://support.temporal.io."
 	} else {
-		s.Command.Long = "Create, list, or remove Search Attributes fields stored in a Workflow\nExecution's metadata:\n\n```\ntemporal operator search-attribute create \\\n    --name YourAttributeName \\\n    --type Keyword\n```\n\nSupported types include: Text, Keyword, Int, Double, Bool, Datetime, and\nKeywordList."
+		s.Command.Long = "Create, list, or remove Search Attributes fields stored in a Workflow\nExecution's metadata:\n\n```\ntemporal operator search-attribute create \\\n    --name YourAttributeName \\\n    --type Keyword\n```\n\nSupported types include: Text, Keyword, Int, Double, Bool, Datetime, and\nKeywordList.\n\nIf you wish to delete a Search Attribute, please contact support\nat https://support.temporal.io."
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.AddCommand(&NewTemporalOperatorSearchAttributeCreateCommand(cctx, &s).Command)

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -1013,6 +1013,9 @@ commands:
       Supported types include: Text, Keyword, Int, Double, Bool, Datetime, and
       KeywordList.
 
+      If you wish to delete a Search Attribute, please contact support
+      at https://support.temporal.io.
+
   - name: temporal operator search-attribute create
     summary: Add custom Search Attributes
     description: |


### PR DESCRIPTION
## What was changed

Quick addition -- to remove search attributes, must contact support.

Source of truth: Jordan Reynolds
See also: Playbook https://runbooks.tmprl-internal.cloud/untriaged/on-call-namespace-customer-operations/adding-renaming-custom-search-attributes/ for reference

Docs PR https://github.com/temporalio/documentation/pull/3112
(Note: This PR does not touch CLI docs)