### PR TITLE
fix: wrong examples for config delete(-profile)?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Example to run a single test case:
 First, update [commands.yaml](internal/temporalcli/commands.yaml) following the rules in that file. Then to regenerate the
 [commands.gen.go](internal/temporalcli/commands.gen.go) file from code, run:
 
-    go run ./internal/cmd/gen-commands -input internal/temporalcli/commands.yaml -pkg temporalcli -context "*CommandContext" > internal/temporalcli/commands.gen.go
+    go run ./cmd/gen-commands -input internal/temporalcli/commands.yaml -pkg temporalcli -context "*CommandContext" > internal/temporalcli/commands.gen.go
 
 This will expect every non-parent command to have a `run` method, so for new commands developers will have to implement
 `run` on the new command in a separate file before it will compile.
@@ -31,7 +31,7 @@ This will expect every non-parent command to have a `run` method, so for new com
 Once a command is updated, the CI will automatically generate new docs
 and create a PR in the Documentation repo with the corresponding updates. To generate these docs locally, run:
 
-    go run ./internal/cmd/gen-docs -input internal/temporalcli/commands.yaml -output dist/docs
+    go run ./cmd/gen-docs -input internal/temporalcli/commands.yaml -output dist/docs
 
 This will auto-generate a new set of docs to `dist/docs/`. If a new root command is added, a new file will be automatically generated, like `temporal activity` and `activity.mdx`.
 

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -835,9 +835,9 @@ func NewTemporalConfigDeleteCommand(cctx *CommandContext, parent *TemporalConfig
 	s.Command.Use = "delete [flags]"
 	s.Command.Short = "Delete a config file property (EXPERIMENTAL)\n"
 	if hasHighlighting {
-		s.Command.Long = "Remove a property within a profile.\n\n\x1b[1mtemporal env delete \\\n    --prop tls.client_cert_path\x1b[0m"
+		s.Command.Long = "Remove a property within a profile.\n\n\x1b[1mtemporal config delete \\\n    --prop tls.client_cert_path\x1b[0m"
 	} else {
-		s.Command.Long = "Remove a property within a profile.\n\n```\ntemporal env delete \\\n    --prop tls.client_cert_path\n```"
+		s.Command.Long = "Remove a property within a profile.\n\n```\ntemporal config delete \\\n    --prop tls.client_cert_path\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.Prop, "prop", "p", "", "Specific property to delete. If unset, deletes entire profile. Required.")
@@ -862,9 +862,9 @@ func NewTemporalConfigDeleteProfileCommand(cctx *CommandContext, parent *Tempora
 	s.Command.Use = "delete-profile [flags]"
 	s.Command.Short = "Delete an entire config profile (EXPERIMENTAL)\n"
 	if hasHighlighting {
-		s.Command.Long = "Remove a full profile entirely. The \x1b[1m--profile\x1b[0m must be set explicitly.\n\n\x1b[1mtemporal env delete-profile \\\n    --profile my-profile\x1b[0m"
+		s.Command.Long = "Remove a full profile entirely. The \x1b[1m--profile\x1b[0m must be set explicitly.\n\n\x1b[1mtemporal config delete-profile \\\n    --profile my-profile\x1b[0m"
 	} else {
-		s.Command.Long = "Remove a full profile entirely. The `--profile` must be set explicitly.\n\n```\ntemporal env delete-profile \\\n    --profile my-profile\n```"
+		s.Command.Long = "Remove a full profile entirely. The `--profile` must be set explicitly.\n\n```\ntemporal config delete-profile \\\n    --profile my-profile\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Run = func(c *cobra.Command, args []string) {

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -787,7 +787,7 @@ commands:
       Remove a property within a profile.
 
       ```
-      temporal env delete \
+      temporal config delete \
           --prop tls.client_cert_path
       ```
     options:
@@ -805,7 +805,7 @@ commands:
       Remove a full profile entirely. The `--profile` must be set explicitly.
 
       ```
-      temporal env delete-profile \
+      temporal config delete-profile \
           --profile my-profile
       ```
 


### PR DESCRIPTION
## What was changed

- replace `temporal env delete` by `temporal config delete` in `temporal config` subcommands helpers
- fix CONTRIBUTING.md for code generation

## Why?

Helpers suggested `temporal env` instead of `temporal config`; feels like a wrong copy/paste.

## Checklist

1. Any docs updates needed?

https://docs.temporal.io/cli/config