### PR TITLE
Bump UI server to 2.45.3 and API to 1.60.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.10.0
 	github.com/temporalio/cli/cliext v0.0.0
-	github.com/temporalio/ui-server/v2 v2.45.0
+	github.com/temporalio/ui-server/v2 v2.45.3
 	go.temporal.io/api v1.60.2
 	go.temporal.io/sdk v1.38.0
 	go.temporal.io/sdk/contrib/envconfig v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938 h1:sEJGhmDo+0FaPWM6f0v8Tjia0H5pR6/Baj6+kS78B+M=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
-github.com/temporalio/ui-server/v2 v2.45.0 h1:JePJfGst0htF/8byuSBjYYVK82ZCd2mDqjrFvWbCAhI=
-github.com/temporalio/ui-server/v2 v2.45.0/go.mod h1:xOQ+dRbyQ9lVwtRPzI95Jb8ds4JlO4dY+8PSi0bcR6c=
+github.com/temporalio/ui-server/v2 v2.45.3 h1:htzeDjUq77Il8bjFuel2bHFC3tA6SNx6clU2iQS0RRI=
+github.com/temporalio/ui-server/v2 v2.45.3/go.mod h1:tsl7cOECAi/uCnCpdMZ//F2Fi8RWTPAvFdRlz3qk19U=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber-common/bark v1.0.0/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Bumps UI server to [v2.45.3](https://github.com/temporalio/ui-server/releases/tag/v2.45.3) and API to [v1.60.2](https://github.com/temporalio/api/releases/tag/v1.60.2).

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
