### PR TITLE
update --command-timeout description

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -311,7 +311,7 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Command.PersistentFlags().Var(&s.Color, "color", "Output coloring. Accepted values: always, never, auto.")
 	s.Command.PersistentFlags().BoolVar(&s.NoJsonShorthandPayloads, "no-json-shorthand-payloads", false, "Raw payload output, even if the JSON option was used.")
 	s.CommandTimeout = 0
-	s.Command.PersistentFlags().Var(&s.CommandTimeout, "command-timeout", "Timeout for the span of a command.")
+	s.Command.PersistentFlags().Var(&s.CommandTimeout, "command-timeout", "The command execution timeout in seconds. 0 means no timeout.")
 	s.initCommand(cctx)
 	return &s
 }

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -197,7 +197,8 @@ commands:
         description: Raw payload output, even if the JSON option was used.
       - name: command-timeout
         type: duration
-        description: Timeout for the span of a command.
+        description: |
+          The command execution timeout in seconds. 0 means no timeout.
 
   - name: temporal activity
     summary: Complete or fail an Activity


### PR DESCRIPTION
## What was changed
update `--command-timeout` description per docs feedback

## Why?
make it more clear

## Checklist
1. How was this tested:
locally with `go run ./cmd/temporal operator nexus endpoint create --help`

2. Any docs updates needed?
yes, see related:
- https://github.com/temporalio/documentation/pull/3162