### PR TITLE
fix build flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ builds:
       dir: cmd/temporal
       binary: temporal
       ldflags:
-        - -s -w -X github.com/temporalio/cli/internal.Version={{.Version}}
+        - -s -w -X github.com/temporalio/cli/internal/temporalcli.Version={{.Version}}
       goarch:
         - amd64
         - arm64


### PR DESCRIPTION
## What was changed

Fixed the ldflags path in `.goreleaser.yml` to correctly set the CLI version at build time.

**Before:** `-X github.com/temporalio/cli/internal.Version={{.Version}}`
**After:** `-X github.com/temporalio/cli/internal/temporalcli.Version={{.Version}}`

## Why?

The `Version` variable is defined in `internal/temporalcli/commands.go`, not `internal/`. The incorrect path meant the ldflags were targeting a non-existent variable, causing all released binaries to show `0.0.0-DEV` instead of the actual version.

## Checklist

1. How was this tested:
   - Built with `goreleaser build --snapshot --single-target`
   - Before fix: `temporal version 0.0.0-DEV (Server 1.30.0, UI 2.45.0)`
   - After fix: `temporal version 1.5.1-SNAPSHOT-31cf9eb (Server 1.30.0, UI 2.45.0)`

2. Any docs updates needed?
   - No