### PR TITLE
quote attribute type to make whitespace more obvious

### DIFF
--- a/temporalcli/commands.operator_search_attribute.go
+++ b/temporalcli/commands.operator_search_attribute.go
@@ -60,7 +60,7 @@ func searchAttributeTypeStringToEnum(search string) (enums.IndexedValueType, err
 			return enums.IndexedValueType(v), nil
 		}
 	}
-	return enums.INDEXED_VALUE_TYPE_UNSPECIFIED, fmt.Errorf("unsupported search attribute type: %v", search)
+	return enums.INDEXED_VALUE_TYPE_UNSPECIFIED, fmt.Errorf("unsupported search attribute type: \"%v\"", search)
 }
 
 func (c *TemporalOperatorSearchAttributeRemoveCommand) run(cctx *CommandContext, args []string) error {


### PR DESCRIPTION


## What was changed
quote attribute type in error message 

## Why?
To make whitespace more obvious
