### PR TITLE
VLN-474: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build-test:
     strategy:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yaml`: Set workflow-level permissions so the GITHUB_TOKEN only reads repository contents and retains actions write access needed for artifact uploads.