### PR TITLE
bump go version

### DIFF
--- a/cliext/go.mod
+++ b/cliext/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/cli/cliext
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/cli
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION


## What was changed
bump go to 1.25.5

## Why?
To be inline with server 1.30 and close CVEs