### PR TITLE
SEC-1654: remediate missing-govulncheck-workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,18 @@
+name: Govulncheck
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: temporalio/public-actions/golang/govulncheck@main


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>missing-govulncheck-workflow</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/cli</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/SEC-1654">SEC-1654</a></td></tr>
</table>

## Summary

- `.github/workflows/govulncheck.yml`: Added a new pull-request-only `Govulncheck` workflow with `contents: read` permissions and a single `ubuntu-latest` job that runs `actions/checkout@v6`, `actions/setup-go@v6` (`go-version-file: go.mod`), and `temporalio/public-actions/golang/govulncheck@main` without `continue-on-error`.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix