### PR TITLE
Add nix flake and direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 /.vscode
 /.zed
 *~
+
+# direnv
+.direnv/
+
+# nix
+/result

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Reference [the documentation](https://docs.temporal.io/cli) for detailed install
 ### Install via download
 
 1. Download the version for your OS and architecture:
-    - [Linux amd64](https://temporal.download/cli/archive/latest?platform=linux&arch=amd64)
-    - [Linux arm64](https://temporal.download/cli/archive/latest?platform=linux&arch=arm64)
-    - [macOS amd64](https://temporal.download/cli/archive/latest?platform=darwin&arch=amd64)
-    - [macOS arm64](https://temporal.download/cli/archive/latest?platform=darwin&arch=arm64) (Apple silicon)
-    - [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
+   - [Linux amd64](https://temporal.download/cli/archive/latest?platform=linux&arch=amd64)
+   - [Linux arm64](https://temporal.download/cli/archive/latest?platform=linux&arch=arm64)
+   - [macOS amd64](https://temporal.download/cli/archive/latest?platform=darwin&arch=amd64)
+   - [macOS arm64](https://temporal.download/cli/archive/latest?platform=darwin&arch=arm64) (Apple silicon)
+   - [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
 2. Extract the downloaded archive.
 3. Add the `temporal` binary to your `PATH` (`temporal.exe` for Windows).
 
@@ -30,6 +30,27 @@ Reference [the documentation](https://docs.temporal.io/cli) for detailed install
 3. Switch to cloned directory, and run `go build ./cmd/temporal`
 
 The executable will be at `temporal` (`temporal.exe` for Windows).
+
+### Build with Nix
+
+1. [Install Nix](https://docs.determinate.systems/getting-started/individuals#install)
+2. Clone repository
+3. Switch to cloned directory, and run `nix build`
+
+The executable will be at `result/bin/temporal`.
+
+### Nix Development Environment
+
+1. [Install Nix](https://docs.determinate.systems/getting-started/individuals#install)
+2. Clone repository
+3. Switch to cloned directory, and run `nix develop`
+
+Go and related tools will be made available in this shell. This can be further automated by direnv:
+
+1. Install direnv: `nix profile add nixpkgs#direnv`
+2. Run `direnv allow` in the project directory
+
+Now every time you enter the project directory, all the tools will be available.
 
 ## Usage
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750400657,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b2485d56967598da068b5a6946dadda8bfcbcd37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "Temporal Server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs =
+    inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [
+                (import ./nix/go-override.nix) # https://github.com/NixOS/nixpkgs/pull/414434/files
+              ];
+            };
+          }
+        );
+    in
+    {
+      packages = forEachSupportedSystem (
+        { pkgs }:
+        let
+          inherit (pkgs) lib;
+        in
+        {
+          default = pkgs.buildGoModule (finalAttrs: {
+            pname = "temporalcli";
+            version = "1.3.0";
+
+            src = builtins.path {
+              path = ./.;
+              filter = lib.cleanSourceFilter;
+              name = "temporalcli-source";
+            };
+
+            vendorHash = "sha256-nHLN8VTD4Zlc8kjjv4XLxgDe+/wN339nukl/VbhWchU=";
+
+            doCheck = false;
+
+            meta = {
+              description = "Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal";
+              homepage = "https://github.com/temporalio/cli";
+              license = lib.licenses.mit;
+              mainProgram = "temporal";
+            };
+          });
+        }
+      );
+
+      devShells = forEachSupportedSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs; [
+              go
+              gotools
+              golangci-lint
+            ];
+          };
+        }
+      );
+    };
+}

--- a/nix/go-override.nix
+++ b/nix/go-override.nix
@@ -1,0 +1,10 @@
+self: super: rec {
+  go_1_24 = super.go_1_24.overrideAttrs (old: rec {
+    version = "1.24.4";
+    src = super.fetchurl {
+      url = "https://go.dev/dl/go${version}.src.tar.gz";
+      hash = "sha256-WoaoOjH5+oFJC4xUIKw4T9PZWj5x+6Zlx7P5XR3+8rQ=";
+    };
+  });
+  go = go_1_24;
+}


### PR DESCRIPTION
## What was changed
Added a nix flake with:
1. A devShell with all the tools in the correct versions for development
2. A nix derivation for the cli that is exposed as a package

## Why?
1. Easily have everything set up to dev on the project, regardless of Go setup for other projects.
2. Consume the package in other nix flakes, e.g. temporal-server

## Checklist

3. How was this tested:
Follow the instructions in the README:
1. Make sure Nix is installed (https://docs.determinate.systems/getting-started/individuals/)
2. `nix build` will build the executable in `result/bin/temporal`
3. `nix develop` will activate a dev shell with go 1.24.4 and related tools
4. `direnv allow` will automatically activate the dev shell when entering the directory (install it with `nix profile add nixpkgs#direnv`) 

5. Any docs updates needed?
Only if the team decides to make the nix development environment a supported one.
