### PR TITLE
make sure warnings go to stderr instead of stdout in taskqueue commands

### DIFF
--- a/internal/temporalcli/commands.taskqueue_config.go
+++ b/internal/temporalcli/commands.taskqueue_config.go
@@ -63,9 +63,9 @@ const (
 )
 
 // printZeroRateLimitWarning prints a warning when a rate limit is set to 0
-func printZeroRateLimitWarning(p *printer.Printer, limitType string) {
-	p.Printlnf("WARNING: Setting %s to 0 will STOP ALL TRAFFIC on this task queue.", limitType)
-	p.Println("         This will prevent any tasks from being dispatched until the limit is changed.")
+func printZeroRateLimitWarning(cctx *CommandContext, limitType string) {
+	fmt.Fprintf(cctx.Options.Stderr, "WARNING: Setting %s to 0 will STOP ALL TRAFFIC on this task queue.\n", limitType)
+	fmt.Fprintln(cctx.Options.Stderr, "         This will prevent any tasks from being dispatched until the limit is changed.")
 }
 
 // parseFairnessKeyWeights parses "key=weight" or "key=default" format strings
@@ -200,7 +200,7 @@ func (c *TemporalTaskQueueConfigSetCommand) run(cctx *CommandContext, args []str
 
 		// Warn about zero rate limit (stops all traffic)
 		if queueRateLimitIsZero {
-			printZeroRateLimitWarning(cctx.Printer, "queue rate limit")
+			printZeroRateLimitWarning(cctx, "queue rate limit")
 		}
 	}
 
@@ -216,7 +216,7 @@ func (c *TemporalTaskQueueConfigSetCommand) run(cctx *CommandContext, args []str
 
 		// Warn about zero rate limit
 		if fairnessRateLimitIsZero {
-			printZeroRateLimitWarning(cctx.Printer, "fairness key rate limit default")
+			printZeroRateLimitWarning(cctx, "fairness key rate limit default")
 		}
 	}
 

--- a/internal/temporalcli/commands.taskqueue_config_test.go
+++ b/internal/temporalcli/commands.taskqueue_config_test.go
@@ -332,8 +332,8 @@ func (s *SharedServerSuite) TestTaskQueue_Config_Validation() {
 		"--queue-rps-limit-reason", "emergency stop",
 	)
 	s.NoError(res.Err)
-	s.Contains(res.Stdout.String(), "WARNING")
-	s.Contains(res.Stdout.String(), "STOP ALL TRAFFIC")
+	s.Contains(res.Stderr.String(), "WARNING")
+	s.Contains(res.Stderr.String(), "STOP ALL TRAFFIC")
 
 	// Duplicate fairness keys - should fail
 	res = s.Execute(


### PR DESCRIPTION
More correct in general but also in particular for structured output

## What was changed
We have a warning printed for stopping all task queues that was being incorrectly being sent to stdout, even with structured output suggested. This fixes that.

## Why?
To not mess up structured output.

## Checklist

1. How was this tested:
Tested locally against a dev server.
