### PR TITLE
Fix batch deployment test nil pointer exception

### DIFF
--- a/temporalcli/commands.workflow_test.go
+++ b/temporalcli/commands.workflow_test.go
@@ -528,7 +528,9 @@ func (s *SharedServerSuite) TestWorkflow_Batch_Update_Options_Versioning_Overrid
 
 			var jsonResp workflowservice.DescribeWorkflowExecutionResponse
 			assert.NoError(t, temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &jsonResp, true))
-			versioningInfo := jsonResp.WorkflowExecutionInfo.VersioningInfo
+
+			versioningInfo := jsonResp.GetWorkflowExecutionInfo().GetVersioningInfo()
+			assert.NotNil(t, versioningInfo)
 			assert.NotNil(t, versioningInfo.VersioningOverride)
 			assert.Equal(t, version2, versioningInfo.VersioningOverride.PinnedVersion)
 		}


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
`TestWorkflow_Batch_Update_Options_Versioning_Override` was assuming a complete proto response
with versioning info, and panic with an invalid pointer ref sometimes.
