### PR TITLE
Add reset reapply to batch reset command

### DIFF
--- a/temporalcli/commands.workflow_reset.go
+++ b/temporalcli/commands.workflow_reset.go
@@ -77,33 +77,9 @@ func (c *TemporalWorkflowResetCommand) doWorkflowReset(cctx *CommandContext, cl 
 		}
 	}
 
-	reapplyExcludes := make([]enums.ResetReapplyExcludeType, 0)
-	for _, exclude := range c.ReapplyExclude.Values {
-		if strings.ToLower(exclude) == "all" {
-			for _, excludeType := range enums.ResetReapplyExcludeType_value {
-				if excludeType == 0 {
-					continue
-				}
-				reapplyExcludes = append(reapplyExcludes, enums.ResetReapplyExcludeType(excludeType))
-			}
-			break
-		}
-		excludeType, err := enums.ResetReapplyExcludeTypeFromString(exclude)
-		if err != nil {
-			return err
-		}
-		reapplyExcludes = append(reapplyExcludes, excludeType)
-	}
-
-	reapplyType := enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
-	if c.ReapplyType.Value != "All" {
-		if len(c.ReapplyExclude.Values) > 0 {
-			return errors.New("--reapply-type cannot be used with --reapply-exclude. Use --reapply-exclude.")
-		}
-		reapplyType, err = enums.ResetReapplyTypeFromString(c.ReapplyType.Value)
-		if err != nil {
-			return err
-		}
+	reapplyExcludes, reapplyType, err := getResetReapplyAndExcludeTypes(c.ReapplyExclude.Values, c.ReapplyType.Value)
+	if err != nil {
+		return fmt.Errorf("getting reset reapply and exclude types failed: %w", err)
 	}
 
 	cctx.Printer.Printlnf("Resetting workflow %s to event ID %d", c.WorkflowId, eventID)
@@ -138,10 +114,15 @@ func (c *TemporalWorkflowResetCommand) runBatchReset(cctx *CommandContext, cl cl
 		VisibilityQuery: c.Query,
 		Reason:          c.Reason,
 	}
+
+	batchResetOptions, err := c.batchResetOptions()
+	if err != nil {
+		return err
+	}
 	request.Operation = &workflowservice.StartBatchOperationRequest_ResetOperation{
 		ResetOperation: &batch.BatchOperationReset{
 			Identity: clientIdentity(),
-			Options:  c.batchResetOptions(c.Type.Value),
+			Options:  batchResetOptions,
 		},
 	}
 	count, err := cl.CountWorkflow(cctx, &workflowservice.CountWorkflowExecutionsRequest{Query: c.Query})
@@ -160,22 +141,33 @@ func (c *TemporalWorkflowResetCommand) runBatchReset(cctx *CommandContext, cl cl
 	return startBatchJob(cctx, cl, &request)
 }
 
-func (c *TemporalWorkflowResetCommand) batchResetOptions(resetType string) *common.ResetOptions {
-	switch resetType {
+func (c *TemporalWorkflowResetCommand) batchResetOptions() (*common.ResetOptions, error) {
+	reapplyExcludes, reapplyType, err := getResetReapplyAndExcludeTypes(c.ReapplyExclude.Values, c.ReapplyType.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	switch c.Type.Value {
 	case "FirstWorkflowTask":
 		return &common.ResetOptions{
-			Target: &common.ResetOptions_FirstWorkflowTask{},
-		}
+			Target:                   &common.ResetOptions_FirstWorkflowTask{},
+			ResetReapplyExcludeTypes: reapplyExcludes,
+			ResetReapplyType:         reapplyType,
+		}, nil
 	case "LastWorkflowTask":
 		return &common.ResetOptions{
-			Target: &common.ResetOptions_LastWorkflowTask{},
-		}
+			Target:                   &common.ResetOptions_LastWorkflowTask{},
+			ResetReapplyExcludeTypes: reapplyExcludes,
+			ResetReapplyType:         reapplyType,
+		}, nil
 	case "BuildId":
 		return &common.ResetOptions{
 			Target: &common.ResetOptions_BuildId{
 				BuildId: c.BuildId,
 			},
-		}
+			ResetReapplyExcludeTypes: reapplyExcludes,
+			ResetReapplyType:         reapplyType,
+		}, nil
 	default:
 		panic("unsupported operation type was filtered by cli framework")
 	}
@@ -313,4 +305,39 @@ func getLastContinueAsNewID(ctx context.Context, namespace, wid, rid string, wfs
 		return "", 0, errors.New("unable to find WorkflowTaskCompleted event for previous execution")
 	}
 	return
+}
+
+func getResetReapplyAndExcludeTypes(resetReapplyExclude []string, resetReapplyType string) ([]enums.ResetReapplyExcludeType, enums.ResetReapplyType, error) {
+	var err error
+
+	var reapplyExcludes []enums.ResetReapplyExcludeType
+	for _, exclude := range resetReapplyExclude {
+		if strings.ToLower(exclude) == "all" {
+			for _, excludeType := range enums.ResetReapplyExcludeType_value {
+				if excludeType == int32(enums.RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED) {
+					continue
+				}
+				reapplyExcludes = append(reapplyExcludes, enums.ResetReapplyExcludeType(excludeType))
+			}
+			break
+		}
+		excludeType, err := enums.ResetReapplyExcludeTypeFromString(exclude)
+		if err != nil {
+			return nil, 0, err
+		}
+		reapplyExcludes = append(reapplyExcludes, excludeType)
+	}
+
+	returnReapplyType := enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
+	if resetReapplyType != "All" {
+		if len(resetReapplyExclude) > 0 {
+			return nil, 0, errors.New("--reapply-type cannot be used with --reapply-exclude. Use --reapply-exclude")
+		}
+		returnReapplyType, err = enums.ResetReapplyTypeFromString(resetReapplyType)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return reapplyExcludes, returnReapplyType, nil
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Previously reset reapply options were ignored for batch reset, and only used for single workflow reset command.
This pr also adds reset reapply options to batch reset command.

## Why?
<!-- Tell your future self why have you made these changes -->
I have found myself needing to batch-reset workflows without reapplying signals, but unable to do so with the temporal cli. It is possible via sdk code and via tctl, which makes it look as someone forgot to add it.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I have tested this with my usecase and worked great.
I have not added any tests. Probably some batch-reset tests are needed, but no logic has been added ( I have reused the method that was used for single reset, so there's not much change it's wrong )

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
