### PR TITLE
Refresh Nexus endpoints on read in dev-server

### DIFF
--- a/internal/temporalcli/commands.server.go
+++ b/internal/temporalcli/commands.server.go
@@ -14,9 +14,15 @@ import (
 var defaultDynamicConfigValues = map[string]any{
 	// Make search attributes immediately visible on creation, so users don't
 	// have to wait for eventual consistency to happen when testing against the
-	// dev-server.  Since it's a very rare thing to create search attributes,
+	// dev-server. Since it's a very rare thing to create search attributes,
 	// we're comfortable that this is very unlikely to mask bugs in user code.
 	"system.forceSearchAttributesCacheRefreshOnRead": true,
+
+	// Make Nexus endpoints immediately visible on creation, so users don't
+	// have to wait for eventual consistency to happen when testing against the
+	// dev-server. Since it's a very rare thing to create Nexus endpoints,
+	// we're comfortable that this is very unlikely to mask bugs in user code.
+	"system.forceNexusEndpointRefreshOnRead": true,
 
 	// Since we disable the SA cache, we need to bump max QPS accordingly.
 	// These numbers were chosen to maintain the ratio between the two that's


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Mirrors the existing `forceSearchAttributesCacheRefreshOnRead` default: makes Nexus endpoint writes immediately visible to readers instead of after the next background long-poll refresh. 

It was added here https://github.com/temporalio/temporal/pull/10208

## Why

Better development experience.