### PR TITLE
Wire enableReplication into CLI

### DIFF
--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -1224,10 +1224,11 @@ func NewTemporalOperatorClusterSystemCommand(cctx *CommandContext, parent *Tempo
 }
 
 type TemporalOperatorClusterUpsertCommand struct {
-	Parent           *TemporalOperatorClusterCommand
-	Command          cobra.Command
-	FrontendAddress  string
-	EnableConnection bool
+	Parent            *TemporalOperatorClusterCommand
+	Command           cobra.Command
+	FrontendAddress   string
+	EnableConnection  bool
+	EnableReplication bool
 }
 
 func NewTemporalOperatorClusterUpsertCommand(cctx *CommandContext, parent *TemporalOperatorClusterCommand) *TemporalOperatorClusterUpsertCommand {
@@ -1245,6 +1246,7 @@ func NewTemporalOperatorClusterUpsertCommand(cctx *CommandContext, parent *Tempo
 	s.Command.Flags().StringVar(&s.FrontendAddress, "frontend-address", "", "Remote endpoint. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "frontend-address")
 	s.Command.Flags().BoolVar(&s.EnableConnection, "enable-connection", false, "Set the connection to \"enabled\".")
+	s.Command.Flags().BoolVar(&s.EnableReplication, "enable-replication", false, "Set the replication to \"enabled\".")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/internal/temporalcli/commands.operator_cluster.go
+++ b/internal/temporalcli/commands.operator_cluster.go
@@ -126,13 +126,14 @@ func (c *TemporalOperatorClusterListCommand) run(cctx *CommandContext, args []st
 					"HistoryShardCount":      cluster.HistoryShardCount,
 					"InitialFailoverVersion": cluster.InitialFailoverVersion,
 					"IsConnectionEnabled":    cluster.IsConnectionEnabled,
+					"IsReplicationEnabled":   cluster.IsReplicationEnabled,
 				})
 			}
 		}
 		// Print table, headers only on first table
 		if len(textTable) > 0 {
 			_ = cctx.Printer.PrintStructured(textTable, printer.StructuredOptions{
-				Fields: []string{"Name", "ClusterId", "Address", "HistoryShardCount", "InitialFailoverVersion", "IsConnectionEnabled"},
+				Fields: []string{"Name", "ClusterId", "Address", "HistoryShardCount", "InitialFailoverVersion", "IsConnectionEnabled", "IsReplicationEnabled"},
 				Table:  &printer.TableOptions{NoHeader: pageIndex > 0},
 			})
 		}
@@ -153,6 +154,7 @@ func (c *TemporalOperatorClusterUpsertCommand) run(cctx *CommandContext, args []
 	_, err = cl.OperatorService().AddOrUpdateRemoteCluster(cctx, &operatorservice.AddOrUpdateRemoteClusterRequest{
 		FrontendAddress:               c.FrontendAddress,
 		EnableRemoteClusterConnection: c.EnableConnection,
+		EnableReplication:             c.EnableReplication,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to upsert cluster: %w", err)

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -1642,6 +1642,9 @@ commands:
       - name: enable-connection
         type: bool
         description: Set the connection to "enabled".
+      - name: enable-replication
+        type: bool
+        description: Set the replication to "enabled".
 
   - name: temporal operator namespace
     summary: Namespace operations


### PR DESCRIPTION
Add --enable-replication flag to the cluster upsert command and display IsReplicationEnabled in cluster list output.

Cherry-picked from #881 (next-server branch). https://github.com/temporalio/cli/pull/881/changes
