### PR TITLE
Support client authority in config profiles

### DIFF
--- a/internal/temporalcli/client.go
+++ b/internal/temporalcli/client.go
@@ -38,6 +38,10 @@ func dialClient(cctx *CommandContext, c *cliext.ClientOptions) (client.Client, e
 		c.Identity = "temporal-cli:" + username + "@" + hostname
 	}
 
+	if err := applyClientAuthorityFromConfig(cctx, c); err != nil {
+		return nil, err
+	}
+
 	// Build client options using cliext
 	builder := &cliext.ClientOptionsBuilder{
 		CommonOptions: cctx.RootCommand.CommonOptions,
@@ -86,6 +90,28 @@ func dialClient(cctx *CommandContext, c *cliext.ClientOptions) (client.Client, e
 	c.Namespace = clientOpts.Namespace
 
 	return cl, nil
+}
+
+func applyClientAuthorityFromConfig(cctx *CommandContext, c *cliext.ClientOptions) error {
+	if c.ClientAuthority != "" || (c.FlagSet != nil && c.FlagSet.Changed("client-authority")) {
+		return nil
+	}
+	if cctx.RootCommand.DisableConfigFile {
+		return nil
+	}
+	_, additionalProfileFields, err := loadEnvConfigFile(cctx)
+	if err != nil {
+		return err
+	}
+	if v, ok, err := clientAuthorityFromAdditionalProfileFields(
+		additionalProfileFields,
+		envConfigProfileName(cctx),
+	); err != nil {
+		return err
+	} else if ok {
+		c.ClientAuthority = v
+	}
+	return nil
 }
 
 func fixedHeaderOverrideInterceptor(

--- a/internal/temporalcli/client_authority_test.go
+++ b/internal/temporalcli/client_authority_test.go
@@ -1,0 +1,84 @@
+package temporalcli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/cli/cliext"
+)
+
+func TestApplyClientAuthorityFromConfig(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.foo]
+client_authority = "profile-authority"`))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cctx := &CommandContext{
+		RootCommand: &TemporalCommand{
+			CommonOptions: cliext.CommonOptions{
+				ConfigFile: f.Name(),
+				Profile:    "foo",
+			},
+		},
+	}
+	var opts cliext.ClientOptions
+
+	require.NoError(t, applyClientAuthorityFromConfig(cctx, &opts))
+	require.Equal(t, "profile-authority", opts.ClientAuthority)
+}
+
+func TestApplyClientAuthorityFromConfig_ExplicitFlagWins(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.foo]
+client_authority = "profile-authority"`))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cctx := &CommandContext{
+		RootCommand: &TemporalCommand{
+			CommonOptions: cliext.CommonOptions{
+				ConfigFile: f.Name(),
+				Profile:    "foo",
+			},
+		},
+	}
+	opts := cliext.ClientOptions{ClientAuthority: "flag-authority"}
+
+	require.NoError(t, applyClientAuthorityFromConfig(cctx, &opts))
+	require.Equal(t, "flag-authority", opts.ClientAuthority)
+}
+
+func TestApplyClientAuthorityFromConfig_ExplicitEmptyFlagWins(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.foo]
+client_authority = "profile-authority"`))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cctx := &CommandContext{
+		RootCommand: &TemporalCommand{
+			CommonOptions: cliext.CommonOptions{
+				ConfigFile: f.Name(),
+				Profile:    "foo",
+			},
+		},
+	}
+	var opts cliext.ClientOptions
+	opts.BuildFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	require.NoError(t, opts.FlagSet.Set("client-authority", ""))
+
+	require.NoError(t, applyClientAuthorityFromConfig(cctx, &opts))
+	require.Empty(t, opts.ClientAuthority)
+}

--- a/internal/temporalcli/commands.config.go
+++ b/internal/temporalcli/commands.config.go
@@ -16,18 +16,21 @@ import (
 func (c *TemporalConfigDeleteCommand) run(cctx *CommandContext, _ []string) error {
 	// Load config
 	profileName := envConfigProfileName(cctx)
-	conf, confProfile, err := loadEnvConfigProfile(cctx, profileName, true)
+	conf, confProfile, additionalProfileFields, err := loadEnvConfigProfile(cctx, profileName, true)
 	if err != nil {
 		return err
 	}
+	propName := normalizeEnvConfigProp(c.Prop)
 	if strings.HasPrefix(c.Prop, "grpc_meta.") {
 		key := strings.TrimPrefix(c.Prop, "grpc_meta.")
 		if _, ok := confProfile.GRPCMeta[key]; !ok {
 			return fmt.Errorf("gRPC meta key %q not found", key)
 		}
 		delete(confProfile.GRPCMeta, key)
+	} else if propName == envConfigPropClientAuthority {
+		deleteClientAuthority(additionalProfileFields, profileName)
 	} else {
-		reflectVal, err := reflectEnvConfigProp(confProfile, c.Prop, true)
+		reflectVal, err := reflectEnvConfigProp(confProfile, propName, true)
 		if err != nil {
 			return err
 		}
@@ -35,13 +38,13 @@ func (c *TemporalConfigDeleteCommand) run(cctx *CommandContext, _ []string) erro
 	}
 
 	// Save
-	return writeEnvConfigFile(cctx, conf)
+	return writeEnvConfigFile(cctx, conf, additionalProfileFields)
 }
 
 func (c *TemporalConfigDeleteProfileCommand) run(cctx *CommandContext, _ []string) error {
 	// Load config
 	profileName := envConfigProfileName(cctx)
-	conf, _, err := loadEnvConfigProfile(cctx, profileName, true)
+	conf, _, additionalProfileFields, err := loadEnvConfigProfile(cctx, profileName, true)
 	if err != nil {
 		return err
 	}
@@ -52,15 +55,16 @@ func (c *TemporalConfigDeleteProfileCommand) run(cctx *CommandContext, _ []strin
 		return fmt.Errorf("to delete an entire profile, --profile must be provided explicitly")
 	}
 	delete(conf.Profiles, profileName)
+	delete(additionalProfileFields, profileName)
 
 	// Save
-	return writeEnvConfigFile(cctx, conf)
+	return writeEnvConfigFile(cctx, conf, additionalProfileFields)
 }
 
 func (c *TemporalConfigGetCommand) run(cctx *CommandContext, _ []string) error {
 	// Load config profile
 	profileName := envConfigProfileName(cctx)
-	conf, confProfile, err := loadEnvConfigProfile(cctx, profileName, true)
+	conf, confProfile, additionalProfileFields, err := loadEnvConfigProfile(cctx, profileName, true)
 	if err != nil {
 		return err
 	}
@@ -70,22 +74,34 @@ func (c *TemporalConfigGetCommand) run(cctx *CommandContext, _ []string) error {
 	}
 	// If there is a specific key requested, show it, otherwise show all
 	if c.Prop != "" {
+		propName := normalizeEnvConfigProp(c.Prop)
 		// We do not support asking for structures with children at this time,
 		// but "tls" is a special case because it's also a bool.
-		if c.Prop == "codec" || c.Prop == "grpc_meta" {
+		if propName == "codec" || propName == "grpc_meta" {
 			return fmt.Errorf("must provide exact property, not parent property")
 		}
-		var reflectVal reflect.Value
 		// gRPC meta is special
 		if strings.HasPrefix(c.Prop, "grpc_meta.") {
 			v, ok := confProfile.GRPCMeta[strings.TrimPrefix(c.Prop, "grpc_meta.")]
 			if !ok {
 				return fmt.Errorf("unknown property %q", c.Prop)
 			}
-			reflectVal = reflect.ValueOf(v)
+			return cctx.Printer.PrintStructured(
+				prop{Property: c.Prop, Value: v},
+				printer.StructuredOptions{Table: &printer.TableOptions{}},
+			)
+		} else if propName == envConfigPropClientAuthority {
+			v, _, err := clientAuthorityFromAdditionalProfileFields(additionalProfileFields, profileName)
+			if err != nil {
+				return err
+			}
+			return cctx.Printer.PrintStructured(
+				prop{Property: envConfigPropClientAuthority, Value: v},
+				printer.StructuredOptions{Table: &printer.TableOptions{}},
+			)
 		} else {
 			// Single value goes into property-value structure
-			reflectVal, err = reflectEnvConfigProp(confProfile, c.Prop, false)
+			reflectVal, err := reflectEnvConfigProp(confProfile, propName, false)
 			if err != nil {
 				return err
 			}
@@ -93,18 +109,22 @@ func (c *TemporalConfigGetCommand) run(cctx *CommandContext, _ []string) error {
 			if reflectVal.Kind() == reflect.Pointer {
 				reflectVal = reflect.ValueOf(!reflectVal.IsNil())
 			}
+			return cctx.Printer.PrintStructured(
+				prop{Property: propName, Value: reflectVal.Interface()},
+				printer.StructuredOptions{Table: &printer.TableOptions{}},
+			)
 		}
-		return cctx.Printer.PrintStructured(
-			prop{Property: c.Prop, Value: reflectVal.Interface()},
-			printer.StructuredOptions{Table: &printer.TableOptions{}},
-		)
 	} else if cctx.JSONOutput {
 		// If it is JSON and not prop specific, we want to dump the TOML
 		// structure in JSON form
 		var tomlConf struct {
 			Profiles map[string]any `toml:"profile"`
 		}
-		if b, err := conf.ToTOML(envconfig.ClientConfigToTOMLOptions{}); err != nil {
+		additionalFields, err := knownAdditionalProfileFields(additionalProfileFields, profileName)
+		if err != nil {
+			return err
+		}
+		if b, err := conf.ToTOML(envconfig.ClientConfigToTOMLOptions{AdditionalProfileFields: additionalFields}); err != nil {
 			return fmt.Errorf("failed converting to TOML: %w", err)
 		} else if err := toml.Unmarshal(b, &tomlConf); err != nil {
 			return fmt.Errorf("failed converting from TOML: %w", err)
@@ -127,6 +147,11 @@ func (c *TemporalConfigGetCommand) run(cctx *CommandContext, _ []string) error {
 			} else if !val.IsZero() {
 				props = append(props, prop{Property: k, Value: val.Interface()})
 			}
+		}
+		if v, ok, err := clientAuthorityFromAdditionalProfileFields(additionalProfileFields, profileName); err != nil {
+			return err
+		} else if ok {
+			props = append(props, prop{Property: envConfigPropClientAuthority, Value: v})
 		}
 
 		// Add "grpc_meta"
@@ -161,19 +186,23 @@ func (c *TemporalConfigListCommand) run(cctx *CommandContext, _ []string) error 
 
 func (c *TemporalConfigSetCommand) run(cctx *CommandContext, _ []string) error {
 	// Load config
-	conf, confProfile, err := loadEnvConfigProfile(cctx, envConfigProfileName(cctx), false)
+	profileName := envConfigProfileName(cctx)
+	conf, confProfile, additionalProfileFields, err := loadEnvConfigProfile(cctx, profileName, false)
 	if err != nil {
 		return err
 	}
+	propName := normalizeEnvConfigProp(c.Prop)
 	// As a special case, "grpc_meta." values are handled specifically
 	if strings.HasPrefix(c.Prop, "grpc_meta.") {
 		if confProfile.GRPCMeta == nil {
 			confProfile.GRPCMeta = map[string]string{}
 		}
 		confProfile.GRPCMeta[strings.TrimPrefix(c.Prop, "grpc_meta.")] = c.Value
+	} else if propName == envConfigPropClientAuthority {
+		setClientAuthority(additionalProfileFields, profileName, c.Value)
 	} else {
 		// Get reflect value
-		reflectVal, err := reflectEnvConfigProp(confProfile, c.Prop, false)
+		reflectVal, err := reflectEnvConfigProp(confProfile, propName, false)
 		if err != nil {
 			return err
 		}
@@ -212,14 +241,16 @@ func (c *TemporalConfigSetCommand) run(cctx *CommandContext, _ []string) error {
 	}
 
 	// Save
-	return writeEnvConfigFile(cctx, conf)
+	return writeEnvConfigFile(cctx, conf, additionalProfileFields)
 }
 
 func envConfigProfileName(cctx *CommandContext) string {
 	if cctx.RootCommand.Profile != "" {
 		return cctx.RootCommand.Profile
-	} else if p, _ := cctx.Options.EnvLookup.LookupEnv("TEMPORAL_PROFILE"); p != "" {
-		return p
+	} else if cctx.Options.EnvLookup != nil {
+		if p, _ := cctx.Options.EnvLookup.LookupEnv("TEMPORAL_PROFILE"); p != "" {
+			return p
+		}
 	}
 	return envconfig.DefaultConfigFileProfile
 }
@@ -228,25 +259,22 @@ func loadEnvConfigProfile(
 	cctx *CommandContext,
 	profile string,
 	failIfNotFound bool,
-) (*envconfig.ClientConfig, *envconfig.ClientConfigProfile, error) {
-	clientConfig, err := envconfig.LoadClientConfig(envconfig.LoadClientConfigOptions{
-		ConfigFilePath: cctx.RootCommand.ConfigFile,
-		EnvLookup:      cctx.Options.EnvLookup,
-	})
+) (*envconfig.ClientConfig, *envconfig.ClientConfigProfile, map[string]map[string]any, error) {
+	clientConfig, additionalProfileFields, err := loadEnvConfigFile(cctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Load profile
 	clientProfile := clientConfig.Profiles[profile]
 	if clientProfile == nil {
 		if failIfNotFound {
-			return nil, nil, fmt.Errorf("profile %q not found", profile)
+			return nil, nil, nil, fmt.Errorf("profile %q not found", profile)
 		}
 		clientProfile = &envconfig.ClientConfigProfile{}
 		clientConfig.Profiles[profile] = clientProfile
 	}
-	return &clientConfig, clientProfile, nil
+	return clientConfig, clientProfile, additionalProfileFields, nil
 }
 
 var envConfigPropsToFieldNames = map[string]string{
@@ -265,6 +293,18 @@ var envConfigPropsToFieldNames = map[string]string{
 	"tls.disable_host_verification": "DisableHostVerification",
 	"codec.endpoint":                "Endpoint",
 	"codec.auth":                    "Auth",
+}
+
+const (
+	envConfigPropClientAuthority      = "client_authority"
+	envConfigPropClientAuthorityAlias = "client-authority"
+)
+
+func normalizeEnvConfigProp(prop string) string {
+	if prop == envConfigPropClientAuthorityAlias {
+		return envConfigPropClientAuthority
+	}
+	return prop
 }
 
 func reflectEnvConfigProp(
@@ -305,21 +345,65 @@ func reflectEnvConfigProp(
 	return parentVal.FieldByName(field), nil
 }
 
-func writeEnvConfigFile(cctx *CommandContext, conf *envconfig.ClientConfig) error {
-	// Get file
+func loadEnvConfigFile(cctx *CommandContext) (*envconfig.ClientConfig, map[string]map[string]any, error) {
+	configFile, err := envConfigFilePath(cctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var data []byte
+	if b, err := os.ReadFile(configFile); err == nil {
+		data = b
+	} else if !os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("failed reading file at %v: %w", configFile, err)
+	}
+
+	clientConfig := &envconfig.ClientConfig{}
+	additionalProfileFields := map[string]map[string]any{}
+	if err := clientConfig.FromTOML(data, envconfig.ClientConfigFromTOMLOptions{
+		AdditionalProfileFields: additionalProfileFields,
+	}); err != nil {
+		return nil, nil, fmt.Errorf("failed parsing config: %w", err)
+	}
+	if clientConfig.Profiles == nil {
+		clientConfig.Profiles = map[string]*envconfig.ClientConfigProfile{}
+	}
+	return clientConfig, additionalProfileFields, nil
+}
+
+func envConfigFilePath(cctx *CommandContext) (string, error) {
 	configFile := cctx.RootCommand.ConfigFile
 	if configFile == "" {
-		configFile, _ = cctx.Options.EnvLookup.LookupEnv("TEMPORAL_CONFIG_FILE")
+		env := cctx.Options.EnvLookup
+		if env == nil {
+			env = envconfig.EnvLookupOS
+		}
+		configFile, _ = env.LookupEnv("TEMPORAL_CONFIG_FILE")
 		if configFile == "" {
 			var err error
 			if configFile, err = envconfig.DefaultConfigFilePath(); err != nil {
-				return err
+				return "", err
 			}
 		}
 	}
+	return configFile, nil
+}
+
+func writeEnvConfigFile(
+	cctx *CommandContext,
+	conf *envconfig.ClientConfig,
+	additionalProfileFields map[string]map[string]any,
+) error {
+	configFile, err := envConfigFilePath(cctx)
+	if err != nil {
+		return err
+	}
+	if err := normalizeAdditionalProfileFields(additionalProfileFields); err != nil {
+		return err
+	}
 
 	// Convert to TOML
-	b, err := conf.ToTOML(envconfig.ClientConfigToTOMLOptions{})
+	b, err := conf.ToTOML(envconfig.ClientConfigToTOMLOptions{AdditionalProfileFields: additionalProfileFields})
 	if err != nil {
 		return fmt.Errorf("failed building TOML: %w", err)
 	}
@@ -331,4 +415,77 @@ func writeEnvConfigFile(cctx *CommandContext, conf *envconfig.ClientConfig) erro
 		return fmt.Errorf("failed writing config file: %w", err)
 	}
 	return nil
+}
+
+func clientAuthorityFromAdditionalProfileFields(
+	additionalProfileFields map[string]map[string]any,
+	profileName string,
+) (string, bool, error) {
+	profileFields := additionalProfileFields[profileName]
+	if profileFields == nil {
+		return "", false, nil
+	}
+	if raw, ok := profileFields[envConfigPropClientAuthority]; ok {
+		v, ok := raw.(string)
+		if !ok {
+			return "", false, fmt.Errorf("property %q must be a string", envConfigPropClientAuthority)
+		}
+		return v, true, nil
+	}
+	if raw, ok := profileFields[envConfigPropClientAuthorityAlias]; ok {
+		v, ok := raw.(string)
+		if !ok {
+			return "", false, fmt.Errorf("property %q must be a string", envConfigPropClientAuthority)
+		}
+		return v, true, nil
+	}
+	return "", false, nil
+}
+
+func setClientAuthority(additionalProfileFields map[string]map[string]any, profileName, value string) {
+	if additionalProfileFields[profileName] == nil {
+		additionalProfileFields[profileName] = map[string]any{}
+	}
+	additionalProfileFields[profileName][envConfigPropClientAuthority] = value
+	delete(additionalProfileFields[profileName], envConfigPropClientAuthorityAlias)
+}
+
+func deleteClientAuthority(additionalProfileFields map[string]map[string]any, profileName string) {
+	if additionalProfileFields[profileName] == nil {
+		return
+	}
+	delete(additionalProfileFields[profileName], envConfigPropClientAuthority)
+	delete(additionalProfileFields[profileName], envConfigPropClientAuthorityAlias)
+}
+
+func normalizeAdditionalProfileFields(additionalProfileFields map[string]map[string]any) error {
+	for profileName, profileFields := range additionalProfileFields {
+		value, ok, err := clientAuthorityFromAdditionalProfileFields(additionalProfileFields, profileName)
+		if err != nil {
+			return err
+		}
+		if ok {
+			profileFields[envConfigPropClientAuthority] = value
+		}
+		delete(profileFields, envConfigPropClientAuthorityAlias)
+	}
+	return nil
+}
+
+func knownAdditionalProfileFields(
+	additionalProfileFields map[string]map[string]any,
+	profileName string,
+) (map[string]map[string]any, error) {
+	value, ok, err := clientAuthorityFromAdditionalProfileFields(additionalProfileFields, profileName)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return map[string]map[string]any{
+		profileName: {
+			envConfigPropClientAuthority: value,
+		},
+	}, nil
 }

--- a/internal/temporalcli/commands.config_test.go
+++ b/internal/temporalcli/commands.config_test.go
@@ -25,6 +25,7 @@ func TestConfig_Get(t *testing.T) {
 address = "my-address"
 namespace = "my-namespace"
 api_key = "my-api-key"
+client_authority = "my-client-authority"
 codec = { endpoint = "my-endpoint", auth = "my-auth" }
 grpc_meta = { some-heAder1 = "some-value1", some-header2 = "some-value2", some_heaDer3 = "some-value3" }
 some_future_key = "some future value not handled"
@@ -74,6 +75,7 @@ disable_host_verification = true`))
 		"address":                       "my-address",
 		"namespace":                     "my-namespace",
 		"api_key":                       "my-api-key",
+		"client_authority":              "my-client-authority",
 		"codec.endpoint":                "my-endpoint",
 		"codec.auth":                    "my-auth",
 		"grpc_meta.some-header1":        "some-value1",
@@ -117,6 +119,7 @@ disable_host_verification = true`))
 	h.JSONEq(`{
 		"address": "my-address",
 		"api_key": "my-api-key",
+		"client_authority": "my-client-authority",
 		"codec": {
 			"auth": "my-auth",
 			"endpoint": "my-endpoint"
@@ -202,6 +205,90 @@ address = "my-address"
 	res = h.Execute("config", "get", "--prop", "tls")
 	h.NoError(res.Err)
 	h.ContainsOnSameLine(res.Stdout.String(), "tls", "false")
+}
+
+func TestConfig_ClientAuthority(t *testing.T) {
+	h := NewCommandHarness(t)
+	defer h.Close()
+
+	f, err := os.CreateTemp("", "")
+	h.NoError(err)
+	h.NoError(f.Close())
+	h.NoError(os.Remove(f.Name()))
+	defer os.Remove(f.Name())
+	h.Options.EnvLookup = EnvLookupMap{"TEMPORAL_CONFIG_FILE": f.Name()}
+
+	// Set accepts the flag-style alias, but writes the canonical config key.
+	res := h.Execute("config", "set", "--prop", "client-authority", "--value", "my-authority")
+	h.NoError(res.Err)
+	b, err := os.ReadFile(f.Name())
+	h.NoError(err)
+	h.Contains(string(b), `client_authority = "my-authority"`)
+	h.NotContains(string(b), "client-authority")
+
+	// Get accepts both spellings and displays the canonical property name.
+	res = h.Execute("config", "get", "--prop", "client_authority")
+	h.NoError(res.Err)
+	h.ContainsOnSameLine(res.Stdout.String(), "client_authority", "my-authority")
+	res = h.Execute("config", "get", "--prop", "client-authority")
+	h.NoError(res.Err)
+	h.ContainsOnSameLine(res.Stdout.String(), "client_authority", "my-authority")
+
+	// Unrelated writes preserve the additional profile field.
+	res = h.Execute("config", "set", "--prop", "address", "--value", "my-address")
+	h.NoError(res.Err)
+	b, err = os.ReadFile(f.Name())
+	h.NoError(err)
+	h.Contains(string(b), `client_authority = "my-authority"`)
+	h.Contains(string(b), `address = "my-address"`)
+
+	// Delete accepts the alias too.
+	res = h.Execute("config", "delete", "--prop", "client-authority")
+	h.NoError(res.Err)
+	b, err = os.ReadFile(f.Name())
+	h.NoError(err)
+	h.NotContains(string(b), "client_authority")
+}
+
+func TestConfig_ClientAuthority_NormalizesExistingAlias(t *testing.T) {
+	h := NewCommandHarness(t)
+	defer h.Close()
+
+	f, err := os.CreateTemp("", "")
+	h.NoError(err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.foo]
+client-authority = "alias-authority"
+client_authority = "canonical-authority"`))
+	h.NoError(err)
+	h.NoError(f.Close())
+	h.Options.EnvLookup = EnvLookupMap{"TEMPORAL_CONFIG_FILE": f.Name(), "TEMPORAL_PROFILE": "foo"}
+
+	res := h.Execute("config", "set", "--prop", "namespace", "--value", "my-namespace")
+	h.NoError(res.Err)
+	b, err := os.ReadFile(f.Name())
+	h.NoError(err)
+	h.Contains(string(b), `client_authority = "canonical-authority"`)
+	h.NotContains(string(b), "client-authority")
+}
+
+func TestConfig_ClientAuthority_RejectsNonString(t *testing.T) {
+	h := NewCommandHarness(t)
+	defer h.Close()
+
+	f, err := os.CreateTemp("", "")
+	h.NoError(err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.foo]
+client_authority = 123`))
+	h.NoError(err)
+	h.NoError(f.Close())
+	h.Options.EnvLookup = EnvLookupMap{"TEMPORAL_CONFIG_FILE": f.Name(), "TEMPORAL_PROFILE": "foo"}
+
+	res := h.Execute("config", "get", "--prop", "client_authority")
+	h.ErrorContains(res.Err, `property "client_authority" must be a string`)
 }
 
 func TestConfig_Delete(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a persisted `client_authority` profile property, with `client-authority` accepted as a flag-style alias.
- Round-trip envconfig additional profile fields so config rewrites preserve unknown TOML keys, including `client_authority`.
- Apply configured client authority to CLI client options unless `--client-authority` is explicitly set.

## Root Cause
`client-authority` existed as a runtime client flag, but `temporal config set` only accepted properties backed by the SDK envconfig profile reflection map. Since envconfig has no `ClientAuthority` field, the property was rejected and could not be persisted.

## Validation
- `go test -mod=readonly ./internal/temporalcli -run 'TestApplyClientAuthorityFromConfig|TestConfig' -count=1`
- `go test ./... -count=1` currently fails before running tests in this checkout because the ignored local `vendor/` directory is incomplete (`vendor/modules.txt` is missing), so Go reports inconsistent vendoring. Use `-mod=readonly` here or regenerate vendor from a clean vendor directory.