### PR TITLE
added `workflow start-update-with-start`  and `workflow execute-update-with-start`  commands

### DIFF
--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -3439,6 +3439,160 @@ commands:
           - accepted
         required: true
 
+  - name: temporal workflow start-update-with-start
+    summary: Send an Update and wait for it to be accepted or rejected (Experimental)
+    description: |
+      Send a message to a Workflow Execution to invoke an Update handler, and wait for
+      the update to be accepted or rejected. If the Workflow Execution is not running, 
+      then a new workflow execution is started and the update is sent.
+
+      Experimental.
+
+      ```
+      temporal workflow start-update-with-start \
+        --update-name YourUpdate \
+        --update-input '{"update-key": "update-value"}' \
+        --workflow-id YourWorkflowId \
+        --type YourWorkflowType \
+        --task-queue YourTaskQueue \
+        --input '{"wf-key": "wf-value"}'
+      ```
+    option-sets:
+      # workflow-id is "required" (runtime check)
+      - shared-workflow-start
+      - workflow-start
+      - payload-input
+    options:
+      - name: update-name
+        type: string
+        description: Update name.
+        required: true
+        aliases:
+          - update-type
+      - name: update-first-execution-run-id
+        type: string
+        description: |
+          Parent Run ID.
+          The update is sent to the last Workflow Execution in the chain started
+          with this Run ID.
+      - name: update-wait-for-stage
+        type: string-enum
+        description: |
+          Update stage to wait for.
+          The only option is `accepted`, but this option is  required. This is to allow
+          a future version of the CLI to choose a default value.
+        enum-values:
+          - accepted
+        required: true
+      - name: update-id
+        type: string
+        description: |
+          Update ID.
+          If unset, defaults to a UUID.
+      - name: run-id
+        type: string
+        short: r
+        description: |
+          Run ID.
+          If unset, looks for an Update against the currently-running Workflow Execution.
+      - name: update-input
+        type: string[]
+        description: |
+          Update input value.
+          Use JSON content or set --update-input-meta to override.
+          Can't be combined with --update-input-file.
+          Can be passed multiple times to pass multiple arguments.
+      - name: update-input-file
+        type: string[]
+        description: |
+          A path or paths for input file(s).
+          Use JSON content or set --update-input-meta to override.
+          Can't be combined with --update-input.
+          Can be passed multiple times to pass multiple arguments.
+      - name: update-input-meta
+        type: string[]
+        description: |
+          Input update payload metadata as a `KEY=VALUE` pair.
+          When the KEY is "encoding", this overrides the default ("json/plain").
+          Can be passed multiple times.
+      - name: update-input-base64
+        type: bool
+        description: |
+          Assume update inputs are base64-encoded and attempt to decode them.
+
+  - name: temporal workflow execute-update-with-start
+    summary: Send an Update and wait for it to complete (Experimental)
+    description: |
+      Send a message to a Workflow Execution to invoke an Update handler, and wait for
+      the update to complete. If the Workflow Execution is not running, then a new workflow
+      execution is started and the update is sent.
+
+      Experimental.
+
+      ```
+      temporal workflow execute-update-with-start \
+        --update-name YourUpdate \
+        --update-input '{"update-key": "update-value"}' \
+        --workflow-id YourWorkflowId \
+        --type YourWorkflowType \
+        --task-queue YourTaskQueue \
+        --input '{"wf-key": "wf-value"}'
+      ```
+
+    option-sets:
+      # workflow-id is "required" (runtime check)
+      - shared-workflow-start
+      - workflow-start
+      - payload-input
+    options:
+      - name: update-name
+        type: string
+        description: Update name.
+        required: true
+        aliases:
+          - update-type
+      - name: update-first-execution-run-id
+        type: string
+        description: |
+          Parent Run ID.
+          The update is sent to the last Workflow Execution in the chain started
+          with this Run ID.
+      - name: update-id
+        type: string
+        description: |
+          Update ID.
+          If unset, defaults to a UUID.
+      - name: run-id
+        type: string
+        short: r
+        description: |
+          Run ID.
+          If unset, looks for an Update against the currently-running Workflow Execution.
+      - name: update-input
+        type: string[]
+        description: |
+          Update input value.
+          Use JSON content or set --update-input-meta to override.
+          Can't be combined with --update-input-file.
+          Can be passed multiple times to pass multiple arguments.
+      - name: update-input-file
+        type: string[]
+        description: |
+          A path or paths for input file(s).
+          Use JSON content or set --update-input-meta to override.
+          Can't be combined with --update-input.
+          Can be passed multiple times to pass multiple arguments.
+      - name: update-input-meta
+        type: string[]
+        description: |
+          Input update payload metadata as a `KEY=VALUE` pair.
+          When the KEY is "encoding", this overrides the default ("json/plain").
+          Can be passed multiple times.
+      - name: update-input-base64
+        type: bool
+        description: |
+          Assume update inputs are base64-encoded and attempt to decode them.
+
 option-sets:
   - name: client
     options:


### PR DESCRIPTION
added `temporal workflow start-update-with-start`  and `temporal workflow execute-update-with-start`  commands

`temporal workflow start-update-with-start` usage: 
```
    temporal workflow start-update-with-start \
      --update-name YourUpdate \
      --update-input '{"update-key": "update-value"}' \
      --workflow-id YourWorkflowId \
      --type YourWorkflowType \
      --task-queue YourTaskQueue \
      --input '{"wf-key": "wf-value"}'
    ```


`temporal workflow execute-update-with-start` usage:
```
    temporal workflow execute-update-with-start \
      --update-name YourUpdate \
      --update-input '{"update-key": "update-value"}' \
      --workflow-id YourWorkflowId \
      --type YourWorkflowType \
      --task-queue YourTaskQueue \
      --input '{"wf-key": "wf-value"}'
```

1. Closes #664

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
Yes
