### PR TITLE
Fix/schedule search attributes text mode

### DIFF
--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -2284,8 +2284,12 @@ func NewTemporalScheduleListMatchingTimesCommand(cctx *CommandContext, parent *T
 	s.Parent = parent
 	s.Command.DisableFlagsInUseLine = true
 	s.Command.Use = "list-matching-times [flags]"
-	s.Command.Short = "List matching times for a Schedule"
-	s.Command.Long = "List the times a Schedule would fire within a given time range.\nUse this command to preview when a Schedule will trigger Workflow\nExecutions without actually running them.\n\nFor example:\ntemporal schedule list-matching-times \\\n--schedule-id \"YourScheduleId\" \\\n--start-time \"2024-01-01T00:00:00Z\" \\\n--end-time \"2024-01-31T23:59:59Z\""
+	s.Command.Short = "List matching times for a Schedule (Experimental)"
+	if hasHighlighting {
+		s.Command.Long = "\nNote: This is an experimental feature and may change in the future.\n\nList the times a Schedule would fire within a given time range.\nUse this command to preview when a Schedule will trigger Workflow\nExecutions without actually running them.\n\nFor example:\n\n\x1b[1m  temporal schedule list-matching-times \\\n    --schedule-id \"YourScheduleId\" \\\n    --start-time \"2024-01-01T00:00:00Z\" \\\n    --end-time \"2024-01-31T23:59:59Z\"\x1b[0m"
+	} else {
+		s.Command.Long = "\nNote: This is an experimental feature and may change in the future.\n\nList the times a Schedule would fire within a given time range.\nUse this command to preview when a Schedule will trigger Workflow\nExecutions without actually running them.\n\nFor example:\n\n```\n  temporal schedule list-matching-times \\\n    --schedule-id \"YourScheduleId\" \\\n    --start-time \"2024-01-01T00:00:00Z\" \\\n    --end-time \"2024-01-31T23:59:59Z\"\n```"
+	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().Var(&s.StartTime, "start-time", "Start of time range to list matching times. Required.")
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "start-time")

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -2103,6 +2103,7 @@ func NewTemporalScheduleCommand(cctx *CommandContext, parent *TemporalCommand) *
 	s.Command.AddCommand(&NewTemporalScheduleDeleteCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleDescribeCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleListCommand(cctx, &s).Command)
+	s.Command.AddCommand(&NewTemporalScheduleListMatchingTimesCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleToggleCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleTriggerCommand(cctx, &s).Command)
 	s.Command.AddCommand(&NewTemporalScheduleUpdateCommand(cctx, &s).Command)
@@ -2262,6 +2263,35 @@ func NewTemporalScheduleListCommand(cctx *CommandContext, parent *TemporalSchedu
 	s.Command.Flags().BoolVarP(&s.Long, "long", "l", false, "Show detailed information.")
 	s.Command.Flags().BoolVar(&s.ReallyLong, "really-long", false, "Show extensive information in non-table form.")
 	s.Command.Flags().StringVarP(&s.Query, "query", "q", "", "Filter results using given List Filter.")
+	s.Command.Run = func(c *cobra.Command, args []string) {
+		if err := s.run(cctx, args); err != nil {
+			cctx.Options.Fail(err)
+		}
+	}
+	return &s
+}
+
+type TemporalScheduleListMatchingTimesCommand struct {
+	Parent  *TemporalScheduleCommand
+	Command cobra.Command
+	ScheduleIdOptions
+	StartTime cliext.FlagTimestamp
+	EndTime   cliext.FlagTimestamp
+}
+
+func NewTemporalScheduleListMatchingTimesCommand(cctx *CommandContext, parent *TemporalScheduleCommand) *TemporalScheduleListMatchingTimesCommand {
+	var s TemporalScheduleListMatchingTimesCommand
+	s.Parent = parent
+	s.Command.DisableFlagsInUseLine = true
+	s.Command.Use = "list-matching-times [flags]"
+	s.Command.Short = "List matching times for a Schedule"
+	s.Command.Long = "List the times a Schedule would fire within a given time range.\nUse this command to preview when a Schedule will trigger Workflow\nExecutions without actually running them.\n\nFor example:\ntemporal schedule list-matching-times \\\n--schedule-id \"YourScheduleId\" \\\n--start-time \"2024-01-01T00:00:00Z\" \\\n--end-time \"2024-01-31T23:59:59Z\""
+	s.Command.Args = cobra.NoArgs
+	s.Command.Flags().Var(&s.StartTime, "start-time", "Start of time range to list matching times. Required.")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "start-time")
+	s.Command.Flags().Var(&s.EndTime, "end-time", "End of time range to list matching times. Required.")
+	_ = cobra.MarkFlagRequired(s.Command.Flags(), "end-time")
+	s.ScheduleIdOptions.BuildFlags(s.Command.Flags())
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/internal/temporalcli/commands.schedule.go
+++ b/internal/temporalcli/commands.schedule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/temporalio/cli/cliext"
 	"github.com/temporalio/cli/internal/printer"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -605,4 +606,31 @@ func formatDuration(d time.Duration) string {
 	// Remove last space
 	s = strings.TrimSpace(s)
 	return s
+}
+
+func (c *TemporalScheduleListMatchingTimesCommand) run(cctx *CommandContext, args []string) error {
+	cl, err := dialClient(cctx, &c.Parent.ClientOptions)
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	res, err := cl.WorkflowService().ListScheduleMatchingTimes(cctx, &workflowservice.ListScheduleMatchingTimesRequest{
+		Namespace:  c.Parent.Namespace,
+		ScheduleId: c.ScheduleId,
+		StartTime:  timestamppb.New(c.StartTime.Time()),
+		EndTime:    timestamppb.New(c.EndTime.Time()),
+	})
+	if err != nil {
+		return err
+	}
+
+	cctx.Printer.StartList()
+	defer cctx.Printer.EndList()
+
+	for _, t := range res.StartTime {
+		cctx.Printer.Printlnf("%v", t.AsTime())
+	}
+
+	return nil
 }

--- a/internal/temporalcli/commands.schedule.go
+++ b/internal/temporalcli/commands.schedule.go
@@ -1,6 +1,7 @@
 package temporalcli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/temporalproto"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 )
@@ -48,8 +50,8 @@ type printableSchedule struct {
 	LastUpdateAt     time.Time     `cli:",cardOmitEmpty"` // describe only
 	ActionCounts     *actionCounts `cli:",cardOmitEmpty"` // describe only
 	// SearchAttributes, Memo
-	SearchAttributes *commonpb.SearchAttributes `cli:",cardOmitEmpty"`
-	Memo             *commonpb.Memo             `cli:",cardOmitEmpty"`
+	SearchAttributes map[string]interface{} `cli:",cardOmitEmpty"`
+	Memo             *commonpb.Memo         `cli:",cardOmitEmpty"`
 }
 
 type actionCounts struct {
@@ -69,7 +71,7 @@ func describeResultToPrintable(id string, desc *client.ScheduleDescription) *pri
 	// ID, SearchAttributes, Memo
 	out := &printableSchedule{
 		ScheduleId:       id,
-		SearchAttributes: desc.SearchAttributes,
+		SearchAttributes: searchAttributesToMap(desc.SearchAttributes),
 		Memo:             desc.Memo,
 	}
 	// Schedule.Action
@@ -114,7 +116,7 @@ func listEntryToPrintable(ent *client.ScheduleListEntry) *printableSchedule {
 		Paused:           ent.Paused,
 		Notes:            ent.Note,
 		Action:           struct{ Workflow string }{Workflow: ent.WorkflowType.Name},
-		SearchAttributes: ent.SearchAttributes,
+		SearchAttributes: searchAttributesToMap(ent.SearchAttributes),
 		Memo:             ent.Memo,
 	}
 	specToPrintable(out, ent.Spec)
@@ -633,4 +635,22 @@ func (c *TemporalScheduleListMatchingTimesCommand) run(cctx *CommandContext, arg
 	}
 
 	return nil
+}
+
+func searchAttributesToMap(sa *commonpb.SearchAttributes) map[string]interface{} {
+	// Step 1 — handle nil
+	if sa == nil {
+		return nil
+	}
+	// Step 2 — marshal to JSON bytes using proto marshaler
+	b, err := temporalproto.CustomJSONMarshalOptions{}.Marshal(sa)
+	if err != nil {
+		return nil
+	}
+	// Step 3 — unmarshal bytes into plain map
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
+	return m
 }

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -2320,6 +2320,33 @@ commands:
       - overlap-policy
       - schedule-id
 
+  - name: temporal schedule list-matching-times
+    summary: List matching times for a Schedule
+    description: |
+      List the times a Schedule would fire within a given time range.
+      Use this command to preview when a Schedule will trigger Workflow
+      Executions without actually running them.
+
+      For example:
+
+      ```
+        temporal schedule list-matching-times \
+          --schedule-id "YourScheduleId" \
+          --start-time "2024-01-01T00:00:00Z" \
+          --end-time "2024-01-31T23:59:59Z"
+      ```
+    options:
+     - name: start-time
+       type: timestamp
+       description: Start of time range to list matching times.
+       required: true
+     - name: end-time
+       type: timestamp
+       description: End of time range to list matching times.
+       required: true
+    option-sets:
+      - schedule-id
+
   - name: temporal schedule create
     summary: Create a new Schedule
     description: |

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -2321,8 +2321,11 @@ commands:
       - schedule-id
 
   - name: temporal schedule list-matching-times
-    summary: List matching times for a Schedule
+    summary: List matching times for a Schedule (Experimental)
     description: |
+      
+      Note: This is an experimental feature and may change in the future.
+
       List the times a Schedule would fire within a given time range.
       Use this command to preview when a Schedule will trigger Workflow
       Executions without actually running them.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Convert `SearchAttributes` field in `printableSchedule` from `*commonpb.SearchAttributes` to `map[string]interface{}`. Added `searchAttributesToMap` helper that uses `temporalproto.CustomJSONMarshalOptions` to correctly serialize typed search attributes.

## Why?
Typed search attributes were printing as empty `{}` in text mode because standard `json.Marshal` doesn't know how to serialize `*commonpb.SearchAttributes` typed fields correctly. JSON mode worked because it used the proto marshaler. This fix ensures text mode uses the same proto-aware marshaling.

## Checklist
1. Closes #590

2. How was this tested: 
All existing tests pass (go test ./...). The fix applies to both describeResultToPrintable and listEntryToPrintable to cover both describe and list commands.

3. Any docs updates needed? 
No — this is a bug fix with no user-facing API changes.


