### PR TITLE
VLN-442: Use first-party action for GitHub app tokens

### DIFF
--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -32,12 +32,14 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: documentation # generate a token with permissions to trigger GHA in documentation repo
+          # Generate a token with permissions to trigger GHA in documentation repo.
+          repositories: |
+            documentation
 
       - name: Trigger Documentation Workflow
         env:

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: |
+            cli
+            docker-builds
 
       - name: Dispatch docker builds Github Action
         env:


### PR DESCRIPTION
## Summary

- `.github/workflows/trigger-publish.yml`: Set the GitHub App token step to include owner temporalio and added repositories list for cli and docker-builds so the generated token retains access to both repos.
- `.github/workflows/trigger-docs.yml`: Upgraded the GitHub App token step to actions/create-github-app-token@v2 and switched repositories input to a multiline list (documentation) with an explanatory comment while keeping the owner scoped to the repository owner.

---

Previous summary:

## Summary

- `.github/workflows/trigger-publish.yml`: Replaced tibdex/github-app-token with actions/create-github-app-token@v2 and converted inputs to the new action’s kebab-case names so the workflow continues generating the app token securely.