### PR TITLE
Bug fix: fix --log-level help rendering

### DIFF
--- a/cliext/flags.gen.go
+++ b/cliext/flags.gen.go
@@ -39,7 +39,7 @@ func (v *CommonOptions) BuildFlags(f *pflag.FlagSet) {
 	f.BoolVar(&v.DisableConfigFile, "disable-config-file", false, "If set, disables loading environment config from config file. EXPERIMENTAL.")
 	f.BoolVar(&v.DisableConfigEnv, "disable-config-env", false, "If set, disables loading environment config from environment variables. EXPERIMENTAL.")
 	v.LogLevel = NewFlagStringEnum([]string{"debug", "info", "warn", "error", "never"}, "info")
-	f.Var(&v.LogLevel, "log-level", "Log level. Default is \"info\" for most commands and \"warn\" for `server start-dev`. Accepted values: debug, info, warn, error, never.")
+	f.Var(&v.LogLevel, "log-level", "Log level. Default is \"info\" for most commands and \"warn\" for \"server start-dev\". Accepted values: debug, info, warn, error, never.")
 	v.LogFormat = NewFlagStringEnum([]string{"text", "json", "pretty"}, "text")
 	f.Var(&v.LogFormat, "log-format", "Log format. Accepted values: text, json.")
 	v.Output = NewFlagStringEnum([]string{"text", "json", "jsonl", "none"}, "text")

--- a/cliext/option-sets.yaml
+++ b/cliext/option-sets.yaml
@@ -51,7 +51,7 @@ option-sets:
           - never
         description: |
           Log level.
-          Default is "info" for most commands and "warn" for `server start-dev`.
+          Default is "info" for most commands and "warn" for "server start-dev".
         default: info
       - name: log-format
         type: string-enum


### PR DESCRIPTION
## What was changed
Remove backticks that were causing broken `--help` rendering:

**Before**
Note spurious presence of "server start-dev" and lack of expected "string"
```
$ temporal --help | rg -C1 -F -- '--log-level'
                Log format. Accepted values: text, json. (default "text")
      --log-level server start-dev
                Log level. Default is "info" for most commands and "warn"
```

**After**
```
$ ./temporal --help | rg -C1 -F -- '--log-level'
                Log format. Accepted values: text, json. (default "text")
      --log-level string
                Log level. Default is "info" for most commands and "warn"
```      

## Why?
Bug
