### PR TITLE
upgrade go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/cli
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION

## What was changed
bump to 1.26

## Why?
CVEs in standard lib
