### PR TITLE
change log-format to string-enum

### DIFF
--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -271,7 +271,7 @@ type TemporalCommand struct {
 	Env                     string
 	EnvFile                 string
 	LogLevel                StringEnum
-	LogFormat               string
+	LogFormat               StringEnum
 	Output                  StringEnum
 	TimeFormat              StringEnum
 	Color                   StringEnum
@@ -302,7 +302,8 @@ func NewTemporalCommand(cctx *CommandContext) *TemporalCommand {
 	s.Command.PersistentFlags().StringVar(&s.EnvFile, "env-file", "", "Path to environment settings file. Defaults to `$HOME/.config/temporalio/temporal.yaml`.")
 	s.LogLevel = NewStringEnum([]string{"debug", "info", "warn", "error", "never"}, "info")
 	s.Command.PersistentFlags().Var(&s.LogLevel, "log-level", "Log level. Default is \"info\" for most commands and \"warn\" for `server start-dev`. Accepted values: debug, info, warn, error, never.")
-	s.Command.PersistentFlags().StringVar(&s.LogFormat, "log-format", "text", "Log format. Options are: text, json.")
+	s.LogFormat = NewStringEnum([]string{"text", "json", "pretty"}, "text")
+	s.Command.PersistentFlags().Var(&s.LogFormat, "log-format", "Log format. Accepted values: text, json.")
 	s.Output = NewStringEnum([]string{"text", "json", "jsonl", "none"}, "text")
 	s.Command.PersistentFlags().VarP(&s.Output, "output", "o", "Non-logging data output format. Accepted values: text, json, jsonl, none.")
 	s.TimeFormat = NewStringEnum([]string{"relative", "iso", "raw"}, "relative")

--- a/temporalcli/commands.go
+++ b/temporalcli/commands.go
@@ -442,7 +442,7 @@ func (c *TemporalCommand) preRun(cctx *CommandContext) error {
 				return fmt.Errorf("invalid log level %q: %w", c.LogLevel.Value, err)
 			}
 			var handler slog.Handler
-			switch c.LogFormat {
+			switch c.LogFormat.Value {
 			// We have a "pretty" alias for compatibility
 			case "", "text", "pretty":
 				handler = slog.NewTextHandler(cctx.Options.Stderr, &slog.HandlerOptions{
@@ -458,7 +458,7 @@ func (c *TemporalCommand) preRun(cctx *CommandContext) error {
 			case "json":
 				handler = slog.NewJSONHandler(cctx.Options.Stderr, &slog.HandlerOptions{Level: level})
 			default:
-				return fmt.Errorf("invalid log format %q", c.LogFormat)
+				return fmt.Errorf("invalid log format %q", c.LogFormat.Value)
 			}
 			cctx.Logger = slog.New(handler)
 		}

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -601,8 +601,8 @@ func TestUnknownCommandExitsNonzero(t *testing.T) {
 	assert.Contains(t, res.Err.Error(), "unknown command")
 }
 
-func TestHiddenAliasLogFormat(t *testing.T) {
-	commandHarness := NewCommandHarness(t)
-	res := commandHarness.Execute("workflow", "list", "--log-format", "pretty")
-	assert.NoError(t, res.Err)
+func (s *SharedServerSuite) TestHiddenAliasLogFormat() {
+	_ = s.waitActivityStarted().GetID()
+	res := s.Execute("workflow", "list", "--log-format", "pretty", "--address", s.Address())
+	s.NoError(res.Err)
 }

--- a/temporalcli/commands_test.go
+++ b/temporalcli/commands_test.go
@@ -600,3 +600,9 @@ func TestUnknownCommandExitsNonzero(t *testing.T) {
 	res := commandHarness.Execute("blerkflow")
 	assert.Contains(t, res.Err.Error(), "unknown command")
 }
+
+func TestHiddenAliasLogFormat(t *testing.T) {
+	commandHarness := NewCommandHarness(t)
+	res := commandHarness.Execute("workflow", "list", "--log-format", "pretty")
+	assert.NoError(t, res.Err)
+}

--- a/temporalcli/commandsgen/code.go
+++ b/temporalcli/commandsgen/code.go
@@ -359,10 +359,14 @@ func (o *Option) writeFlagBuilding(selfVar, flagVar string, w *codeWriter) error
 			return fmt.Errorf("missing enum values")
 		}
 		// Create enum
-		pieces := make([]string, len(o.EnumValues))
+		pieces := make([]string, len(o.EnumValues)+len(o.HiddenLegacyValues))
 		for i, enumVal := range o.EnumValues {
 			pieces[i] = fmt.Sprintf("%q", enumVal)
 		}
+		for i, legacyVal := range o.HiddenLegacyValues {
+			pieces[i+len(o.EnumValues)] = fmt.Sprintf("%q", legacyVal)
+		}
+
 		w.writeLinef("%v.%v = NewStringEnum([]string{%v}, %q)",
 			selfVar, o.fieldName(), strings.Join(pieces, ", "), o.Default)
 		flagMeth = "Var"
@@ -371,9 +375,12 @@ func (o *Option) writeFlagBuilding(selfVar, flagVar string, w *codeWriter) error
 			return fmt.Errorf("missing enum values")
 		}
 		// Create enum
-		pieces := make([]string, len(o.EnumValues))
+		pieces := make([]string, len(o.EnumValues)+len(o.HiddenLegacyValues))
 		for i, enumVal := range o.EnumValues {
 			pieces[i] = fmt.Sprintf("%q", enumVal)
+		}
+		for i, legacyVal := range o.HiddenLegacyValues {
+			pieces[i+len(o.EnumValues)] = fmt.Sprintf("%q", legacyVal)
 		}
 
 		if o.Default != "" {

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -161,10 +161,13 @@ commands:
           Default is "info" for most commands and "warn" for `server start-dev`.
         default: info
       - name: log-format
-        type: string
-        description: |
-          Log format.
-          Options are: text, json.
+        type: string-enum
+        description: Log format.
+        enum-values:
+          - text
+          - json
+        hidden-legacy-values:
+          - pretty
         default: text
       - name: output
         type: string-enum

--- a/temporalcli/commandsgen/parse.go
+++ b/temporalcli/commandsgen/parse.go
@@ -20,16 +20,17 @@ var CommandsYAML []byte
 type (
 	// Option represents the structure of an option within option sets.
 	Option struct {
-		Name         string   `yaml:"name"`
-		Type         string   `yaml:"type"`
-		Description  string   `yaml:"description"`
-		Short        string   `yaml:"short,omitempty"`
-		Default      string   `yaml:"default,omitempty"`
-		Env          string   `yaml:"env,omitempty"`
-		Required     bool     `yaml:"required,omitempty"`
-		Aliases      []string `yaml:"aliases,omitempty"`
-		EnumValues   []string `yaml:"enum-values,omitempty"`
-		Experimental bool     `yaml:"experimental,omitempty"`
+		Name               string   `yaml:"name"`
+		Type               string   `yaml:"type"`
+		Description        string   `yaml:"description"`
+		Short              string   `yaml:"short,omitempty"`
+		Default            string   `yaml:"default,omitempty"`
+		Env                string   `yaml:"env,omitempty"`
+		Required           bool     `yaml:"required,omitempty"`
+		Aliases            []string `yaml:"aliases,omitempty"`
+		EnumValues         []string `yaml:"enum-values,omitempty"`
+		Experimental       bool     `yaml:"experimental,omitempty"`
+		HiddenLegacyValues []string `yaml:"hidden-legacy-values,omitempty"`
 	}
 
 	// Command represents the structure of each command in the commands map.


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
addressed https://github.com/temporalio/cli/pull/677#discussion_r1773519018 regarding "pretty" as a legacy alias for "text"

to accomplish this, added a new `hidden-legacy-values` field that can be used to deprecate options in the future

## Why?
<!-- Tell your future self why have you made these changes -->
better argument typing

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
added a test to test `--log-format pretty` works


<!--- update README if applicable
      or point out where to update docs.temporal.io -->
