### PR TITLE
fix: JSON output for workflow update execute/result commands

### DIFF
--- a/internal/temporalcli/commands.workflow.go
+++ b/internal/temporalcli/commands.workflow.go
@@ -485,15 +485,49 @@ func workflowUpdateHelper(cctx *CommandContext,
 	var valuePtr interface{}
 	err = updateHandle.Get(cctx, &valuePtr)
 	if err != nil {
+		if cctx.JSONOutput {
+			return cctx.Printer.PrintStructured(
+				struct {
+					Name     string `json:"name"`
+					UpdateID string `json:"updateId"`
+					Error    string `json:"error"`
+				}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID(), Error: err.Error()},
+				printer.StructuredOptions{})
+		}
 		return fmt.Errorf("unable to update workflow: %w", err)
+	}
+
+	// Handle result serialization based on JSONShorthandPayloads
+	var resultJSON json.RawMessage
+	if cctx.JSONShorthandPayloads {
+		// Decode payloads to native Go value
+		if payloads, ok := valuePtr.(*common.Payloads); ok {
+			var decoded any
+			if err := converter.GetDefaultDataConverter().FromPayloads(payloads, &decoded); err != nil {
+				return fmt.Errorf("failed decoding result: %w", err)
+			}
+			resultJSON, err = json.Marshal(decoded)
+		} else {
+			resultJSON, err = json.Marshal(valuePtr)
+		}
+	} else {
+		// Marshal raw payloads as proto JSON
+		if payloads, ok := valuePtr.(*common.Payloads); ok {
+			resultJSON, err = cctx.MarshalProtoJSON(payloads)
+		} else {
+			resultJSON, err = json.Marshal(valuePtr)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed marshaling result: %w", err)
 	}
 
 	return cctx.Printer.PrintStructured(
 		struct {
-			Name     string      `json:"name"`
-			UpdateID string      `json:"updateId"`
-			Result   interface{} `json:"result"`
-		}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID(), Result: valuePtr},
+			Name     string          `json:"name"`
+			UpdateID string          `json:"updateId"`
+			Result   json.RawMessage `json:"result"`
+		}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID(), Result: resultJSON},
 		printer.StructuredOptions{})
 }
 


### PR DESCRIPTION
## Problem

When using `-o json` with `temporal workflow update execute` or `temporal workflow update result`:

1. **Update failure returns no JSON** — errors are returned as plain `fmt.Errorf`, breaking JSON output mode. Users expect structured JSON even on failure.

2. **`--no-json-shorthand-payloads` flag is silently ignored** — update results always decode payloads with the default converter, regardless of the flag. This differs from other commands like `activity complete` which properly respect this option.

## Root Cause

Located in `workflowUpdateHelper` (`internal/temporalcli/commands.workflow.go`):

- **Line ~488**: Update failure returns `fmt.Errorf("unable to update workflow: %w", err)`, which bypasses the JSON printer entirely.
- **Lines ~491-497**: Result is printed as `interface{}` without checking `cctx.JSONShorthandPayloads`, ignoring the `--no-json-shorthand-payloads` flag.

## Fix

1. **JSON error output**: When `cctx.JSONOutput` is true and the update fails, use `cctx.Printer.PrintStructured` to return a structured JSON response with `name`, `updateId`, and `error` fields. Falls back to the existing `fmt.Errorf` for non-JSON mode.

2. **Respect `--no-json-shorthand-payloads`**: Added conditional serialization based on `cctx.JSONShorthandPayloads`:
   - `true` (default): decode payloads via `converter.GetDefaultDataConverter().FromPayloads()` for clean JSON output
   - `false`: use `cctx.MarshalProtoJSON()` for raw protobuf JSON representation

This matches the pattern used in `printActivityResult` (`commands.activity.go` line 282).

## Testing

- Existing `TestWorkflow_Update_Execute` and `TestWorkflow_Update_Result` tests pass.
- Build compiles cleanly with `go build ./internal/temporalcli/...`.

Fixes #952