### PR TITLE
Perform Base64 decode before JSON validation in create payloads

### DIFF
--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -2,6 +2,7 @@ package temporalcli_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -758,6 +759,35 @@ func (s *SharedServerSuite) TestActivity_Execute_RetriesOnEmptyPollResponse() {
 	)
 	s.NoError(res.Err)
 	s.Contains(res.Stdout.String(), "standalone-result")
+}
+
+func (s *SharedServerSuite) TestActivity_Execute_JsonWithBase64() {
+	var receivedInput any
+	s.Worker().OnDevActivity(func(ctx context.Context, a any) (any, error) {
+		receivedInput = a
+		return map[string]string{"foo": "bar"}, nil
+	})
+
+	jsonInput := `"my-input"` // JSON string as input, before base64 encode
+	base64Input := base64.StdEncoding.EncodeToString([]byte(jsonInput))
+	res := s.Execute(
+		"activity", "execute",
+		"--activity-id", "exec-test",
+		"--type", "DevActivity",
+		"--task-queue", s.Worker().Options.TaskQueue,
+		"--start-to-close-timeout", "30s",
+		"-i", base64Input,
+		"--input-base64",
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+	out := res.Stdout.String()
+	s.Contains(out, "Running execution:")
+	s.ContainsOnSameLine(out, "ActivityId", "exec-test")
+	s.Contains(out, "Results:")
+	s.ContainsOnSameLine(out, "Status", "COMPLETED")
+	s.ContainsOnSameLine(out, "Result", `{"foo":"bar"}`)
+	s.Equal("my-input", receivedInput)
 }
 
 // startActivity starts an activity via the CLI and returns

--- a/internal/temporalcli/payload.go
+++ b/internal/temporalcli/payload.go
@@ -14,6 +14,13 @@ import (
 func CreatePayloads(data [][]byte, metadata map[string][][]byte, isBase64 bool) (*common.Payloads, error) {
 	ret := &common.Payloads{Payloads: make([]*common.Payload, len(data))}
 	for i, in := range data {
+		// Decode base64 if base64'd (std encoding only for now)
+		if isBase64 {
+			var err error
+			if in, err = base64.StdEncoding.DecodeString(string(in)); err != nil {
+				return nil, fmt.Errorf("input #%v is not valid base64", i+1)
+			}
+		}
 		var metadataForIndex = make(map[string][]byte, len(metadata))
 		for k, vals := range metadata {
 			if len(vals) == 0 {
@@ -28,13 +35,6 @@ func CreatePayloads(data [][]byte, metadata map[string][][]byte, isBase64 bool) 
 				return nil, fmt.Errorf("input #%v is not valid JSON", i+1)
 			}
 			metadataForIndex[k] = v
-		}
-		// Decode base64 if base64'd (std encoding only for now)
-		if isBase64 {
-			var err error
-			if in, err = base64.StdEncoding.DecodeString(string(in)); err != nil {
-				return nil, fmt.Errorf("input #%v is not valid base64", i+1)
-			}
 		}
 		ret.Payloads[i] = &common.Payload{Data: in, Metadata: metadataForIndex}
 	}


### PR DESCRIPTION
## What changed?

Previously, the Base64 decoding was done after JSON validation. This prevented 
setting --input option with Base64 of JSON value. Base64 decoding is now done
before any JSON validation, if encoding indicates json.

## Why changed?

The --input-base64 boolean flag indicates that the input is in base64. From help:
```
--input-base64     Assume inputs are base64-encoded and attempt to decode them.
```
If the flag is present, then input is not in JSON, and must be supplied as base64 
encoded value. If no input-meta is supplied to change the encoding, or is set as
json/plain or similar, then previously, it attempted to validate input as JSON before
base64 decode, which failed.

## Checklist

**Stability**
- [ ] (N/A) Breaking changes are marked with 💥 in the PR title and release notes
- [ ] (N/A) Changes to JSON output (`-o json` / `-o jsonl`) are treated as breaking changes

**Design**
- [ ] (N/A) This feature does not depend on Cloud-only APIs or behavior (it works against an OSS server)
- [ ] (N/A) New commands follow `temporal <noun> <verb>` structure (e.g. `temporal workflow start`)
- [ ] (N/A) New flags are named after the API concept, not the implementation mechanism (good: `--search-attribute`, bad: `--index-field`)
- [ ] (N/A) New flags don't duplicate an existing flag that serves the same purpose
- [ ] (N/A) New flags do not have short aliases without strong justification
- [ ] (N/A) Experimental features are marked with `(Experimental)` in `commands.yaml`

**Help text** (see style guide at the top of `commands.yaml`)
- [ ] (N/A) All flags shown in help text and examples are implemented and functional
- [ ] (N/A) Summaries use sentence case and have no trailing period
- [ ] (N/A) Long descriptions end with a period and include at least one example invocation
- [ ] (N/A) Examples use long flags (`--namespace`, not `-n`), one flag per line
- [ ] (N/A) Placeholder values use `YourXxx` form (`YourWorkflowId`, `YourNamespace`)

**Behavior**
- [ ] (N/A) Results go to stdout; errors and warnings go to stderr
- [ ] (N/A) Error messages are lowercase with no trailing punctuation

**Tests**
- [x] Added functional test(s) (`SharedServerSuite`)
- [ ] Added unit test(s) (`func TestXxx`) where applicable

## Manual tests

<!-- Edit the code samples below to provide setup and happy-path and error-path testing instructions. -->

**Setup**

Start server, and worker from samples-go for standalone_activity/helloworld
```
temporal server start-dev --headless
cd samples-go
go run standalone-activity/helloworld/worker/main.go
```

**Happy path**

The following test should not work previously, but should work after the fix in this PR.

```
$ echo -e -n "\"Temporal\"" | base64
IlRlbXBvcmFsIg==

$ temporal activity execute \
    --type Activity \
    --task-queue standalone-activity-helloworld \
    --activity-id YourActivityId \
    --start-to-close-timeout 10s \
    --input IlRlbXBvcmFsIg== \
    --input-base64
```

Without the fix:
```
Error: input #1 is not valid JSON
```

With the fix:
```
Running execution:
  ActivityId  YourActivityId
  RunId       ...
  Namespace   default
Results:
  Status  COMPLETED
  Result  "Hello Temporal!"
```
