### PR TITLE
feat: add schedule list-matching-times command

### DIFF
--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -2103,6 +2103,7 @@ func NewTemporalScheduleCommand(cctx *CommandContext, parent *TemporalCommand) *
 	s.Command.AddCommand(&NewTemporalScheduleDeleteCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleDescribeCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleListCommand(cctx, &s).Command)
+	s.Command.AddCommand(&NewTemporalScheduleListMatchingTimesCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleToggleCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleTriggerCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleUpdateCommand(cctx, &s).Command)
@@ -2262,6 +2263,39 @@ func NewTemporalScheduleListCommand(cctx *CommandContext, parent *TemporalSchedu
 	s.Command.Flags().BoolVarP(&s.Long, "long", "l", false, "Show detailed information.")
 	s.Command.Flags().BoolVar(&s.ReallyLong, "really-long", false, "Show extensive information in non-table form.")
 	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Filter results using given List Filter.")
+	s.Command.Run = func(c *cobra.Command, args []string) {
+		if err := s.run(cctx, args); err != nil {
+			cctx.Options.Fail(err)
+		}
+	}
+	return &s
+}
+
+type TemporalScheduleListMatchingTimesCommand struct {
+	Parent  *TemporalScheduleCommand
+	Command cobra.Command
+	ScheduleIdOptions
+	EndTime   cliext.FlagTimestamp
+	StartTime cliext.FlagTimestamp
+}
+
+func NewTemporalScheduleListMatchingTimesCommand(cctx *CommandContext, parent *TemporalScheduleCommand) *TemporalScheduleListMatchingTimesCommand {
+	var s TemporalScheduleListMatchingTimesCommand
+	s.Parent = parent
+	s.Command.DisableFlagsInUseLine = true
+	s.Command.Use = "list-matching-times [flags]"
+	s.Command.Short = "Display future Schedule action times"
+	if hasHighlighting {
+		s.Command.Long = "Lists the times a Schedule would run in a specified interval:\n\n\x1b[1mtemporal schedule list-matching-times \\\n    --schedule-id YourScheduleId \\\n    --start-time \"2026-01-01T00:00:00Z\" \\\n    --end-time \"2026-01-02T00:00:00Z\"\x1b[0m"
+	} else {
+		s.Command.Long = "Lists the times a Schedule would run in a specified interval:\n\n```\ntemporal schedule list-matching-times \\\n    --schedule-id YourScheduleId \\\n    --start-time \"2026-01-01T00:00:00Z\" \\\n    --end-time \"2026-01-02T00:00:00Z\"\n```"
+	}
+	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().Var(&s.EndTime, "end-time", "End of the time interval. Required.")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "end-time")
+	s.Command.Flags().Var(&s.StartTime, "start-time", "Start of the time interval. Required.")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "start-time")
+	s.ScheduleIdOptions.BuildFlags(s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/internal/temporalcli/commands.schedule.go
+++ b/internal/temporalcli/commands.schedule.go
@@ -17,6 +17,7 @@ import (
 	schedpb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type printableSchedule struct {
@@ -463,6 +464,38 @@ func (c *TemporalScheduleListCommand) run(cctx *CommandContext, args []string) e
 	}
 	cctx.Printer.PrintStructured(page, printOpts)
 
+	return nil
+}
+
+func (c *TemporalScheduleListMatchingTimesCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := dialClient(cctx, &c.Parent.ClientOptions)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	res, err := cl.WorkflowService().ListScheduleMatchingTimes(cctx, &workflowservice.ListScheduleMatchingTimesRequest{
+		Namespace:  c.Parent.Namespace,
+		ScheduleId: c.ScheduleId,
+		StartTime:  timestamppb.New(c.StartTime.Time()),
+		EndTime:    timestamppb.New(c.EndTime.Time()),
+	})
+	if err != nil {
+		return err
+	}
+
+	times := make([]time.Time, len(res.StartTime))
+	for i, t := range res.StartTime {
+		times[i] = t.AsTime()
+	}
+
+	if cctx.JSONOutput {
+		return cctx.Printer.PrintStructured(times, printer.StructuredOptions{})
+	}
+
+	for _, t := range times {
+		cctx.Printer.Println(t.Format(time.RFC3339Nano))
+	}
 	return nil
 }
 

--- a/internal/temporalcli/commands.schedule_test.go
+++ b/internal/temporalcli/commands.schedule_test.go
@@ -364,6 +364,34 @@ func (s *SharedServerSuite) TestSchedule_List() {
 	s.Error(res.Err)
 }
 
+func (s *SharedServerSuite) TestSchedule_ListMatchingTimes() {
+	schedId, _, res := s.createSchedule("--calendar", `{"hour":"12","minute":"0"}`)
+	s.NoError(res.Err)
+
+	args := []string{
+		"schedule", "list-matching-times",
+		"--address", s.Address(),
+		"--schedule-id", schedId,
+		"--start-time", "2026-01-01T00:00:00Z",
+		"--end-time", "2026-01-03T00:00:00Z",
+	}
+
+	res = s.Execute(args...)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.Contains(out, "2026-01-01T12:00:00Z")
+	s.Contains(out, "2026-01-02T12:00:00Z")
+
+	res = s.Execute(append(args, "--output", "json")...)
+	s.NoError(res.Err)
+	var jsonOut []string
+	s.NoError(json.Unmarshal(res.Stdout.Bytes(), &jsonOut))
+	s.Equal([]string{
+		"2026-01-01T12:00:00Z",
+		"2026-01-02T12:00:00Z",
+	}, jsonOut)
+}
+
 func (s *SharedServerSuite) TestSchedule_Toggle() {
 	schedId, _, res := s.createSchedule("--interval", "10d")
 	s.NoError(res.Err)

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -2259,6 +2259,7 @@ commands:
         - schedule delete
         - schedule describe
         - schedule list
+        - schedule list-matching-times
         - schedule toggle
         - schedule trigger
         - schedule update
@@ -2404,6 +2405,29 @@ commands:
         short: q
         type: string
         description: Filter results using given List Filter.
+
+  - name: temporal schedule list-matching-times
+    summary: Display future Schedule action times
+    description: |
+      Lists the times a Schedule would run in a specified interval:
+
+      ```
+      temporal schedule list-matching-times \
+          --schedule-id YourScheduleId \
+          --start-time "2026-01-01T00:00:00Z" \
+          --end-time "2026-01-02T00:00:00Z"
+      ```
+    options:
+      - name: end-time
+        type: timestamp
+        description: End of the time interval.
+        required: true
+      - name: start-time
+        type: timestamp
+        description: Start of the time interval.
+        required: true
+    option-sets:
+      - schedule-id
 
   - name: temporal schedule toggle
     summary: Pause or unpause a Schedule


### PR DESCRIPTION
## Summary
- add `temporal schedule list-matching-times`
- call `ListScheduleMatchingTimes` with schedule ID, start time, and end time
- print one timestamp per line in text mode and a JSON array in JSON mode

Fixes #1030

## Validation
- go test ./internal/temporalcli -run 'TestSharedServerSuite/TestSchedule_ListMatchingTimes'\n- go test ./internal/temporalcli\n- git diff --check