### PR TITLE
Fix username in default reason string

### DIFF
--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -1335,3 +1335,37 @@ func (s *SharedServerSuite) TestActivity_List_Pagination() {
 	s.NoError(res.Err)
 	s.Equal(3, strings.Count(res.Stdout.String(), "page-test-"))
 }
+
+func (s *SharedServerSuite) TestActivity_Terminate_DefaultReason_NoUnknownUser() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	started := s.startActivity("terminate-default-reason-test")
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	res := s.Execute(
+		"activity", "terminate",
+		"--activity-id", "terminate-default-reason-test",
+		"--run-id", runID,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	res = s.Execute(
+		"activity", "result", "-o", "json",
+		"--activity-id", "terminate-default-reason-test",
+		"--run-id", runID,
+		"--address", s.Address(),
+	)
+	s.Error(res.Err)
+	var outcome map[string]any
+	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &outcome))
+	failureMsg, _ := outcome["failure"].(map[string]any)["message"].(string)
+	s.Contains(failureMsg, "Requested from CLI by")
+	s.NotContains(failureMsg, "<unknown-user>")
+}

--- a/internal/temporalcli/commands.workflow.go
+++ b/internal/temporalcli/commands.workflow.go
@@ -499,7 +499,7 @@ func workflowUpdateHelper(cctx *CommandContext,
 
 func username() string {
 	username := "<unknown-user>"
-	if u, err := user.Current(); err != nil && u.Username != "" {
+	if u, err := user.Current(); err == nil && u.Username != "" {
 		username = u.Username
 	}
 	return username


### PR DESCRIPTION
## What was changed
Use username in default reason when username is available. 

## Why?
It's what was intended; the code just had a typo.

## How was this tested:

1. Contains a test of termination
2. Manually tested termination of standalone activity

```
$ temporal activity terminate --activity-id standalone_activity_helloworld_ActivityID
Activity terminated

$ temporal activity result -a standalone_activity_helloworld_ActivityID
Results:
  Status   FAILED
  Failure
    Message: Requested from CLI by dan
Error: activity failed
```
