### PR TITLE
Use payload input options for activity complete results

### DIFF
--- a/internal/temporalcli/commands.activity.go
+++ b/internal/temporalcli/commands.activity.go
@@ -575,8 +575,7 @@ func (c *TemporalActivityCompleteCommand) run(cctx *CommandContext, args []strin
 	}
 	defer cl.Close()
 
-	metadata := map[string][][]byte{"encoding": {[]byte("json/plain")}}
-	resultPayloads, err := CreatePayloads([][]byte{[]byte(c.Result)}, metadata, false)
+	resultPayloads, err := c.PayloadInputOptions.buildRawInputPayloads()
 	if err != nil {
 		return err
 	}

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -33,7 +33,7 @@ func (s *SharedServerSuite) TestActivity_Complete() {
 		"activity", "complete",
 		"--activity-id", activityId,
 		"--workflow-id", wid,
-		"--result", "\"complete-activity-result\"",
+		"--input", "\"complete-activity-result\"",
 		"--identity", identity,
 		"--address", s.Address(),
 	)
@@ -88,7 +88,7 @@ func (s *SharedServerSuite) TestActivity_Complete_InvalidResult() {
 		"activity", "complete",
 		"--activity-id", activityId,
 		"--workflow-id", run.GetID(),
-		"--result", "{not json}",
+		"--input", "{not json}",
 		"--address", s.Address(),
 	)
 	s.ErrorContains(res.Err, "is not valid JSON")
@@ -1055,7 +1055,7 @@ func (s *SharedServerSuite) TestActivity_Complete_ByRunId() {
 		"activity", "complete",
 		"--activity-id", "sa-complete-test",
 		"--run-id", runID,
-		"--result", `"completed-externally"`,
+		"--input", `"completed-externally"`,
 		"--identity", identity,
 		"--address", s.Address(),
 	)

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -533,12 +533,12 @@ func NewTemporalActivityCancelCommand(cctx *CommandContext, parent *TemporalActi
 }
 
 type TemporalActivityCompleteCommand struct {
-	Parent     *TemporalActivityCommand
-	Command    cobra.Command
+	Parent  *TemporalActivityCommand
+	Command cobra.Command
+	PayloadInputOptions
 	ActivityId string
 	WorkflowId string
 	RunId      string
-	Result     string
 }
 
 func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalActivityCommand) *TemporalActivityCompleteCommand {
@@ -548,17 +548,16 @@ func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalAc
 	s.Command.Use = "complete [flags]"
 	s.Command.Short = "Mark an activity as completed successfully with a result"
 	if hasHighlighting {
-		s.Command.Long = "Complete an Activity, marking it as successfully finished. Specify the\nActivity ID and include a JSON result for the returned value:\n\n\x1b[1mtemporal activity complete \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId \\\n    --result '{\"YourResultKey\": \"YourResultVal\"}'\x1b[0m"
+		s.Command.Long = "Complete an Activity, marking it as successfully finished. Specify the\nActivity ID and include a JSON result for the returned value:\n\n\x1b[1mtemporal activity complete \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId \\\n    --input '{\"YourResultKey\": \"YourResultVal\"}'\x1b[0m"
 	} else {
-		s.Command.Long = "Complete an Activity, marking it as successfully finished. Specify the\nActivity ID and include a JSON result for the returned value:\n\n```\ntemporal activity complete \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId \\\n    --result '{\"YourResultKey\": \"YourResultVal\"}'\n```"
+		s.Command.Long = "Complete an Activity, marking it as successfully finished. Specify the\nActivity ID and include a JSON result for the returned value:\n\n```\ntemporal activity complete \\\n    --activity-id YourActivityId \\\n    --workflow-id YourWorkflowId \\\n    --input '{\"YourResultKey\": \"YourResultVal\"}'\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.ActivityId, "activity-id", "a", "", "Activity ID. This may be the ID of an Activity invoked by a Workflow, or of a Standalone Activity. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow ID. Required for workflow Activities. Omit for Standalone Activities.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run ID. For workflow Activities (when --workflow-id is provided), this is the Workflow Run ID. For Standalone Activities, this is the Activity Run ID.")
-	s.Command.Flags().StringVar(&s.Result, "result", "", "Result `JSON` to return. Required.")
-	_ = cobra.MarkFlagRequired(s.Command.Flags(), "result")
+	s.PayloadInputOptions.BuildFlags(s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -210,7 +210,7 @@ commands:
       temporal activity complete \
           --activity-id YourActivityId \
           --workflow-id YourWorkflowId \
-          --result '{"YourResultKey": "YourResultVal"}'
+          --input '{"YourResultKey": "YourResultVal"}'
       ```
     options:
       - name: activity-id
@@ -233,10 +233,8 @@ commands:
           Run ID. For workflow Activities (when --workflow-id is
           provided), this is the Workflow Run ID. For Standalone
           Activities, this is the Activity Run ID.
-      - name: result
-        type: string
-        description: Result `JSON` to return.
-        required: true
+    option-sets:
+      - payload-input
 
   - name: temporal activity count
     summary: Count Standalone Activities matching a query (Experimental)


### PR DESCRIPTION
## What changed

- Replaces the `activity complete --result` string flag with the shared `PayloadInputOptions` flags.
- Updates help text/generated command code to show `--input`.
- Updates activity completion tests to use the shared payload input path.

## Why

This makes `activity complete` consistent with other CLI commands that accept payload input, including support for `--input-file`, `--input-base64`, and `--input-meta`.

Closes #446.

## Testing

- `go test ./cmd/gen-commands`
- `go test ./internal/temporalcli -run 'TestSharedServerSuite/TestActivity_Complete|TestSharedServerSuite/TestActivity_Complete_InvalidResult'`\n- `go test ./internal/temporalcli -run 'TestSharedServerSuite/TestActivity_Complete_ByRunId'`\n- `go test ./cmd/temporal`