### PR TITLE
User Metadata set on start / desc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 # Used by IDE
 /.idea
 /.vscode
+/.zed
 *~
-

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -190,6 +190,8 @@ type SharedWorkflowStartOptions struct {
 	TaskTimeout      Duration
 	SearchAttribute  []string
 	Memo             []string
+	StaticSummary    string
+	StaticDetails    string
 }
 
 func (v *SharedWorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.FlagSet) {
@@ -206,6 +208,8 @@ func (v *SharedWorkflowStartOptions) buildFlags(cctx *CommandContext, f *pflag.F
 	f.Var(&v.TaskTimeout, "task-timeout", "Fail a Workflow Task if it lasts longer than `DURATION`. This is the Start-to-close timeout for a Workflow Task.")
 	f.StringArrayVar(&v.SearchAttribute, "search-attribute", nil, "Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. For example: 'YourKey={\"your\": \"value\"}'. Can be passed multiple times.")
 	f.StringArrayVar(&v.Memo, "memo", nil, "Memo using 'KEY=\"VALUE\"' pairs. Use JSON values.")
+	f.StringVar(&v.StaticSummary, "static-summary", "", "Static Workflow summary for human consumption in UIs. Uses Temporal Markdown formatting, should be a single line.")
+	f.StringVar(&v.StaticDetails, "static-details", "", "Static Workflow details for human consumption in UIs. Uses Temporal Markdown formatting, may be multiple lines.")
 }
 
 type WorkflowStartOptions struct {

--- a/temporalcli/commands.schedule.go
+++ b/temporalcli/commands.schedule.go
@@ -270,6 +270,8 @@ func toScheduleAction(sw *SharedWorkflowStartOptions, i *PayloadInputOptions) (c
 		// RetryPolicy not supported yet
 		UntypedSearchAttributes: untypedSearchAttributes,
 		Memo:                    opts.Memo,
+		StaticSummary:           opts.StaticSummary,
+		StaticDetails:           opts.StaticDetails,
 	}
 	if action.Args, err = i.buildRawInput(); err != nil {
 		return nil, err

--- a/temporalcli/commands.schedule_test.go
+++ b/temporalcli/commands.schedule_test.go
@@ -190,8 +190,8 @@ func (s *SharedServerSuite) TestSchedule_CreateDescribe_UserMetadata() {
 	)
 	s.NoError(res.Err)
 	out := res.Stdout.String()
-	s.ContainsOnSameLine(out, "Action", "summary", "summ")
-	s.ContainsOnSameLine(out, "Action", "details", "farts")
+	s.ContainsOnSameLine(out, "Action", "Summary", "summ")
+	s.ContainsOnSameLine(out, "Action", "Details", "details")
 }
 
 func (s *SharedServerSuite) TestSchedule_List() {

--- a/temporalcli/commands.schedule_test.go
+++ b/temporalcli/commands.schedule_test.go
@@ -176,6 +176,24 @@ func (s *SharedServerSuite) TestSchedule_CreateDescribe_SearchAttributes_Memo() 
 	s.ContainsOnSameLine(out, "Action", "wfMemo", b64(`"other data"`))
 }
 
+func (s *SharedServerSuite) TestSchedule_CreateDescribe_UserMetadata() {
+	schedId, _, res := s.createSchedule("--interval", "10d",
+		"--static-summary", "summ",
+		"--static-details", "details",
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"schedule", "describe",
+		"--address", s.Address(),
+		"-s", schedId,
+	)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.ContainsOnSameLine(out, "Action", "summary", "summ")
+	s.ContainsOnSameLine(out, "Action", "details", "farts")
+}
+
 func (s *SharedServerSuite) TestSchedule_List() {
 	res := s.Execute(
 		"operator", "search-attribute", "create",

--- a/temporalcli/commands.workflow_exec.go
+++ b/temporalcli/commands.workflow_exec.go
@@ -386,6 +386,8 @@ func buildStartOptions(sw *SharedWorkflowStartOptions, w *WorkflowStartOptions) 
 		CronSchedule:                             w.Cron,
 		WorkflowExecutionErrorWhenAlreadyStarted: w.FailExisting,
 		StartDelay:                               w.StartDelay.Duration(),
+		StaticSummary:                            sw.StaticSummary,
+		StaticDetails:                            sw.StaticDetails,
 	}
 	if w.IdReusePolicy.Value != "" {
 		var err error

--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -134,6 +134,20 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		HistorySize:          info.HistorySizeBytes,
 	}, printer.StructuredOptions{})
 
+	staticSummary := resp.GetExecutionConfig().GetUserMetadata().GetSummary()
+	staticDetails := resp.GetExecutionConfig().GetUserMetadata().GetDetails()
+	if len(staticSummary.GetData()) > 0 || len(staticDetails.GetData()) > 0 {
+		cctx.Printer.Println()
+		cctx.Printer.Println(color.MagentaString("Metadata:"))
+		_ = cctx.Printer.PrintStructured(struct {
+			StaticSummary *common.Payload
+			StaticDetails *common.Payload
+		}{
+			StaticSummary: staticSummary,
+			StaticDetails: staticDetails,
+		}, printer.StructuredOptions{})
+	}
+
 	if info.VersioningInfo != nil {
 		cctx.Printer.Println()
 		cctx.Printer.Println(color.MagentaString("Versioning Info:"))

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -950,3 +950,46 @@ func (s *SharedServerSuite) Test_WorkflowResult() {
 	s.Contains(output, `"message": "failed on purpose"`)
 	s.Contains(output, "workflowExecutionFailedEventAttributes")
 }
+
+func (s *SharedServerSuite) TestWorkflow_Describe_WorkflowMetadata() {
+	workflowId := uuid.NewString()
+
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
+		return map[string]string{"foo": "bar"}, nil
+	})
+
+	res := s.Execute(
+		"workflow", "start",
+		"--address", s.Address(),
+		"--task-queue", s.Worker().Options.TaskQueue,
+		"--type", "DevWorkflow",
+		"--workflow-id", workflowId,
+		"--static-summary", "summie",
+		"--static-details", "deets",
+	)
+	s.NoError(res.Err)
+
+	// Text
+	res = s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", workflowId,
+	)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.ContainsOnSameLine(out, "StaticSummary", "summie")
+	s.ContainsOnSameLine(out, "StaticDetails", "deets")
+
+	// JSON
+	res = s.Execute(
+		"workflow", "describe",
+		"-o", "json",
+		"--address", s.Address(),
+		"-w", workflowId,
+	)
+	s.NoError(res.Err)
+	var jsonOut workflowservice.DescribeWorkflowExecutionResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &jsonOut, true))
+	s.NotNil(jsonOut.ExecutionConfig.UserMetadata.Summary)
+	s.NotNil(jsonOut.ExecutionConfig.UserMetadata.Details)
+}

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -3991,6 +3991,16 @@ option-sets:
         description: |
           Memo using 'KEY="VALUE"' pairs.
           Use JSON values.
+      - name: static-summary
+        type: string
+        description: |
+          Static Workflow summary for human consumption in UIs.
+          Uses Temporal Markdown formatting, should be a single line.
+      - name: static-details
+        type: string
+        description: |
+          Static Workflow details for human consumption in UIs.
+          Uses Temporal Markdown formatting, may be multiple lines.
 
   - name: workflow-start
     options:

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -3993,11 +3993,13 @@ option-sets:
           Use JSON values.
       - name: static-summary
         type: string
+        experimental: true
         description: |
           Static Workflow summary for human consumption in UIs.
           Uses Temporal Markdown formatting, should be a single line.
       - name: static-details
         type: string
+        experimental: true
         description: |
           Static Workflow details for human consumption in UIs.
           Uses Temporal Markdown formatting, may be multiple lines.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Added `--static-summary` and `--static-details` to all workflow-start like operations
* Added summary & details to workflow describe

## Why?
Useful feature

## Checklist
<!--- add/delete as needed --->

1. Closes 

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
