### PR TITLE
Expose parent and root execution in describe call

### DIFF
--- a/temporalcli/commands.workflow_view.go
+++ b/temporalcli/commands.workflow_view.go
@@ -117,6 +117,8 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		StateTransitionCount int64
 		HistoryLength        int64
 		HistorySize          int64
+		ParentExecution      *common.WorkflowExecution `cli:",cardOmitEmpty"`
+		RootExecution        *common.WorkflowExecution `cli:",cardOmitEmpty"`
 	}{
 		WorkflowId:           info.Execution.WorkflowId,
 		RunId:                info.Execution.RunId,
@@ -132,6 +134,8 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		StateTransitionCount: info.StateTransitionCount,
 		HistoryLength:        info.HistoryLength,
 		HistorySize:          info.HistorySizeBytes,
+		ParentExecution:      info.ParentExecution,
+		RootExecution:        info.RootExecution,
 	}, printer.StructuredOptions{})
 
 	extendedInfo := resp.WorkflowExtendedInfo

--- a/temporalcli/commands.workflow_view_test.go
+++ b/temporalcli/commands.workflow_view_test.go
@@ -993,3 +993,62 @@ func (s *SharedServerSuite) TestWorkflow_Describe_WorkflowMetadata() {
 	s.NotNil(jsonOut.ExecutionConfig.UserMetadata.Summary)
 	s.NotNil(jsonOut.ExecutionConfig.UserMetadata.Details)
 }
+
+func (s *SharedServerSuite) TestWorkflow_Describe_RootWorkflow() {
+	s.Worker().OnDevWorkflow(func(ctx workflow.Context, input any) (any, error) {
+		if input.(string) == "child" {
+			return "done", nil
+		}
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: 10 * time.Second,
+		})
+		childHandle := workflow.ExecuteChildWorkflow(ctx, DevWorkflow, "child")
+		var childWE workflow.Execution
+		err := childHandle.GetChildWorkflowExecution().Get(ctx, &childWE)
+		if err != nil {
+			return nil, err
+		}
+		err = childHandle.Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		return childWE.ID, err
+	})
+
+	run, err := s.Client.ExecuteWorkflow(
+		s.Context,
+		client.StartWorkflowOptions{TaskQueue: s.Worker().Options.TaskQueue},
+		DevWorkflow,
+		"ignored",
+	)
+	s.NoError(err)
+	var wfRes string
+	err = run.Get(s.Context, &wfRes)
+	s.NoError(err)
+
+	// Text
+	res := s.Execute(
+		"workflow", "describe",
+		"--address", s.Address(),
+		"-w", wfRes,
+	)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.ContainsOnSameLine(out, "ParentExecution", run.GetID())
+	s.ContainsOnSameLine(out, "RootExecution", run.GetID())
+
+	// JSON
+	res = s.Execute(
+		"workflow", "describe",
+		"-o", "json",
+		"--address", s.Address(),
+		"-w", wfRes,
+	)
+	s.NoError(res.Err)
+	var jsonOut workflowservice.DescribeWorkflowExecutionResponse
+	s.NoError(temporalcli.UnmarshalProtoJSONWithOptions(res.Stdout.Bytes(), &jsonOut, true))
+	s.Equal(run.GetID(), jsonOut.WorkflowExecutionInfo.ParentExecution.GetWorkflowId())
+	s.Equal(run.GetRunID(), jsonOut.WorkflowExecutionInfo.ParentExecution.GetRunId())
+	s.Equal(run.GetID(), jsonOut.WorkflowExecutionInfo.RootExecution.GetWorkflowId())
+	s.Equal(run.GetRunID(), jsonOut.WorkflowExecutionInfo.RootExecution.GetRunId())
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added parent/root wf info to describe

Looks like:

```
 Execution Info:
          WorkflowId            0195ca09-b69b-7e44-9a65-1117d2397586_5
          RunId                 0195ca09-b6a1-78a2-8b45-0daf88dccf3a
          Type                  DevWorkflow
          Namespace             default
          TaskQueue             a08916ee-28d6-4452-b662-a3cbb219dd13
          AssignedBuildId        
          StartTime             now
          CloseTime             now
          ExecutionTime         now
          SearchAttributes      map[BuildIds:metadata:{key:"encoding"  value:"json/plain"}  metadata:{key:"type"  value:"KeywordList"}  data:"[\"unversioned\",\"unversioned:41011f52e0e0155ca1113ec603b7f2ae\"]"]
          StateTransitionCount  4
          HistoryLength         5
          HistorySize           830
          ParentExecution       {"workflowId":"957a44a6-bea0-45b5-be0e-cab73a4351d3","runId":"0195ca09-b69b-7e44-9a65-1117d2397586"}
          RootExecution         {"workflowId":"957a44a6-bea0-45b5-be0e-cab73a4351d3","runId":"0195ca09-b69b-7e44-9a65-1117d2397586"}
        Extended Execution Info:
          CancelRequested    false
          OriginalStartTime  now
        
        Results:
          RunTime         0s
          Status          COMPLETED
          Result          "done"
          ResultEncoding  json/plain
```          

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes 
https://github.com/temporalio/cli/issues/763
2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
