### PR TITLE
Add id-conflict-policy

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -177,10 +177,11 @@ func (v *SharedWorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.F
 }
 
 type WorkflowStartOptions struct {
-	Cron          string
-	FailExisting  bool
-	StartDelay    Duration
-	IdReusePolicy StringEnum
+	Cron             string
+	FailExisting     bool
+	StartDelay       Duration
+	IdReusePolicy    StringEnum
+	IdConflictPolicy StringEnum
 }
 
 func (v *WorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
@@ -190,6 +191,8 @@ func (v *WorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet
 	f.Var(&v.StartDelay, "start-delay", "Delay before starting the Workflow Execution. Can't be used with cron schedules. If the Workflow receives a signal or update prior to this time, the Workflow Execution starts immediately.")
 	v.IdReusePolicy = NewStringEnum([]string{"AllowDuplicate", "AllowDuplicateFailedOnly", "RejectDuplicate", "TerminateIfRunning"}, "")
 	f.Var(&v.IdReusePolicy, "id-reuse-policy", "Re-use policy for the Workflow ID in new Workflow Executions. Accepted values: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning.")
+	v.IdConflictPolicy = NewStringEnum([]string{"Fail", "UseExisting", "TerminateExisting"}, "")
+	f.Var(&v.IdConflictPolicy, "id-conflict-policy", "Determines how to resolve a conflict when spawning a new Workflow Execution with a particular Workflow Id used by an existing Open Workflow Execution. Accepted values: Fail, UseExisting, TerminateExisting.")
 }
 
 type PayloadInputOptions struct {

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -283,6 +283,14 @@ func buildStartOptions(sw *SharedWorkflowStartOptions, w *WorkflowStartOptions) 
 			return o, fmt.Errorf("invalid workflow ID reuse policy: %w", err)
 		}
 	}
+	if w.IdConflictPolicy.Value != "" {
+		var err error
+		o.WorkflowIDConflictPolicy, err = stringToProtoEnum[enums.WorkflowIdConflictPolicy](
+			w.IdConflictPolicy.Value, enums.WorkflowIdConflictPolicy_shorthandValue, enums.WorkflowIdConflictPolicy_value)
+		if err != nil {
+			return o, fmt.Errorf("invalid workflow ID conflict policy: %w", err)
+		}
+	}
 	if len(sw.Memo) > 0 {
 		var err error
 		if o.Memo, err = stringKeysJSONValues(sw.Memo, false); err != nil {

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -3076,6 +3076,15 @@ option-sets:
           - AllowDuplicateFailedOnly
           - RejectDuplicate
           - TerminateIfRunning
+      - name: id-conflict-policy
+        type: string-enum
+        description: |
+          Determines how to resolve a conflict when spawning a new Workflow Execution
+          with a particular Workflow Id used by an existing Open Workflow Execution.
+        enum-values:
+          - Fail
+          - UseExisting
+          - TerminateExisting
   - name: payload-input
     options:
       - name: input


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

ADded id-conflict-policy as a parameter for `workflow start` and `execute`

## Why?
<!-- Tell your future self why have you made these changes -->
Part of larger effort to get WorkflowIdConflictPolicy plumbed through all of the SDKs and CLI.

## Checklist
<!--- add/delete as needed --->

1. Closes #528
