### PR TITLE
fix: update regional endpoint for API key CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Test cloud API key env var
         if: ${{ matrix.cloudTestTarget && env.HAS_SECRETS == 'true' }}
         env:
-          TEMPORAL_ADDRESS: us-west-2.aws.api.temporal.io:7233
+          TEMPORAL_ADDRESS: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
           TEMPORAL_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
           TEMPORAL_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
         shell: bash
@@ -117,7 +117,7 @@ jobs:
       - name: Test cloud API key arg
         if: ${{ matrix.cloudTestTarget && env.HAS_SECRETS == 'true' }}
         env:
-          TEMPORAL_ADDRESS: us-west-2.aws.api.temporal.io:7233
+          TEMPORAL_ADDRESS: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
           TEMPORAL_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
         shell: bash
         run: go run ./cmd/temporal workflow list --limit 2 --api-key ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Test cloud API key env var
         if: ${{ matrix.cloudTestTarget && env.HAS_SECRETS == 'true' }}
         env:
-          TEMPORAL_ADDRESS: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
+          TEMPORAL_ADDRESS: us-east-1.aws.api.temporal.io:7233
           TEMPORAL_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
           TEMPORAL_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
         shell: bash
@@ -117,7 +117,7 @@ jobs:
       - name: Test cloud API key arg
         if: ${{ matrix.cloudTestTarget && env.HAS_SECRETS == 'true' }}
         env:
-          TEMPORAL_ADDRESS: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
+          TEMPORAL_ADDRESS: us-east-1.aws.api.temporal.io:7233
           TEMPORAL_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
         shell: bash
         run: go run ./cmd/temporal workflow list --limit 2 --api-key ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}


### PR DESCRIPTION
## Summary
- Update the hardcoded regional endpoint for API key cloud tests

## Test plan
- CI should pass with the updated endpoint