### PR TITLE
feat(apt): support apt deb for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,11 @@ jobs:
           GIT_BRANCH: ${{ steps.branch.outputs.branch }}
           BUILD_PLATFORM: ${{ steps.platform.outputs.platform }}
           GO_VERSION: ${{ steps.go.outputs.go }}
+          
+      - name: Update APT Repository
+        uses: dawidd6/action-debian-repository@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          packages_directory: dist/
+          branch: gh-pages
+          commit_message: "chore: update APT repository for release ${{ github.ref_name }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,3 +69,18 @@ changelog:
 
 announce:
   skip: "true"
+
+nfpms:
+  - id: temporal-apt
+    package_name: temporal
+    file_name_template: "temporal_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - nix 
+    vendor: Temporal Technologies Inc.
+    homepage: https://temporal.io/
+    maintainer: Temporal CLI Team <info@temporal.io>
+    description: "Command-line interface for running Temporal Server and interacting with Workflows, Activities, and Namespaces."
+    license: MIT
+    formats:
+      - deb
+    bindir: /usr/bin  

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	go.temporal.io/api v1.60.1
 	go.temporal.io/sdk v1.38.0
 	go.temporal.io/sdk/contrib/envconfig v0.1.0
-	golang.org/x/mod v0.31.0
 	go.temporal.io/server v1.30.0
+	golang.org/x/mod v0.31.0
 	golang.org/x/term v0.38.0
 	golang.org/x/tools v0.40.0
 	google.golang.org/grpc v1.72.2


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
Adds support for deb packages to the release process 

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

GoReleaser uses a built-in tool called nfpm to generate Linux packages. Adding an nfpms block to the existing .goreleaser.yml file.

To make it a true apt source (so users don't have to download the .deb manually), the GitHub Action parses the generated .deb files and creates an APT repository hosted on the repository's gh-pages branch.
 
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
https://github.com/temporalio/cli/issues/816 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
