### PR TITLE
Moved autogen comments out of the doc headers

### DIFF
--- a/temporalcli/commandsgen/docs.go
+++ b/temporalcli/commandsgen/docs.go
@@ -58,8 +58,6 @@ func (c *Command) writeDoc(w *docWriter) error {
 func (w *docWriter) writeCommand(c *Command) {
 	fileName := c.fileName()
 	w.fileMap[fileName] = &bytes.Buffer{}
-	w.fileMap[fileName].WriteString("{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.\n")
-	w.fileMap[fileName].WriteString("This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}\n")
 	w.fileMap[fileName].WriteString("---\n")
 	w.fileMap[fileName].WriteString("id: " + fileName + "\n")
 	w.fileMap[fileName].WriteString("title: Temporal CLI " + fileName + " command reference\n")
@@ -76,6 +74,8 @@ func (w *docWriter) writeCommand(c *Command) {
 		w.fileMap[fileName].WriteString("  - " + tag + "\n")
 	}
 	w.fileMap[fileName].WriteString("---\n\n")
+	w.fileMap[fileName].WriteString("{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.\n")
+	w.fileMap[fileName].WriteString("This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}\n")
 }
 
 func (w *docWriter) writeSubcommand(c *Command) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This was breaking the header on the CLI docs pages. Now it's immediately after the header.

Here's the commit with the breaking change: https://github.com/temporalio/cli/commit/9fb5fbfe909de4596ee21efb35cc6ccf483c9005

Here's the commit showing the breaking change in the docs: https://github.com/temporalio/documentation/commit/c8eec39f1daf62162f3a020bfeb95eb7e868ac79#diff-0c36e6922979f7bce143e964b8e3b55a32e04f0e686c0bf1982275ce97bc5316


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
