### PR TITLE
upgrade golang version to 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bookworm AS builder
+FROM golang:1.24-bookworm AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/cli
 
-go 1.23.2
+go 1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
## What was changed
Updated the Go version from 1.23.2 to 1.24.4 across the project:
- Updated `go.mod` to specify Go 1.24.4
- Updated `Dockerfile` to use `golang:1.24-bookworm` base image
- Ran `go mod tidy` to ensure dependency compatibility

## Why?
Upgrading to Go 1.24.4 brings the latest language features, performance improvements, and security patches. This ensures the Temporal CLI project stays current with the latest stable Go release and benefits from:
- Latest Go runtime optimizations
- Security fixes and improvements
- Access to new language features and standard library updates
- Better compatibility with modern development tools and CI/CD environments

## Checklist

1. Closes <!-- No specific issue for this maintenance update -->

2. How was this tested:
- Verified `go mod tidy` completed successfully with no errors
- Built the binary successfully using `go build ./cmd/temporal` (as per CONTRIBUTING.md)
- Ran tests using `go test ./...` to ensure all existing functionality works
- Built Docker image successfully using updated Go 1.24.4 base image
- Tested both the local binary and Docker image functionality by running `temporal --version` and `temporal --help`
- Confirmed CLI operates normally with all basic commands working as expected in both environments

3. Any docs updates needed?
No documentation updates required - this is an internal Go version upgrade that doesn't affect user-facing functionality or APIs.
