### PR TITLE
Add new flags for encoding and file input in activity complete and fail

### DIFF
--- a/internal/temporalcli/commands.activity.go
+++ b/internal/temporalcli/commands.activity.go
@@ -568,6 +568,39 @@ func (c *TemporalActivityTerminateCommand) run(cctx *CommandContext, args []stri
 	return nil
 }
 
+// buildInputPayloadOptions builds and returns InputPayloadOptions using at most one
+// supplied values for input, inputFile, etc. It is used when input like semantics are
+// implemented at other places such as for result or detail in activity complete or
+// fail command handler, respectively. If both of input are inputFile are supplied,
+// otherwise it return nil with error. If none of these are supplied, it returns nil without error.
+func buildInputPayloadOptions(
+	input string,
+	inputFile string,
+	inputMeta string,
+	inputBase64 bool,
+) (*PayloadInputOptions, error) {
+	if input == "" && inputFile == "" {
+		// no error if none are supplied.
+		return nil, nil
+	}
+	if input != "" && inputFile != "" {
+		return nil, fmt.Errorf("provide exactly one of input or inputFile")
+	}
+
+	resultPayloadOpts := PayloadInputOptions{
+		InputBase64: inputBase64,
+	}
+	if inputMeta != "" {
+		resultPayloadOpts.InputMeta = []string{inputMeta}
+	}
+	if input != "" && inputFile == "" {
+		resultPayloadOpts.Input = []string{input}
+	} else if input == "" && inputFile != "" {
+		resultPayloadOpts.InputFile = []string{inputFile}
+	}
+	return &resultPayloadOpts, nil
+}
+
 func (c *TemporalActivityCompleteCommand) run(cctx *CommandContext, args []string) error {
 	cl, err := dialClient(cctx, &c.Parent.ClientOptions)
 	if err != nil {
@@ -575,8 +608,13 @@ func (c *TemporalActivityCompleteCommand) run(cctx *CommandContext, args []strin
 	}
 	defer cl.Close()
 
-	metadata := map[string][][]byte{"encoding": {[]byte("json/plain")}}
-	resultPayloads, err := CreatePayloads([][]byte{[]byte(c.Result)}, metadata, false)
+	resultPayloadOpts, err := buildInputPayloadOptions(c.Result, c.ResultFile, c.ResultMeta, c.ResultBase64)
+	if resultPayloadOpts == nil || err != nil {
+		// TODO: where do we check that one of result or result-file is used. also for details in activity fail command.
+		return fmt.Errorf("provide exactly one of result or result-file")
+	}
+
+	resultPayloads, err := resultPayloadOpts.buildRawInputPayloads()
 	if err != nil {
 		return err
 	}
@@ -602,10 +640,15 @@ func (c *TemporalActivityFailCommand) run(cctx *CommandContext, args []string) e
 	}
 	defer cl.Close()
 
+	detailPayloadOpts, err := buildInputPayloadOptions(c.Detail, c.DetailFile, c.DetailMeta, c.DetailBase64)
+	if err != nil {
+		// TODO: if both detail and detail-file were used, then return error.
+		return fmt.Errorf("provide one of detail or detail-file, but not both")
+	}
+
 	var detailPayloads *common.Payloads
-	if len(c.Detail) > 0 {
-		metadata := map[string][][]byte{"encoding": {[]byte("json/plain")}}
-		detailPayloads, err = CreatePayloads([][]byte{[]byte(c.Detail)}, metadata, false)
+	if detailPayloadOpts != nil {
+		detailPayloads, err = detailPayloadOpts.buildRawInputPayloads()
 		if err != nil {
 			return err
 		}

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -136,6 +136,7 @@ func (s *SharedServerSuite) TestActivity_Complete_ResultMeta() {
 	runID := started["runId"].(string)
 	<-activityStarted
 
+	// although including nul (\x00) will work here, it won't in actual command line.
 	result := "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a"
 
 	res := s.Execute(
@@ -156,6 +157,16 @@ func (s *SharedServerSuite) TestActivity_Complete_ResultMeta() {
 	s.NoError(handle.Get(s.Context, &actual))
 	s.Equal(result, string(actual))
 
+	res = s.Execute(
+		"activity", "result",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	output := res.Stdout.String()
+	s.Contains(output, base64.StdEncoding.EncodeToString([]byte(result)))
 }
 
 func (s *SharedServerSuite) TestActivity_Complete_ResultMeta_Protobuf() {
@@ -218,6 +229,7 @@ func (s *SharedServerSuite) TestActivity_Complete_ResultFile() {
 	runID := started["runId"].(string)
 	<-activityStarted
 
+	// this can include nul, as it gets stored in a file.
 	result := "\x48\x65\x6c\x6c\x6f\x00\x57\x6f\x72\x6c\x64"
 	resultFile := filepath.Join(s.T().TempDir(), "input.bin")
 	os.WriteFile(resultFile, []byte(result), 0644)
@@ -266,6 +278,7 @@ func (s *SharedServerSuite) TestActivity_Complete_ResultBase64() {
 	runID := started["runId"].(string)
 	<-activityStarted
 
+	// base64 encoding works with nul character.
 	result := "\x48\x65\x6c\x6c\x6f\x00\x57\x6f\x72\x6c\x64"
 	encoded := base64.StdEncoding.EncodeToString([]byte(result))
 

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -2,14 +2,19 @@ package temporalcli_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
+	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
@@ -115,6 +120,251 @@ func (s *SharedServerSuite) TestActivity_Fail_InvalidDetail() {
 	s.Nil(started)
 	s.Nil(completed)
 	s.Nil(failed)
+}
+
+// Tests activity complete --result-meta ... --result-file ... --result-base64
+func (s *SharedServerSuite) TestActivity_Complete_ResultMeta() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	activityId := "sa-complete-test-result-meta"
+	started := s.startActivity(activityId)
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	result := "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a"
+
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--result", result,
+		"--result-meta", "encoding=binary/plain",
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	handle := s.Client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: activityId,
+		RunID:      runID,
+	})
+	var actual []byte
+	s.NoError(handle.Get(s.Context, &actual))
+	s.Equal(result, string(actual))
+
+}
+
+func (s *SharedServerSuite) TestActivity_Complete_ResultMeta_Protobuf() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	activityId := "sa-complete-test-result-meta-protobuf"
+	started := s.startActivity(activityId)
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	// similar to workflow input-meta test
+	result := &workflowservice.StartWorkflowExecutionRequest{
+		WorkflowId: "result-meta-test",
+		Input: &common.Payloads{
+			Payloads: []*common.Payload{
+				{Data: []byte("xyz")},
+			},
+		},
+	}
+	serialized, _ := proto.Marshal(result)
+
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--result", string(serialized),
+		"--result-meta", "encoding=binary/protobuf",
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	handle := s.Client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: activityId,
+		RunID:      runID,
+	})
+	var actual workflowservice.StartWorkflowExecutionRequest
+	s.NoError(handle.Get(s.Context, &actual))
+	actualSerialized, _ := proto.Marshal(&actual)
+	s.Equal(serialized, actualSerialized)
+	s.Equal(result.WorkflowId, actual.WorkflowId)
+	s.Equal(result.Input.Payloads[0].Data, actual.Input.Payloads[0].Data)
+
+}
+
+func (s *SharedServerSuite) TestActivity_Complete_ResultFile() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	activityId := "sa-complete-test-result-file"
+	started := s.startActivity(activityId)
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	result := "\x48\x65\x6c\x6c\x6f\x00\x57\x6f\x72\x6c\x64"
+	resultFile := filepath.Join(s.T().TempDir(), "input.bin")
+	os.WriteFile(resultFile, []byte(result), 0644)
+	defer os.Remove(resultFile)
+
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--result", result,
+		"--result-file", resultFile,
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "one of result or result-file")
+
+	res = s.Execute(
+		"activity", "complete",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--result-file", resultFile,
+		"--result-meta", "encoding=binary/plain",
+		"--identity", identity,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	handle := s.Client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: activityId,
+		RunID:      runID,
+	})
+	var actual []byte
+	s.NoError(handle.Get(s.Context, &actual))
+	s.Equal(result, string(actual))
+}
+
+func (s *SharedServerSuite) TestActivity_Complete_ResultBase64() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	activityId := "sa-complete-test-result-base64"
+	started := s.startActivity(activityId)
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	result := "\x48\x65\x6c\x6c\x6f\x00\x57\x6f\x72\x6c\x64"
+	encoded := base64.StdEncoding.EncodeToString([]byte(result))
+
+	res := s.Execute(
+		"activity", "complete",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--result", encoded,
+		"--result-meta", "encoding=binary/plain",
+		"--result-base64",
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	handle := s.Client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: activityId,
+		RunID:      runID,
+	})
+	var actual []byte
+	s.NoError(handle.Get(s.Context, &actual))
+	s.Equal(result, string(actual))
+}
+
+// Tests activity fail --detail-file ... --detail-meta ...
+func (s *SharedServerSuite) TestActivity_Fail_DetailMeta() {
+	activityStarted := make(chan struct{})
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		close(activityStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	activityId := "sa-fail-test-detail-meta"
+	started := s.startActivity(activityId)
+	runID := started["runId"].(string)
+	<-activityStarted
+
+	detail := "\x48\x65\x6c\x6c\x6f\x00\x57\x6f\x72\x6c\x64"
+	detailFile := filepath.Join(s.T().TempDir(), "input.bin")
+	os.WriteFile(detailFile, []byte(detail), 0644)
+	defer os.Remove(detailFile)
+
+	res := s.Execute(
+		"activity", "fail",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--detail", detail,
+		"--detail-file", detailFile,
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "one of detail or detail-file")
+
+	res = s.Execute(
+		"activity", "fail",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--reason", "testing for fail",
+		"--detail-file", detailFile,
+		"--detail-meta", "encoding=binary/plain",
+		"--identity", identity,
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	handle := s.Client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: activityId,
+		RunID:      runID,
+	})
+	err := handle.Get(s.Context, nil)
+	s.Error(err)
+	s.Equal(err.Error(), "testing for fail")
+
+	res = s.Execute(
+		"activity", "result",
+		"-o", "json",
+		"--activity-id", activityId,
+		"--run-id", runID,
+		"--address", s.Address(),
+	)
+	s.Error(res.Err)
+
+	output := res.Stdout.String()
+	s.Contains(output, "testing for fail")
+	s.Contains(output, base64.StdEncoding.EncodeToString([]byte(detail)))
+
+	// //// TODO: is there a simpler way to check this?
+	// var jsonOut map[string]any
+	// s.NoError(json.Unmarshal(output, &jsonOut))
+	// s.NotEmpty(jsonOut["failure"])
+	// jsonOut = jsonOut["failure"].(map[string]any)
+	// s.NotEmpty(jsonOut["applicationFailureInfo"])
+	// jsonOut = jsonOut["details"].(map[string]any)
+	// s.NotEmpty(jsonOut["payloads"])
+	// jsonArr := jsonOut["payloads"].([]any)
+	// s.NotEmpty(jsonArr)
+	// jsonOut = jsonArr[0].(map[string]any)
+	// s.NotEmpty(jsonOut["data"])
+	// s.Equal(detail, jsonOut["data"])
+
 }
 
 func (s *SharedServerSuite) TestActivityOptionsUpdate_Accept() {

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -560,10 +560,10 @@ func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalAc
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow ID. Required for workflow Activities. Omit for Standalone Activities.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run ID. For workflow Activities (when --workflow-id is provided), this is the Workflow Run ID. For Standalone Activities, this is the Activity Run ID.")
-	s.Command.Flags().StringVar(&s.Result, "result", "", "Result to return. Use JSON content or set --result-meta to override. Can't be combined with --result-file.")
-	s.Command.Flags().StringVar(&s.ResultFile, "result-file", "", "A path for result file. Use JSON content or set --result-file to override. Can't be combined with --result.")
+	s.Command.Flags().StringVar(&s.Result, "result", "", "Result to return. Use JSON content or set --result-meta to override. Can't be combined with --result-file. Exactly one of --result or --result-file must be supplied.")
+	s.Command.Flags().StringVar(&s.ResultFile, "result-file", "", "A path for result file. Use JSON content or set --result-meta to override. Can't be combined with --result.")
 	s.Command.Flags().StringVar(&s.ResultMeta, "result-meta", "", "Result payload metadata as a `KEY=VALUE` pair. When the KEY is \"encoding\", this overrides the default (\"json/plain\").")
-	s.Command.Flags().BoolVar(&s.ResultBase64, "result-base64", false, "Assume result is base64-encoded and attempt to decode them.")
+	s.Command.Flags().BoolVar(&s.ResultBase64, "result-base64", false, "Assume result is base64-encoded and attempt to decode it.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -687,9 +687,9 @@ func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivi
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow ID. Required for workflow Activities. Omit for Standalone Activities.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run ID. For workflow Activities (when --workflow-id is provided), this is the Workflow Run ID. For Standalone Activities, this is the Activity Run ID.")
 	s.Command.Flags().StringVar(&s.Detail, "detail", "", "Failure detail. Attached as the failure details payload. Use JSON content or set --detail-meta to override. Can't be combined with --detail-file.")
-	s.Command.Flags().StringVar(&s.DetailFile, "detail-file", "", "A path for result file. Use JSON content or set --detail-file to override. Can't be combined with --detail.")
+	s.Command.Flags().StringVar(&s.DetailFile, "detail-file", "", "A path for result file. Use JSON content or set --detail-meta to override. Can't be combined with --detail.")
 	s.Command.Flags().StringVar(&s.DetailMeta, "detail-meta", "", "Result payload metadata as a `KEY=VALUE` pair. When the KEY is \"encoding\", this overrides the default (\"json/plain\").")
-	s.Command.Flags().BoolVar(&s.DetailBase64, "detail-base64", false, "Assume detail is base64-encoded and attempt to decode them.")
+	s.Command.Flags().BoolVar(&s.DetailBase64, "detail-base64", false, "Assume detail is base64-encoded and attempt to decode it.")
 	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Failure reason. Attached as the failure message.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -533,12 +533,15 @@ func NewTemporalActivityCancelCommand(cctx *CommandContext, parent *TemporalActi
 }
 
 type TemporalActivityCompleteCommand struct {
-	Parent     *TemporalActivityCommand
-	Command    cobra.Command
-	ActivityId string
-	WorkflowId string
-	RunId      string
-	Result     string
+	Parent       *TemporalActivityCommand
+	Command      cobra.Command
+	ActivityId   string
+	WorkflowId   string
+	RunId        string
+	Result       string
+	ResultFile   string
+	ResultMeta   string
+	ResultBase64 bool
 }
 
 func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalActivityCommand) *TemporalActivityCompleteCommand {
@@ -557,8 +560,10 @@ func NewTemporalActivityCompleteCommand(cctx *CommandContext, parent *TemporalAc
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow ID. Required for workflow Activities. Omit for Standalone Activities.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run ID. For workflow Activities (when --workflow-id is provided), this is the Workflow Run ID. For Standalone Activities, this is the Activity Run ID.")
-	s.Command.Flags().StringVar(&s.Result, "result", "", "Result `JSON` to return. Required.")
-	_ = cobra.MarkFlagRequired(s.Command.Flags(), "result")
+	s.Command.Flags().StringVar(&s.Result, "result", "", "Result to return. Use JSON content or set --result-meta to override. Can't be combined with --result-file.")
+	s.Command.Flags().StringVar(&s.ResultFile, "result-file", "", "A path for result file. Use JSON content or set --result-file to override. Can't be combined with --result.")
+	s.Command.Flags().StringVar(&s.ResultMeta, "result-meta", "", "Result payload metadata as a `KEY=VALUE` pair. When the KEY is \"encoding\", this overrides the default (\"json/plain\").")
+	s.Command.Flags().BoolVar(&s.ResultBase64, "result-base64", false, "Assume result is base64-encoded and attempt to decode them.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)
@@ -653,13 +658,16 @@ func NewTemporalActivityExecuteCommand(cctx *CommandContext, parent *TemporalAct
 }
 
 type TemporalActivityFailCommand struct {
-	Parent     *TemporalActivityCommand
-	Command    cobra.Command
-	ActivityId string
-	WorkflowId string
-	RunId      string
-	Detail     string
-	Reason     string
+	Parent       *TemporalActivityCommand
+	Command      cobra.Command
+	ActivityId   string
+	WorkflowId   string
+	RunId        string
+	Detail       string
+	DetailFile   string
+	DetailMeta   string
+	DetailBase64 bool
+	Reason       string
 }
 
 func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivityCommand) *TemporalActivityFailCommand {
@@ -678,7 +686,10 @@ func NewTemporalActivityFailCommand(cctx *CommandContext, parent *TemporalActivi
 	_ = cobra.MarkFlagRequired(s.Command.Flags(), "activity-id")
 	s.Command.Flags().StringVarP(&s.WorkflowId, "workflow-id", "w", "", "Workflow ID. Required for workflow Activities. Omit for Standalone Activities.")
 	s.Command.Flags().StringVarP(&s.RunId, "run-id", "r", "", "Run ID. For workflow Activities (when --workflow-id is provided), this is the Workflow Run ID. For Standalone Activities, this is the Activity Run ID.")
-	s.Command.Flags().StringVar(&s.Detail, "detail", "", "Failure detail (JSON). Attached as the failure details payload.")
+	s.Command.Flags().StringVar(&s.Detail, "detail", "", "Failure detail. Attached as the failure details payload. Use JSON content or set --detail-meta to override. Can't be combined with --detail-file.")
+	s.Command.Flags().StringVar(&s.DetailFile, "detail-file", "", "A path for result file. Use JSON content or set --detail-file to override. Can't be combined with --detail.")
+	s.Command.Flags().StringVar(&s.DetailMeta, "detail-meta", "", "Result payload metadata as a `KEY=VALUE` pair. When the KEY is \"encoding\", this overrides the default (\"json/plain\").")
+	s.Command.Flags().BoolVar(&s.DetailBase64, "detail-base64", false, "Assume detail is base64-encoded and attempt to decode them.")
 	s.Command.Flags().StringVar(&s.Reason, "reason", "", "Failure reason. Attached as the failure message.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -235,8 +235,25 @@ commands:
           Activities, this is the Activity Run ID.
       - name: result
         type: string
-        description: Result `JSON` to return.
-        required: true
+        description: |
+          Result to return.
+          Use JSON content or set --result-meta to override.
+          Can't be combined with --result-file.
+      - name: result-file
+        type: string
+        description: |
+          A path for result file.
+          Use JSON content or set --result-file to override.
+          Can't be combined with --result.
+      - name: result-meta
+        type: string
+        description: |
+          Result payload metadata as a `KEY=VALUE` pair.
+          When the KEY is "encoding", this overrides the default ("json/plain").
+      - name: result-base64
+        type: bool
+        description: |
+          Assume result is base64-encoded and attempt to decode them.
 
   - name: temporal activity count
     summary: Count Standalone Activities matching a query (Experimental)
@@ -326,8 +343,24 @@ commands:
       - name: detail
         type: string
         description: |
-          Failure detail (JSON). Attached as the failure details
-          payload.
+          Failure detail. Attached as the failure details payload.
+          Use JSON content or set --detail-meta to override.
+          Can't be combined with --detail-file.
+      - name: detail-file
+        type: string
+        description: |
+          A path for result file.
+          Use JSON content or set --detail-file to override.
+          Can't be combined with --detail.
+      - name: detail-meta
+        type: string
+        description: |
+          Result payload metadata as a `KEY=VALUE` pair.
+          When the KEY is "encoding", this overrides the default ("json/plain").
+      - name: detail-base64
+        type: bool
+        description: |
+          Assume detail is base64-encoded and attempt to decode them.
       - name: reason
         type: string
         description: |

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -238,22 +238,24 @@ commands:
         description: |
           Result to return.
           Use JSON content or set --result-meta to override.
-          Can't be combined with --result-file.
+          Can't be combined with --result-file. Exactly one of --result
+          or --result-file must be supplied.
       - name: result-file
         type: string
         description: |
           A path for result file.
-          Use JSON content or set --result-file to override.
+          Use JSON content or set --result-meta to override.
           Can't be combined with --result.
       - name: result-meta
         type: string
         description: |
           Result payload metadata as a `KEY=VALUE` pair.
-          When the KEY is "encoding", this overrides the default ("json/plain").
+          When the KEY is "encoding", this overrides the default
+          ("json/plain").
       - name: result-base64
         type: bool
         description: |
-          Assume result is base64-encoded and attempt to decode them.
+          Assume result is base64-encoded and attempt to decode it.
 
   - name: temporal activity count
     summary: Count Standalone Activities matching a query (Experimental)
@@ -350,17 +352,18 @@ commands:
         type: string
         description: |
           A path for result file.
-          Use JSON content or set --detail-file to override.
+          Use JSON content or set --detail-meta to override.
           Can't be combined with --detail.
       - name: detail-meta
         type: string
         description: |
           Result payload metadata as a `KEY=VALUE` pair.
-          When the KEY is "encoding", this overrides the default ("json/plain").
+          When the KEY is "encoding", this overrides the default
+          ("json/plain").
       - name: detail-base64
         type: bool
         description: |
-          Assume detail is base64-encoded and attempt to decode them.
+          Assume detail is base64-encoded and attempt to decode it.
       - name: reason
         type: string
         description: |


### PR DESCRIPTION
## Related issues

Addresses #954 

## What changed?

In activity complete, add new result-meta, result-file, result-base64
options to set encoding and/or supply result from a file.

In activity fail, add new detail-meta, detail-file, detail-base64 options
to set encoding and/or supply failure detail from a file.

Similar to input and input-file flags for other commands, only one of
result or result-file can be used, and at most one of detail or detail-file
can be used.

## Checklist

**Stability**
- [ ] (N/A) Breaking changes are marked with 💥 in the PR title and release notes
- [ ] (N/A) Changes to JSON output (`-o json` / `-o jsonl`) are treated as breaking changes

**Design**
- [x] This feature does not depend on Cloud-only APIs or behavior (it works against an OSS server)
- [ ] (N/A) New commands follow `temporal <noun> <verb>` structure (e.g. `temporal workflow start`)
- [x] New flags are named after the API concept, not the implementation mechanism (good: `--search-attribute`, bad: `--index-field`)
- [x] New flags don't duplicate an existing flag that serves the same purpose
- [x] New flags do not have short aliases without strong justification
- [ ] (N/A) Experimental features are marked with `(Experimental)` in `commands.yaml`

**Help text** (see style guide at the top of `commands.yaml`)
- [ ] (N/A) All flags shown in help text and examples are implemented and functional
- [ ] (N/A) Summaries use sentence case and have no trailing period
- [ ] (N/A) Long descriptions end with a period and include at least one example invocation
- [ ] (N/A) Examples use long flags (`--namespace`, not `-n`), one flag per line
- [ ] (N/A) Placeholder values use `YourXxx` form (`YourWorkflowId`, `YourNamespace`)

**Behavior**
- [ ] (N/A) Results go to stdout; errors and warnings go to stderr
- [x] Error messages are lowercase with no trailing punctuation

**Tests**
- [x] Added functional test(s) (`SharedServerSuite`)
- [ ] (N/A) Added unit test(s) (`func TestXxx`) where applicable

## Manual tests

The manual test below uses standalone activity, and tests the new flags in 
`activity complete` and `activity fail` commands.

**Setup**

Start the server, assume worker for task queue `YourTaskQueue` is running,
start a standalone activity.
```
temporal server start-dev --headless
temporal activity start \
    --type YourActivityType \
    --task-queue YourTaskQueue \
    --activity-id YourActivityId \
    --start-to-close-timeout 10s

Running execution:
  ActivityId  YourActivityId
  RunId       <your-run-id>
  Namespace   default
```

**Happy path**
Note the `RunId` value, `<your-run-id>`, in the output above, as it is used in
each of the test path below.

1. complete with result-meta.
```
$ temporal activity complete \
    --activity-id YourActivityId \
    --run-id <your-run-id> \
    --result "Hello World" \
    --result-meta binary/plain
$ temporal activity result \
    --activity-id YourActivityId \
    --run-id <your-run-id>

 Results:
  Status  COMPLETED
  Result  "SGVsbG8gV29ybGQ="
```

2. complete with result-meta and result-base64.
```
$ temporal activity complete \
    --activity-id YourActivityId \
    --run-id <your-run-id> \
    --result "SGVsbG8AV29ybGQ=" \
    --result-meta binary/plain \
    --result-base64
$ temporal activity result \
    --activity-id YourActivityId \
    --run-id <your-run-id>

 Results:
  Status  COMPLETED
  Result  "SGVsbG8AV29ybGQ="
```
TODO: To use result-base64 without result-meta, we need to fix in `CreatePayloads`.

3. Complete with result-meta and result-file.
```
$ echo -e -n "Hello\x00World" > in.bin
$ temporal activity complete \
    --activity-id YourActivityId \
    --run-id <RunId-from-above> \
    --result-file in.bin \
    --result-meta "encoding=binary/plain"
$ temporal activity result \
    --activity-id YourActivityId \
    --run-id <your-run-id>

Results:
  Status  COMPLETED
  Result  "SGVsbG8AV29ybGQ="
```
or

4. Fail with detail, detail-meta and detail-base64.
```
$ temporal activity fail \
    --activity-id YourActivityId \
    --run-id <RunId-from-above> \
    --detail "AAECAwo="
    --detail-meta "encoding=binary/plain"
    --detail-base64

$ temporal activity result \
    --activity-id YourActivityId \
    --run-id <RunId-from-above> \
    --output jsonl

{"activityId":"YourActivityId",...,"status":"FAILED",... "data":"AAECAwo="...}
Error: activity failed
```

TODO: The other values for result-meta and detail-meta, e.g.,  binary/protobuf and
json/protobuf, are also supported, but require compiled protobuf files, or a new
option of `--output raw` in `activity result` to verify via CLI.

**Error case**

1. Only one of result or result-file is allowed. Use in.bin from the above steps.
```
$ temporal activity complete \
    --activity-id YourActivityId \
    --run-id <RunId-from-above> \
    --result "Hello World" \
    --result-file in.bin

Error: provide exactly one of result or result-file
$ echo $?
1
```

2. At most one of detail or detail-file is allowed.
```
$ temporal activity fail \
    --activity-id YourActivityId \
    --run-id <RunId-from-above> \
    --detail "Hello World" \
    --detail-file in.bin

Error: provide one of detail or detail-file, but not both
```

**Composition** <!-- How might a user combine this with existing commands? e.g. using the output of one command as input to another -->
```
$ temporal activity complete ... --result ... --result-meta ...
$ temporal activity complete ... --result ... --result-meta ... --result-base64
$ temporal activity complete ... --result-file ... --result-meta ...
$ temporal activity complete ... --result ... --result-base64

$ temporal activity fail ... --detail ... --detail-meta ...
$ temporal activity fail ... --detail ... --detail-meta ... --detail-base64
$ temporal activity fail ... --detail-file ... --detail-meta ...
$ temporal activity fail ... --detail ... --detail-base64
```
