### PR TITLE
Fix workflow update JSON result output

### DIFF
--- a/internal/temporalcli/commands.workflow.go
+++ b/internal/temporalcli/commands.workflow.go
@@ -343,7 +343,12 @@ func (c *TemporalWorkflowUpdateResultCommand) run(cctx *CommandContext, args []s
 		UpdateID:   c.UpdateId,
 	})
 	var valuePtr any
-	err = updateHandle.Get(cctx, &valuePtr)
+	var rawValue converter.RawValue
+	if cctx.JSONOutput {
+		err = updateHandle.Get(cctx, &rawValue)
+	} else {
+		err = updateHandle.Get(cctx, &valuePtr)
+	}
 	printMe := struct {
 		UpdateID string `json:"updateId"`
 		Result   any    `json:"result,omitempty"`
@@ -371,8 +376,35 @@ func (c *TemporalWorkflowUpdateResultCommand) run(cctx *CommandContext, args []s
 		return fmt.Errorf("unable to fetch update result: %w", err)
 	}
 
-	printMe.Result = valuePtr
+	if cctx.JSONOutput {
+		resultJSON, err := workflowUpdatePayloadJSON(cctx, rawValue.Payload())
+		if err != nil {
+			return err
+		}
+		printMe.Result = resultJSON
+	} else {
+		printMe.Result = valuePtr
+	}
 	return cctx.Printer.PrintStructured(printMe, printer.StructuredOptions{})
+}
+
+func workflowUpdatePayloadJSON(cctx *CommandContext, payload *common.Payload) (json.RawMessage, error) {
+	if cctx.JSONShorthandPayloads {
+		var valuePtr any
+		if err := converter.GetDefaultDataConverter().FromPayloads(&common.Payloads{Payloads: []*common.Payload{payload}}, &valuePtr); err != nil {
+			return nil, fmt.Errorf("failed decoding result: %w", err)
+		}
+		resultJSON, err := json.Marshal(valuePtr)
+		if err != nil {
+			return nil, fmt.Errorf("failed marshaling result: %w", err)
+		}
+		return resultJSON, nil
+	}
+	resultJSON, err := cctx.MarshalProtoJSON(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed marshaling result: %w", err)
+	}
+	return resultJSON, nil
 }
 
 func (c *TemporalWorkflowUpdateDescribeCommand) run(cctx *CommandContext, args []string) error {
@@ -482,19 +514,53 @@ func workflowUpdateHelper(cctx *CommandContext,
 			printer.StructuredOptions{})
 	}
 
-	var valuePtr interface{}
-	err = updateHandle.Get(cctx, &valuePtr)
+	var valuePtr any
+	var rawValue converter.RawValue
+	if cctx.JSONOutput {
+		err = updateHandle.Get(cctx, &rawValue)
+	} else {
+		err = updateHandle.Get(cctx, &valuePtr)
+	}
 	if err != nil {
+		appErr := &temporal.ApplicationError{}
+		if errors.As(err, &appErr) {
+			printMe := struct {
+				Name     string `json:"name"`
+				UpdateID string `json:"updateId"`
+				Failure  any    `json:"failure"`
+			}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID()}
+			if cctx.JSONOutput {
+				fromAppErr, err := fromApplicationError(appErr)
+				if err != nil {
+					return fmt.Errorf("unable to update workflow: %w", err)
+				}
+				printMe.Failure = fromAppErr
+			} else {
+				printMe.Failure = appErr.Error()
+			}
+			if err := cctx.Printer.PrintStructured(printMe, printer.StructuredOptions{}); err != nil {
+				return err
+			}
+			return errors.New("update is failed")
+		}
 		return fmt.Errorf("unable to update workflow: %w", err)
 	}
 
-	return cctx.Printer.PrintStructured(
-		struct {
-			Name     string      `json:"name"`
-			UpdateID string      `json:"updateId"`
-			Result   interface{} `json:"result"`
-		}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID(), Result: valuePtr},
-		printer.StructuredOptions{})
+	printMe := struct {
+		Name     string `json:"name"`
+		UpdateID string `json:"updateId"`
+		Result   any    `json:"result"`
+	}{Name: updateStartOpts.Name, UpdateID: updateHandle.UpdateID()}
+	if cctx.JSONOutput {
+		resultJSON, err := workflowUpdatePayloadJSON(cctx, rawValue.Payload())
+		if err != nil {
+			return err
+		}
+		printMe.Result = resultJSON
+	} else {
+		printMe.Result = valuePtr
+	}
+	return cctx.Printer.PrintStructured(printMe, printer.StructuredOptions{})
 }
 
 func username() string {

--- a/internal/temporalcli/commands.workflow_test.go
+++ b/internal/temporalcli/commands.workflow_test.go
@@ -1012,10 +1012,23 @@ func (s *SharedServerSuite) TestWorkflow_Update_Result() {
 	s.NoError(res.Err)
 	s.ContainsOnSameLine(res.Stdout.String(), "Result", "hi pass")
 	// JSON
+	passingJSONUpdateId := "passing-json"
+	res = s.Execute("--no-json-shorthand-payloads", "workflow", "update", "execute", "--address", s.Address(), "-w", run.GetID(),
+		"--name", updateName, "-i", `"json"`, "--update-id", passingJSONUpdateId, "-o", "json")
+	s.NoError(res.Err)
+	s.Contains(res.Stdout.String(), `"result": {`)
+	s.Contains(res.Stdout.String(), `"metadata": {`)
+	s.Contains(res.Stdout.String(), `"data":`)
 	res = s.Execute("workflow", "update", "result", "--address", s.Address(), "-w", run.GetID(),
 		"--update-id", passingUpdateId, "-o", "json")
 	s.NoError(res.Err)
 	s.Contains(res.Stdout.String(), `"result": "hi pass"`)
+	res = s.Execute("--no-json-shorthand-payloads", "workflow", "update", "result", "--address", s.Address(), "-w", run.GetID(),
+		"--update-id", passingUpdateId, "-o", "json")
+	s.NoError(res.Err)
+	s.Contains(res.Stdout.String(), `"result": {`)
+	s.Contains(res.Stdout.String(), `"metadata": {`)
+	s.Contains(res.Stdout.String(), `"data":`)
 
 	rejectedUpdateId := "rejected"
 	res = s.Execute("workflow", "update", "execute", "--address", s.Address(), "-w", run.GetID(),
@@ -1029,8 +1042,10 @@ func (s *SharedServerSuite) TestWorkflow_Update_Result() {
 
 	failUpdateId := "fail"
 	res = s.Execute("workflow", "update", "execute", "--address", s.Address(), "-w", run.GetID(),
-		"--name", updateName, "-i", `"fail"`, "--update-id", failUpdateId)
+		"--name", updateName, "-i", `"fail"`, "--update-id", failUpdateId, "-o", "json")
 	s.Error(res.Err)
+	s.ErrorContains(res.Err, "update is failed")
+	s.Contains(res.Stdout.String(), `"message": "failing"`)
 	res = s.Execute("workflow", "update", "result", "--address", s.Address(), "-w", run.GetID(),
 		"--update-id", failUpdateId)
 	s.Error(res.Err)


### PR DESCRIPTION
## What changed

Fixes workflow update JSON output so update results preserve raw payload details when `--no-json-shorthand-payloads` is used. Also emits structured JSON failure details for `workflow update execute -o json` when an update fails with an application error.

Closes #952.

## Testing

- `go test ./internal/temporalcli -run 'TestSharedServerSuite/TestWorkflow_Update_Result'`\n- `go test ./cmd/temporal`