### PR TITLE
pause: add pause activity information to workflow describe cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,3 +175,5 @@ require (
 	modernc.org/strutil v1.2.1 // indirect
 	modernc.org/token v1.1.0 // indirect
 )
+
+replace go.temporal.io/api => ../api-go

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,6 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.51.0 h1:9+e14GrIa7nWoWoudqj/PSwm33yYjV+u8TAR9If7s/g=
-go.temporal.io/api v1.51.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.35.0 h1:lRNAQ5As9rLgYa7HBvnmKyzxLcdElTuoFJ0FXM/AsLQ=
 go.temporal.io/sdk v1.35.0/go.mod h1:1q5MuLc2MEJ4lneZTHJzpVebW2oZnyxoIOWX3oFVebw=
 go.temporal.io/sdk/contrib/envconfig v0.1.0 h1:s+G/Ujph+Xl2jzLiiIm2T1vuijDkUL4Kse49dgDVGBE=


### PR DESCRIPTION
## What was changed
Added pause information display for pending activities in `temporal workflow describe` command. Shows `Paused` status, `PauseTime`, and `PausedBy` fields when activities are paused.

## Why?
Users get visibility into whether activities are paused when troubleshooting workflow execution issues.

## Checklist

1. Closes #[issue-number]

2. How was this tested:
Run `temporal workflow describe` on workflows with paused activities to verify pause information displays correctly.

3. Any docs updates needed?
No documentation updates required - this is additional output in existing command.

Based on your changes to add pause information for activities in the workflow describe command, here's a succinct PR description:

## What was changed
Added pause information display for pending activities in `temporal workflow describe` command. Shows `Paused` status, `PauseTime`, and `PausedBy` fields when activities are paused.

## Why?
Users need visibility into whether activities are paused when troubleshooting workflow execution issues.

## Checklist

1. Closes #[issue-number]

2. How was this tested:
Run `temporal workflow describe` on workflows with paused activities to verify pause information displays correctly.

3. Any docs updates needed?
No documentation updates required - this is additional output in existing command.

[Requires this api pr to be merged first](https://github.com/temporalio/api/pull/613)