### PR TITLE
Fix mismatched go versions (and AS casing)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm as builder
+FROM golang:1.23-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Updated the image for building from `golang:1.22-bookworm` to `golang:1.23-bookworm` in the `Dockerfile`
- Changed casing on `AS` statement to match the rest of the `Dockerfile`

## Why?
- Dockerfile was using `golang:1.22-bookworm` as the builder image, but `go.mod` requires `>= 1.23`, and so the docker image build fails.
- The case of the `AS` keyword was causing a (non fatal) build error in Docker

## Checklist
1. Closes n/a

2. How was this tested:
`docker build .` the original version, observe the errors...
```
 => ERROR [builder 4/4] RUN go build ./cmd/temporal                                                                                                                                                             0.2s
------                                                                                                                                                                                                               
 > [builder 4/4] RUN go build ./cmd/temporal:
0.146 go: go.mod requires go >= 1.23 (running go 1.22.8; GOTOOLCHAIN=local)
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile:9
--------------------
```

`docker build .` this version and observe that these errors are not present

3. Any docs updates needed?

no.
