### PR TITLE
Update nexus commands.yml for docs gen

### DIFF
--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -147,7 +147,7 @@ commands:
         type: string
         description: |
           Path to environment settings file.
-          (defaults to `$HOME/.config/temporalio/temporal.yaml`).
+          Defaults to `$HOME/.config/temporalio/temporal.yaml`.
       - name: log-level
         type: string-enum
         enum-values:
@@ -194,7 +194,7 @@ commands:
         default: auto
       - name: no-json-shorthand-payloads
         type: bool
-        description: Raw payload output, even if they are JSON.
+        description: Raw payload output, even if the JSON option was used.
       - name: command-timeout
         type: duration
         description: Timeout for the span of a command.
@@ -542,7 +542,7 @@ commands:
     docs:
       description-header: >-
         Operator commands in Temporal allow actions on Namespaces, Search Attributes,
-        and Clusters using specific subcommands. Execute with
+        Clusters and Nexus Endpoints using specific subcommands. Execute with
         "temporal operator [command] [subcommand] [options]".
       keywords:
         - cli reference
@@ -558,6 +558,13 @@ commands:
         - namespace delete
         - namespace describe
         - namespace list
+        - nexus
+        - nexus endpoint
+        - nexus endpoint create
+        - nexus endpoint delete
+        - nexus endpoint get
+        - nexus endpoint list
+        - nexus endpoint update
         - operator
         - search attribute
         - search attribute create
@@ -737,7 +744,7 @@ commands:
         description: |
           Namespace data as `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey={"your": "value"}'.
+          For example: `'YourKey={"your": "value"}'`.
           Can be passed multiple times.
       - name: description
         type: string
@@ -877,7 +884,7 @@ commands:
         description: |
           Namespace data as `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey={"your": "value"}'.
+          For example: `'YourKey={"your": "value"}'`.
           Can be passed multiple times.
       - name: description
         type: string
@@ -917,29 +924,29 @@ commands:
   - name: temporal operator nexus
     summary: Commands for managing Nexus resources (EXPERIMENTAL)
     description: |
-      Nexus commands enable managing Nexus resources.
+      These commands manage Nexus resources.
 
-      Nexus commands follow this syntax:
+      nexus commands follow this syntax:
 
       ```
-      temporal operator nexus [command] [command] [command options]
+      temporal operator nexus [command] [subcommand] [options]
       ```
 
   - name: temporal operator nexus endpoint
     summary: Commands for managing Nexus Endpoints (EXPERIMENTAL)
     description: |
-      Endpoint commands enable managing Nexus Endpoints.
+      These commands manage Nexus Endpoints.
 
-      Endpoint commands follow this syntax:
+      Nexus Endpoint commands follow this syntax:
 
       ```
-      temporal operator nexus endpoint [command] [command options]
+      temporal operator nexus endpoint [command] [options]
       ```
 
   - name: temporal operator nexus endpoint create
-    summary: Create a new Nexus Endpoint (EXPERIMENTAL)
+    summary: Create a Nexus Endpoint (EXPERIMENTAL)
     description: |
-      Create a new Nexus Endpoint on the Server.
+      Create a Nexus Endpoint on the Server.
 
       An endpoint name is used in workflow code to invoke Nexus operations.  The
       endpoint target may either be a worker, in which case `--target-namespace` and
@@ -955,61 +962,35 @@ commands:
         --target-task-queue your-task-queue \
         --description-file DESCRIPTION.md
       ```
-    options:
-      - name: name
-        type: string
-        description: Endpoint name.
-        required: true
-      - name: description
-        type: string
-        description: |
-          Endpoint description in markdown format (encoded using the configured codec server).
-      - name: description-file
-        type: string
-        description: |
-          Endpoint description file in markdown format (encoded using the configured codec server).
-      - name: target-namespace
-        type: string
-        description: Namespace in which a handler worker will be polling for Nexus tasks on.
-      - name: target-task-queue
-        type: string
-        description: Task Queue in which a handler worker will be polling for Nexus tasks on.
-      - name: target-url
-        type: string
-        description: URL to direct Nexus requests to.
-
+    option-sets:
+      - nexus-endpoint-identity
+      - nexus-endpoint-config
   - name: temporal operator nexus endpoint delete
     summary: Delete a Nexus Endpoint (EXPERIMENTAL)
     description: |
-      Delete a Nexus Endpoint configuration from the Server.
+      Delete a Nexus Endpoint from the Server.
 
       ```
       temporal operator nexus endpoint delete --name your-endpoint
       ```
-    options:
-      - name: name
-        type: string
-        description: Endpoint name.
-        required: true
+    option-sets:
+      - nexus-endpoint-identity
 
   - name: temporal operator nexus endpoint get
     summary: Get a Nexus Endpoint by name (EXPERIMENTAL)
     description: |
-      Get a Nexus Endpoint configuration by name from the Server.
+      Get a Nexus Endpoint by name from the Server.
 
       ```
       temporal operator nexus endpoint get --name your-endpoint
       ```
-    options:
-      - name: name
-        type: string
-        description: Endpoint name.
-        required: true
+    option-sets:
+      - nexus-endpoint-identity
 
   - name: temporal operator nexus endpoint list
     summary: List Nexus Endpoints (EXPERIMENTAL)
     description: |
-      List all Nexus Endpoint configurations on the Server.
+      List all Nexus Endpoints on the Server.
 
       ```
       temporal operator nexus endpoint list
@@ -1043,31 +1024,13 @@ commands:
         --name your-endpoint \
         --description-file DESCRIPTION.md
       ```
+    option-sets:
+      - nexus-endpoint-identity
+      - nexus-endpoint-config
     options:
-      - name: name
-        type: string
-        description: Endpoint name.
-        required: true
-      - name: description
-        type: string
-        description: |
-          Endpoint description in markdown format (encoded using the configured codec server).
-      - name: description-file
-        type: string
-        description: |
-          Endpoint description file in markdown format (encoded using the configured codec server).
       - name: unset-description
         type: bool
         description: Unset the description.
-      - name: target-namespace
-        type: string
-        description: Namespace in which a handler worker will be polling for Nexus tasks on.
-      - name: target-task-queue
-        type: string
-        description: Task Queue in which a handler worker will be polling for Nexus tasks on.
-      - name: target-url
-        type: string
-        description: URL to direct Nexus requests to.
 
   - name: temporal operator search-attribute
     summary: Search Attribute operations
@@ -1555,7 +1518,7 @@ commands:
         description: |
           Dynamic configuration value using `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey="YourString"'.
+          For example: `'YourKey="YourString"'`.
           Can be passed multiple times.
       - name: log-config
         type: bool
@@ -2524,6 +2487,7 @@ commands:
         description: Content for an SQL-like `QUERY` List Filter.
       - name: archived
         type: bool
+        experimental: true
         description: Limit output to archived Workflow Executions.
       - name: limit
         type: int
@@ -2953,6 +2917,7 @@ commands:
 option-sets:
 
   - name: client
+    description: Commands that connect to a Temporal Service
     options:
       - name: address
         type: string
@@ -3035,6 +3000,7 @@ option-sets:
         env: TEMPORAL_CODEC_AUTH
 
   - name: overlap-policy
+    description: Schedule commands
     options:
       - name: overlap-policy
         type: string-enum
@@ -3049,6 +3015,7 @@ option-sets:
         default: Skip
 
   - name: schedule-id
+    description: Schedule commands
     options:
       - name: schedule-id
         type: string
@@ -3057,6 +3024,7 @@ option-sets:
         short: s
 
   - name: schedule-configuration
+    description: Schedule commands
     options:
       - name: calendar
         type: string[]
@@ -3112,17 +3080,18 @@ option-sets:
         description: |
           Set schedule Search Attributes using `KEY="VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey={"your": "value"}'.
+          For example: `'YourKey={"your": "value"}'`.
           Can be passed multiple times.
       - name: schedule-memo
         type: string[]
         description: |
           Set schedule memo using `KEY="VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey={"your": "value"}'.
+          For example: `'YourKey={"your": "value"}'`.
           Can be passed multiple times.
 
   - name: workflow-reference
+    description: Commands that reference a Workflow
     options:
       - name: workflow-id
         type: string
@@ -3135,6 +3104,7 @@ option-sets:
         description: Run ID.
 
   - name: single-workflow-or-batch
+    description: Commands that may use a Batch Job
     options:
       - name: workflow-id
         type: string
@@ -3174,6 +3144,7 @@ option-sets:
           Only allowed if query is present.
 
   - name: shared-workflow-start
+    description: Commands that start a workflow
     options:
       - name: workflow-id
         type: string
@@ -3212,7 +3183,7 @@ option-sets:
         description: |
           Search Attribute in `KEY=VALUE` format.
           Keys must be identifiers, and values must be JSON values.
-          For example: 'YourKey={"your": "value"}'.
+          For example: `'YourKey={"your": "value"}'`.
           Can be passed multiple times.
       - name: memo
         type: string[]
@@ -3221,6 +3192,7 @@ option-sets:
           Use JSON values.
 
   - name: workflow-start
+    description: Commands that start a workflow
     options:
       - name: cron
         type: string
@@ -3256,6 +3228,7 @@ option-sets:
           - UseExisting
           - TerminateExisting
   - name: payload-input
+    description: Commands accepting an input payload
     options:
       - name: input
         type: string[]
@@ -3284,6 +3257,7 @@ option-sets:
           Assume inputs are base64-encoded and attempt to decode them.
 
   - name: update-starting
+    description: Workflow update commands
     options:
       - name: name
         type: string
@@ -3315,6 +3289,7 @@ option-sets:
           If unset, looks for an Update against the currently-running Workflow Execution.
 
   - name: update-targeting
+    description: Workflow update commands
     options:
       - name: workflow-id
         short: w
@@ -3333,3 +3308,37 @@ option-sets:
         description: |
           Run ID.
           If unset, updates the currently-running Workflow Execution.
+
+  - name: nexus-endpoint-identity
+    description: Nexus endpoint commands
+    options:
+      - name: name
+        type: string
+        description: Endpoint name.
+        required: true
+
+  - name: nexus-endpoint-config
+    description: Nexus endpoint commands
+    options:
+      - name: description
+        type: string
+        description: |
+          Nexus Endpoint description.
+          You may use Markdown formatting in the description.
+      - name: description-file
+        type: string
+        description: |
+          Path to the Nexus Endpoint description file.
+          Contents of the description file may use Markdown formatting.
+      - name: target-namespace
+        type: string
+        description: Namespace in which a handler Worker will be poll for Nexus tasks.
+      - name: target-task-queue
+        type: string
+        description: Task Queue in which a handler Worker will poll for Nexus tasks.
+      - name: target-url
+        type: string
+        experimental: true
+        description: |
+          An external Nexus Endpoint where Nexus requests are forwarded to.
+          May be used as an alternative to `--target-namespace` and `--target-task-queue`.

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -195,9 +195,10 @@ commands:
       - name: no-json-shorthand-payloads
         type: bool
         description: Raw payload output, even if the JSON option was used.
-      - name: command-timeout
-        type: duration
-        description: Timeout for the span of a command.
+      # not yet supported
+      #- name: command-timeout
+      #  type: duration
+      #  description: Timeout for the span of a command.
 
   - name: temporal activity
     summary: Complete or fail an Activity
@@ -948,8 +949,8 @@ commands:
     description: |
       Create a Nexus Endpoint on the Server.
 
-      An endpoint name is used in workflow code to invoke Nexus operations.  The
-      endpoint target may either be a worker, in which case `--target-namespace` and
+      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.  The
+      endpoint target may either be a Worker, in which case `--target-namespace` and
       `--target-task-queue` must both be provided, or an external URL, in which case
       `--target-url` must be provided.
 
@@ -1001,8 +1002,8 @@ commands:
     description: |
       Update an existing Nexus Endpoint on the Server.
 
-      An endpoint name is used in workflow code to invoke Nexus operations.  The
-      endpoint target may either be a worker, in which case `--target-namespace` and
+      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.  The
+      endpoint target may either be a Worker, in which case `--target-namespace` and
       `--target-task-queue` must both be provided, or an external URL, in which case
       `--target-url` must be provided.
 
@@ -3324,15 +3325,15 @@ option-sets:
         type: string
         description: |
           Nexus Endpoint description.
-          You may use Markdown formatting in the description.
+          You may use Markdown formatting in the Nexus Endpoint description.
       - name: description-file
         type: string
         description: |
           Path to the Nexus Endpoint description file.
-          Contents of the description file may use Markdown formatting.
+          The contents of the description file may use Markdown formatting.
       - name: target-namespace
         type: string
-        description: Namespace in which a handler Worker will be poll for Nexus tasks.
+        description: Namespace in which a handler Worker will poll for Nexus tasks.
       - name: target-task-queue
         type: string
         description: Task Queue in which a handler Worker will poll for Nexus tasks.

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -926,7 +926,7 @@ commands:
     description: |
       These commands manage Nexus resources.
 
-      nexus commands follow this syntax:
+      Nexus commands follow this syntax:
 
       ```
       temporal operator nexus [command] [subcommand] [options]
@@ -948,10 +948,8 @@ commands:
     description: |
       Create a Nexus Endpoint on the Server.
 
-      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.  The
-      endpoint target may either be a Worker, in which case `--target-namespace` and
-      `--target-task-queue` must both be provided, or an external URL, in which case
-      `--target-url` must be provided.
+      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
+      The endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
 
       This command will fail if an endpoint with the same name is already registered.
 
@@ -1001,10 +999,8 @@ commands:
     description: |
       Update an existing Nexus Endpoint on the Server.
 
-      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.  The
-      endpoint target may either be a Worker, in which case `--target-namespace` and
-      `--target-task-queue` must both be provided, or an external URL, in which case
-      `--target-url` must be provided.
+      A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
+      The endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
 
       The endpoint is patched; existing fields for which flags are not provided are
       left as they were.

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -1001,7 +1001,7 @@ commands:
     summary: Update an existing Nexus Endpoint (EXPERIMENTAL)
     description: |
       Update an existing Nexus Endpoint on the Server.
-      
+     
       A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
       The Endpoint target may either be a Worker, in which case
       `--target-namespace` and `--target-task-queue` must both be provided, or

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -951,7 +951,7 @@ commands:
       A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
       The endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
 
-      This command will fail if an endpoint with the same name is already registered.
+      This command will fail if an Endpoint with the same name is already registered.
 
       ```
       temporal operator nexus endpoint create \
@@ -1000,10 +1000,9 @@ commands:
       Update an existing Nexus Endpoint on the Server.
 
       A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
-      The endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
+      The Endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
 
-      The endpoint is patched; existing fields for which flags are not provided are
-      left as they were.
+      The Endpoint is patched; existing fields for which flags are not provided are left as they were.
 
       Update only the target task queue:
 
@@ -2996,7 +2995,6 @@ option-sets:
         env: TEMPORAL_CODEC_AUTH
 
   - name: overlap-policy
-    description: Schedule commands
     options:
       - name: overlap-policy
         type: string-enum
@@ -3011,7 +3009,6 @@ option-sets:
         default: Skip
 
   - name: schedule-id
-    description: Schedule commands
     options:
       - name: schedule-id
         type: string
@@ -3020,7 +3017,6 @@ option-sets:
         short: s
 
   - name: schedule-configuration
-    description: Schedule commands
     options:
       - name: calendar
         type: string[]
@@ -3087,7 +3083,6 @@ option-sets:
           Can be passed multiple times.
 
   - name: workflow-reference
-    description: Commands that reference a Workflow
     options:
       - name: workflow-id
         type: string
@@ -3100,7 +3095,6 @@ option-sets:
         description: Run ID.
 
   - name: single-workflow-or-batch
-    description: Commands that may use a Batch Job
     options:
       - name: workflow-id
         type: string
@@ -3140,7 +3134,6 @@ option-sets:
           Only allowed if query is present.
 
   - name: shared-workflow-start
-    description: Commands that start a workflow
     options:
       - name: workflow-id
         type: string
@@ -3188,7 +3181,6 @@ option-sets:
           Use JSON values.
 
   - name: workflow-start
-    description: Commands that start a workflow
     options:
       - name: cron
         type: string
@@ -3224,7 +3216,6 @@ option-sets:
           - UseExisting
           - TerminateExisting
   - name: payload-input
-    description: Commands accepting an input payload
     options:
       - name: input
         type: string[]
@@ -3253,7 +3244,6 @@ option-sets:
           Assume inputs are base64-encoded and attempt to decode them.
 
   - name: update-starting
-    description: Workflow update commands
     options:
       - name: name
         type: string
@@ -3285,7 +3275,6 @@ option-sets:
           If unset, looks for an Update against the currently-running Workflow Execution.
 
   - name: update-targeting
-    description: Workflow update commands
     options:
       - name: workflow-id
         short: w
@@ -3306,7 +3295,6 @@ option-sets:
           If unset, updates the currently-running Workflow Execution.
 
   - name: nexus-endpoint-identity
-    description: Nexus endpoint commands
     options:
       - name: name
         type: string
@@ -3314,7 +3302,6 @@ option-sets:
         required: true
 
   - name: nexus-endpoint-config
-    description: Nexus endpoint commands
     options:
       - name: description
         type: string
@@ -3328,13 +3315,13 @@ option-sets:
           The contents of the description file may use Markdown formatting.
       - name: target-namespace
         type: string
-        description: Namespace in which a handler Worker will poll for Nexus tasks.
+        description: Namespace where a handler Worker polls for Nexus tasks.
       - name: target-task-queue
         type: string
-        description: Task Queue in which a handler Worker will poll for Nexus tasks.
+        description: Task Queue that a handler Worker polls for Nexus tasks.
       - name: target-url
         type: string
         experimental: true
         description: |
-          An external Nexus Endpoint where Nexus requests are forwarded to.
+          An external Nexus Endpoint that receives forwarded Nexus requests.
           May be used as an alternative to `--target-namespace` and `--target-task-queue`.

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -195,10 +195,9 @@ commands:
       - name: no-json-shorthand-payloads
         type: bool
         description: Raw payload output, even if the JSON option was used.
-      # not yet supported
-      #- name: command-timeout
-      #  type: duration
-      #  description: Timeout for the span of a command.
+      - name: command-timeout
+        type: duration
+        description: Timeout for the span of a command.
 
   - name: temporal activity
     summary: Complete or fail an Activity

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -744,7 +744,7 @@ commands:
         description: |
           Namespace data as `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey={"your": "value"}'`.
+          For example: 'YourKey={"your": "value"}'.
           Can be passed multiple times.
       - name: description
         type: string
@@ -884,7 +884,7 @@ commands:
         description: |
           Namespace data as `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey={"your": "value"}'`.
+          For example: 'YourKey={"your": "value"}'.
           Can be passed multiple times.
       - name: description
         type: string
@@ -1519,7 +1519,7 @@ commands:
         description: |
           Dynamic configuration value using `KEY=VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey="YourString"'`.
+          For example: 'YourKey="YourString"'.
           Can be passed multiple times.
       - name: log-config
         type: bool
@@ -3078,14 +3078,14 @@ option-sets:
         description: |
           Set schedule Search Attributes using `KEY="VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey={"your": "value"}'`.
+          For example: 'YourKey={"your": "value"}'.
           Can be passed multiple times.
       - name: schedule-memo
         type: string[]
         description: |
           Set schedule memo using `KEY="VALUE` pairs.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey={"your": "value"}'`.
+          For example: 'YourKey={"your": "value"}'.
           Can be passed multiple times.
 
   - name: workflow-reference
@@ -3178,7 +3178,7 @@ option-sets:
         description: |
           Search Attribute in `KEY=VALUE` format.
           Keys must be identifiers, and values must be JSON values.
-          For example: `'YourKey={"your": "value"}'`.
+          For example: 'YourKey={"your": "value"}'.
           Can be passed multiple times.
       - name: memo
         type: string[]

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -541,9 +541,9 @@ commands:
       - client
     docs:
       description-header: >-
-        Operator commands in Temporal allow actions on Namespaces, Search Attributes,
-        Clusters and Nexus Endpoints using specific subcommands. Execute with
-        "temporal operator [command] [subcommand] [options]".
+        Operator commands in Temporal allow actions on Namespaces, Search
+        Attributes, Clusters and Nexus Endpoints using specific subcommands.
+        Execute with "temporal operator [command] [subcommand] [options]".
       keywords:
         - cli reference
         - cluster
@@ -949,9 +949,12 @@ commands:
       Create a Nexus Endpoint on the Server.
 
       A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
-      The endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
-
-      This command will fail if an Endpoint with the same name is already registered.
+      The endpoint target may either be a Worker, in which case
+      `--target-namespace` and `--target-task-queue` must both be provided, or
+      an external URL, in which case `--target-url` must be provided.
+      
+      This command will fail if an Endpoint with the same name is already
+      registered.
 
       ```
       temporal operator nexus endpoint create \
@@ -998,11 +1001,14 @@ commands:
     summary: Update an existing Nexus Endpoint (EXPERIMENTAL)
     description: |
       Update an existing Nexus Endpoint on the Server.
-
+      
       A Nexus Endpoint name is used in Workflow code to invoke Nexus Operations.
-      The Endpoint target may either be a Worker, in which case `--target-namespace` and `--target-task-queue` must both be provided, or an external URL, in which case `--target-url` must be provided.
-
-      The Endpoint is patched; existing fields for which flags are not provided are left as they were.
+      The Endpoint target may either be a Worker, in which case
+      `--target-namespace` and `--target-task-queue` must both be provided, or
+      an external URL, in which case `--target-url` must be provided.
+      
+      The Endpoint is patched; existing fields for which flags are not provided
+      are left as they were.
 
       Update only the target task queue:
 
@@ -3324,4 +3330,5 @@ option-sets:
         experimental: true
         description: |
           An external Nexus Endpoint that receives forwarded Nexus requests.
-          May be used as an alternative to `--target-namespace` and `--target-task-queue`.
+          May be used as an alternative to `--target-namespace` and
+          `--target-task-queue`.

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -2918,7 +2918,6 @@ commands:
 option-sets:
 
   - name: client
-    description: Commands that connect to a Temporal Service
     options:
       - name: address
         type: string


### PR DESCRIPTION
## What was changed
- Updated `commands.yml` to address feedback on:
  - https://github.com/temporalio/documentation/pull/3149#discussion_r1800246386
- Intended for use with the following, but also is fine to merge standalone
  - #691
  - #692

See this branch for [the combined approach](https://github.com/prasek/temporal-cli/tree/cli-docs-gen-all) with all PRs merged in.

## Why?
To create CLI docs for Nexus.

## Checklist
1. How was this tested:
- `go run ./temporalcli/internal/cmd/gen-docs `
- also tested with [the combined appraoch](https://github.com/prasek/temporal-cli/tree/cli-docs-gen-all)
   - copied generated docs (or subset) to temporalio/documentation
   - `yarn start`
   - verified via http://localhost:3000/

Ran `go test ./...`

Tested locally with:
```
go run ./cmd/temporal operator nexus endpoint create --name myendpoint --target-namespace my-target-namespace --target-task-queue my-handler-task-queue --description '## Sales Services
Workflow'\''s to support Customer-to-Order generation.

## other
stuff
'
```

2. Any docs updates needed?
- overall docs gen needs more alignment with the existing docs, but that is out of scope for these Nexus changes
- will update https://github.com/temporalio/documentation/pull/3149 with cherry picked generated content from [the combined approach](https://github.com/prasek/temporal-cli/tree/cli-docs-gen-all) .