### PR TITLE
fix: activity pause,unpause,reset accept activity type OR activity id

### DIFF
--- a/temporalcli/commands.activity.go
+++ b/temporalcli/commands.activity.go
@@ -208,6 +208,10 @@ func (c *TemporalActivityPauseCommand) run(cctx *CommandContext, args []string) 
 		Identity: c.Identity,
 	}
 
+	if c.ActivityType != "" && c.ActivityId != "" {
+		return fmt.Errorf("either Activity Type or Activity Id, but not both")
+	}
+
 	if c.ActivityType != "" {
 		request.Activity = &workflowservice.PauseActivityRequest_Type{Type: c.ActivityType}
 	} else if c.ActivityId != "" {
@@ -259,6 +263,10 @@ func (c *TemporalActivityUnpauseCommand) run(cctx *CommandContext, args []string
 			ResetHeartbeat: c.ResetHeartbeats,
 			Jitter:         durationpb.New(c.Jitter.Duration()),
 			Identity:       c.Identity,
+		}
+
+		if c.ActivityType != "" && c.ActivityId != "" {
+			return fmt.Errorf("either Activity Type or Activity Id, but not both")
 		}
 
 		if c.ActivityType != "" {
@@ -316,6 +324,10 @@ func (c *TemporalActivityResetCommand) run(cctx *CommandContext, args []string) 
 		Identity:       c.Identity,
 		KeepPaused:     c.KeepPaused,
 		ResetHeartbeat: c.ResetHeartbeats,
+	}
+
+	if c.ActivityType != "" && c.ActivityId != "" {
+		return fmt.Errorf("either Activity Type or Activity Id, but not both")
 	}
 
 	if c.ActivityType != "" {

--- a/temporalcli/commands.activity.go
+++ b/temporalcli/commands.activity.go
@@ -208,16 +208,15 @@ func (c *TemporalActivityPauseCommand) run(cctx *CommandContext, args []string) 
 		Identity: c.Identity,
 	}
 
-	if c.ActivityType != "" && c.ActivityId != "" {
-		return fmt.Errorf("either Activity Type or Activity Id, but not both")
+	if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
+		return err
 	}
 
 	if c.ActivityType != "" {
 		request.Activity = &workflowservice.PauseActivityRequest_Type{Type: c.ActivityType}
-	} else if c.ActivityId != "" {
+	}
+	if c.ActivityId != "" {
 		request.Activity = &workflowservice.PauseActivityRequest_Id{Id: c.ActivityId}
-	} else {
-		return fmt.Errorf("either Activity Type or Activity Id must be provided")
 	}
 
 	_, err = cl.WorkflowService().PauseActivity(cctx, request)
@@ -265,16 +264,15 @@ func (c *TemporalActivityUnpauseCommand) run(cctx *CommandContext, args []string
 			Identity:       c.Identity,
 		}
 
-		if c.ActivityType != "" && c.ActivityId != "" {
-			return fmt.Errorf("either Activity Type or Activity Id, but not both")
+		if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
+			return err
 		}
 
 		if c.ActivityType != "" {
 			request.Activity = &workflowservice.UnpauseActivityRequest_Type{Type: c.ActivityType}
-		} else if c.ActivityId != "" {
+		}
+		if c.ActivityId != "" {
 			request.Activity = &workflowservice.UnpauseActivityRequest_Id{Id: c.ActivityId}
-		} else {
-			return fmt.Errorf("either Activity Type or Activity Id must be provided")
 		}
 
 		_, err = cl.WorkflowService().UnpauseActivity(cctx, request)
@@ -326,16 +324,15 @@ func (c *TemporalActivityResetCommand) run(cctx *CommandContext, args []string) 
 		ResetHeartbeat: c.ResetHeartbeats,
 	}
 
-	if c.ActivityType != "" && c.ActivityId != "" {
-		return fmt.Errorf("either Activity Type or Activity Id, but not both")
+	if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
+		return err
 	}
 
 	if c.ActivityType != "" {
 		request.Activity = &workflowservice.ResetActivityRequest_Type{Type: c.ActivityType}
-	} else if c.ActivityId != "" {
+	}
+	if c.ActivityId != "" {
 		request.Activity = &workflowservice.ResetActivityRequest_Id{Id: c.ActivityId}
-	} else {
-		return fmt.Errorf("either Activity Type or Activity Id must be provided")
 	}
 
 	resp, err := cl.WorkflowService().ResetActivity(cctx, request)

--- a/temporalcli/commands.activity.go
+++ b/temporalcli/commands.activity.go
@@ -208,15 +208,16 @@ func (c *TemporalActivityPauseCommand) run(cctx *CommandContext, args []string) 
 		Identity: c.Identity,
 	}
 
-	if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
-		return err
+	if c.ActivityId != "" && c.ActivityType != "" {
+		return fmt.Errorf("either Activity Type or Activity Id, but not both")
 	}
 
 	if c.ActivityType != "" {
 		request.Activity = &workflowservice.PauseActivityRequest_Type{Type: c.ActivityType}
-	}
-	if c.ActivityId != "" {
+	} else if c.ActivityId != "" {
 		request.Activity = &workflowservice.PauseActivityRequest_Id{Id: c.ActivityId}
+	} else {
+		return fmt.Errorf("either Activity Type or Activity Id must be provided")
 	}
 
 	_, err = cl.WorkflowService().PauseActivity(cctx, request)
@@ -264,15 +265,16 @@ func (c *TemporalActivityUnpauseCommand) run(cctx *CommandContext, args []string
 			Identity:       c.Identity,
 		}
 
-		if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
-			return err
+		if c.ActivityId != "" && c.ActivityType != "" {
+			return fmt.Errorf("either Activity Type or Activity Id, but not both")
 		}
 
 		if c.ActivityType != "" {
 			request.Activity = &workflowservice.UnpauseActivityRequest_Type{Type: c.ActivityType}
-		}
-		if c.ActivityId != "" {
+		} else if c.ActivityId != "" {
 			request.Activity = &workflowservice.UnpauseActivityRequest_Id{Id: c.ActivityId}
+		} else {
+			return fmt.Errorf("either Activity Type or Activity Id must be provided")
 		}
 
 		_, err = cl.WorkflowService().UnpauseActivity(cctx, request)
@@ -324,15 +326,16 @@ func (c *TemporalActivityResetCommand) run(cctx *CommandContext, args []string) 
 		ResetHeartbeat: c.ResetHeartbeats,
 	}
 
-	if err := c.ActivityReferenceOptions.validateFlags(); err != nil {
-		return err
+	if c.ActivityId != "" && c.ActivityType != "" {
+		return fmt.Errorf("either Activity Type or Activity Id, but not both")
 	}
 
 	if c.ActivityType != "" {
 		request.Activity = &workflowservice.ResetActivityRequest_Type{Type: c.ActivityType}
-	}
-	if c.ActivityId != "" {
+	} else if c.ActivityId != "" {
 		request.Activity = &workflowservice.ResetActivityRequest_Id{Id: c.ActivityId}
+	} else {
+		return fmt.Errorf("either Activity Type or Activity Id must be provided")
 	}
 
 	resp, err := cl.WorkflowService().ResetActivity(cctx, request)

--- a/temporalcli/commands.activity_test.go
+++ b/temporalcli/commands.activity_test.go
@@ -247,6 +247,16 @@ func (s *SharedServerSuite) TestActivityCommandFailed_NoActivityTpeOrId() {
 	}
 }
 
+func (s *SharedServerSuite) TestActivityCommandFailed_BothActivityTpeOrId() {
+	run := s.waitActivityStarted()
+
+	commands := []string{"pause", "unpause", "reset"}
+	for _, command := range commands {
+		res := sendActivityCommand(command, run, s, "--activity-id", activityId, "--activity-type", activityType)
+		s.Error(res.Err)
+	}
+}
+
 func (s *SharedServerSuite) TestActivityReset() {
 	run := s.waitActivityStarted()
 

--- a/temporalcli/commands.gen.go
+++ b/temporalcli/commands.gen.go
@@ -3,8 +3,6 @@
 package temporalcli
 
 import (
-	"fmt"
-
 	"github.com/mattn/go-isatty"
 
 	"github.com/spf13/cobra"
@@ -475,35 +473,10 @@ func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivi
 	return &s
 }
 
-type ActivityReferenceOptions struct {
-	ActivityId   string
-	ActivityType string
-}
-
-func (v *ActivityReferenceOptions) buildFlags(_ *CommandContext, f *pflag.FlagSet, activityType string, onlyWithoutQuery bool) {
-	f.StringVarP(&v.ActivityId, "activity-id", "a", "", fmt.Sprintf("Activity ID to %s.", activityType))
-	if onlyWithoutQuery {
-		f.StringVarP(&v.ActivityType, "activity-type", "g", "", fmt.Sprintf("Activity Type to %s. Can only be used without --query.", activityType))
-	} else {
-		f.StringVarP(&v.ActivityType, "activity-type", "g", "", fmt.Sprintf("Activity Type to %s.", activityType))
-	}
-}
-
-func (v *ActivityReferenceOptions) validateFlags() error {
-	if v.ActivityId != "" && v.ActivityType != "" {
-		return fmt.Errorf("either Activity Type or Activity Id, but not both")
-	}
-	if v.ActivityId == "" && v.ActivityType == "" {
-		return fmt.Errorf("either Activity Type or Activity Id, but not both")
-	}
-	return nil
-}
-
 type TemporalActivityPauseCommand struct {
 	Parent  *TemporalActivityCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	ActivityReferenceOptions
 	ActivityId   string
 	ActivityType string
 	Identity     string
@@ -521,9 +494,10 @@ func NewTemporalActivityPauseCommand(cctx *CommandContext, parent *TemporalActiv
 		s.Command.Long = "Pause an Activity.\n\nIf the Activity is not currently running (e.g. because it previously\nfailed), it will not be run again until it is unpaused.\n\nHowever, if the Activity is currently running, it will run to completion.\nIf the Activity is on its last retry attempt and fails, the failure will\nbe returned to the caller, just as if the Activity had not been paused.\n\nActivities can be specified by their Activity ID or Activity Type.\nOne of those parameters must be provided. If both are provided - Activity\nType will be used, and Activity ID will be ignored.\n\nSpecify the Activity and Workflow IDs:\n\n```\ntemporal activity pause \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId\n```"
 	}
 	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().StringVarP(&s.ActivityId, "activity-id", "a", "", "Activity ID to pause. Either `activity-id` or `activity-type` must be provided, but not both.")
+	s.Command.Flags().StringVarP(&s.ActivityType, "activity-type", "g", "", "Either `activity-id` or `activity-type` must be provided, but not both.Activity Type to pause.")
 	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of the user submitting this request.")
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
-	s.ActivityReferenceOptions.buildFlags(cctx, s.Command.Flags(), "pause", false)
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -536,7 +510,6 @@ type TemporalActivityResetCommand struct {
 	Parent  *TemporalActivityCommand
 	Command cobra.Command
 	WorkflowReferenceOptions
-	ActivityReferenceOptions
 	ActivityId      string
 	ActivityType    string
 	Identity        string
@@ -556,11 +529,12 @@ func NewTemporalActivityResetCommand(cctx *CommandContext, parent *TemporalActiv
 		s.Command.Long = "Resetting an activity resets both the number of attempts and the activity\ntimeout.\n\nIf activity is paused and 'keep_paused' flag is not provided - it will be\nunpaused.\nIf activity is paused and 'keep_paused' flag is provided - it will stay\npaused.\nIf activity is waiting for the retry, is will be rescheduled immediately.\nIf the 'reset_heartbeats' flag is set, the activity heartbeat timer and\nheartbeats will be reset.\n\nActivities can be specified by their Activity ID or Activity Type.\nOne of those parameters must be provided. If both are provided - Activity\nType will be used, and Activity ID will be ignored.\n\nSpecify the Activity Type of ID and Workflow IDs:\n\n```\ntemporal activity reset \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId\n    --keep-paused\n    --reset-heartbeats\n```"
 	}
 	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().StringVarP(&s.ActivityId, "activity-id", "a", "", "Activity ID to reset. Either `activity-id` or `activity-type` must be provided, but not both.")
+	s.Command.Flags().StringVarP(&s.ActivityType, "activity-type", "g", "", "Activity Type to reset. Either `activity-id` or `activity-type` must be provided, but not both.")
 	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of the user submitting this request.")
 	s.Command.Flags().BoolVar(&s.KeepPaused, "keep-paused", false, "If activity was paused - it will stay paused.")
 	s.Command.Flags().BoolVar(&s.ResetHeartbeats, "reset-heartbeats", false, "Reset the Activity's heartbeat.")
 	s.WorkflowReferenceOptions.buildFlags(cctx, s.Command.Flags())
-	s.ActivityReferenceOptions.buildFlags(cctx, s.Command.Flags(), "reset", false)
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -573,7 +547,6 @@ type TemporalActivityUnpauseCommand struct {
 	Parent  *TemporalActivityCommand
 	Command cobra.Command
 	SingleWorkflowOrBatchOptions
-	ActivityReferenceOptions
 	ActivityId      string
 	ActivityType    string
 	Identity        string
@@ -595,6 +568,8 @@ func NewTemporalActivityUnpauseCommand(cctx *CommandContext, parent *TemporalAct
 		s.Command.Long = "Re-schedule a previously-paused Activity for execution.\n\nIf the Activity is not running and is past its retry timeout, it will be\nscheduled immediately. Otherwise, it will be scheduled after its retry\ntimeout expires.\n\nUse `--reset-attempts` to reset the number of previous run attempts to\nzero. For example, if an Activity is near the maximum number of attempts\nN specified in its retry policy, `--reset-attempts` will allow the\nActivity to be retried another N times after unpausing.\n\nUse `--reset-heartbeat` to reset the Activity's heartbeats.\n\nActivities can be specified by their Activity ID or Activity Type.\nOne of those parameters must be provided. If both are provided - Activity\nType will be used, and Activity ID will be ignored.\n\nActivities can be unpaused in bulk via a visibility Query list filter:\n\n```\ntemporal activity unpause \\\n    --query YourQuery \\\n    --reason YourReasonForTermination\n```\n\n\nSpecify the Activity ID or Type and Workflow IDs:\n\n```\ntemporal activity unpause \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId\n    --reset-attempts\n    --reset-heartbeats\n```"
 	}
 	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().StringVarP(&s.ActivityId, "activity-id", "a", "", "Activity ID to unpause. Can only be used without --query or --match-all. Either `activity-id` or `activity-type` must be provided, but not both.")
+	s.Command.Flags().StringVarP(&s.ActivityType, "activity-type", "g", "", "Activity Type to unpause. Can only be used without --match-all. Either `activity-id` or `activity-type` must be provided, but not both.")
 	s.Command.Flags().StringVar(&s.Identity, "identity", "", "Identity of the user submitting this request.")
 	s.Command.Flags().BoolVar(&s.ResetAttempts, "reset-attempts", false, "Also reset the activity attempts.")
 	s.Command.Flags().BoolVar(&s.ResetHeartbeats, "reset-heartbeats", false, "Reset the Activity's heartbeats. Only works with --reset-attempts.")
@@ -602,7 +577,6 @@ func NewTemporalActivityUnpauseCommand(cctx *CommandContext, parent *TemporalAct
 	s.Jitter = 0
 	s.Command.Flags().VarP(&s.Jitter, "jitter", "j", "The activity will start at random a time within the specified duration. Can only be used with --query.")
 	s.SingleWorkflowOrBatchOptions.buildFlags(cctx, s.Command.Flags())
-	s.ActivityReferenceOptions.buildFlags(cctx, s.Command.Flags(), "unpause", true)
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -454,6 +454,7 @@ commands:
         description: Identity of the user submitting this request.
     option-sets:
       - workflow reference
+      - activity-reference
 
   - name: temporal activity unpause
     summary: Unpause an Activity
@@ -526,6 +527,7 @@ commands:
           Can only be used with --query.
     option-sets:
       - single-workflow-or-batch
+      - activity-reference
 
   - name: temporal activity reset
     summary: Reset an Activity
@@ -574,6 +576,7 @@ commands:
         description: Reset the Activity's heartbeat.
     option-sets:
       - workflow reference
+      - activity-reference
 
   - name: temporal batch
     summary: Manage running batch jobs

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -454,7 +454,6 @@ commands:
         description: Identity of the user submitting this request.
     option-sets:
       - workflow reference
-      - activity-reference
 
   - name: temporal activity unpause
     summary: Unpause an Activity
@@ -528,7 +527,6 @@ commands:
           Can only be used with --query.
     option-sets:
       - single-workflow-or-batch
-      - activity-reference
 
   - name: temporal activity reset
     summary: Reset an Activity
@@ -577,7 +575,6 @@ commands:
         description: Reset the Activity's heartbeat.
     option-sets:
       - workflow reference
-      - activity-reference
 
   - name: temporal batch
     summary: Manage running batch jobs

--- a/temporalcli/commandsgen/commands.yml
+++ b/temporalcli/commandsgen/commands.yml
@@ -444,11 +444,11 @@ commands:
       - name: activity-id
         short: a
         type: string
-        description: Activity ID to pause.
+        description: Activity ID to pause. Either `activity-id` or `activity-type` must be provided, but not both.
       - name: activity-type
         short: g
         type: string
-        description: Activity Type to pause.
+        description: Either `activity-id` or `activity-type` must be provided, but not both.Activity Type to pause.
       - name: identity
         type: string
         description: Identity of the user submitting this request.
@@ -499,11 +499,12 @@ commands:
         short: a
         type: string
         description: |
-          Activity ID to unpause. Can only be used without --query.
+          Activity ID to unpause. Can only be used without --query or --match-all. Either `activity-id` or `activity-type` must be provided, but not both.
       - name: activity-type
         short: g
         type: string
-        description: Activity Type to unpause.
+        description: |
+          Activity Type to unpause. Can only be used without --match-all. Either `activity-id` or `activity-type` must be provided, but not both.
       - name: identity
         type: string
         description: Identity of the user submitting this request.
@@ -560,11 +561,11 @@ commands:
       - name: activity-id
         short: a
         type: string
-        description: Activity ID to pause.
+        description: Activity ID to reset. Either `activity-id` or `activity-type` must be provided, but not both.
       - name: activity-type
         short: g
         type: string
-        description: Activity Type to pause.
+        description: Activity Type to reset. Either `activity-id` or `activity-type` must be provided, but not both.
       - name: identity
         type: string
         description: Identity of the user submitting this request.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
`temporal activity {pause,unpause,reset}` commands take either an `--activity-id` or `activity-type` argument but not both. If both are provided the command will fail

## Why?
We want to fail when both are provided, the user doesn't need to provide activity type and id as type can be inferred from type.

## Checklist
<!--- add/delete as needed --->

1. Closes no issue

2. How was this tested:
* new unit test showing failure

3. Any docs updates needed?
documentation updates will be needed, @drewhoskins-temporal  or @ychebotarev can share where and I will update