### PR TITLE
Add client-authority support to config profile settings

### DIFF
--- a/cliext/client.go
+++ b/cliext/client.go
@@ -132,6 +132,11 @@ func (b *ClientOptionsBuilder) Build(ctx context.Context) (client.Options, error
 		profile.APIKey = cfg.ApiKey
 	}
 
+	// Set client authority on profile if provided
+	if cfg.ClientAuthority != "" {
+		profile.Authority = cfg.ClientAuthority
+	}
+
 	// Handle gRPC metadata from flags.
 	if len(cfg.GrpcMeta) > 0 {
 		grpcMetaFromArg, err := parseKeyValuePairs(cfg.GrpcMeta)

--- a/cliext/config.oauth.go
+++ b/cliext/config.oauth.go
@@ -141,11 +141,7 @@ func resolveConfigAndProfile(configFilePath, profileName string, envLookup envco
 		configFilePath, _ = envLookup.LookupEnv("TEMPORAL_CONFIG_FILE")
 	}
 	if configFilePath == "" {
-		var err error
-		configFilePath, err = envconfig.DefaultConfigFilePath()
-		if err != nil {
-			return "", "", fmt.Errorf("failed to get default config path: %w", err)
-		}
+		configFilePath = envconfig.DefaultConfigFilePath()
 	}
 
 	// Resolve profile name.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/temporalio/ui-server/v2 v2.49.1
 	go.temporal.io/api v1.62.13
 	go.temporal.io/sdk v1.44.1
-	go.temporal.io/sdk/contrib/envconfig v1.0.0
+	go.temporal.io/sdk/contrib/envconfig v1.0.2
 	go.temporal.io/server v1.32.0-157.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/mod v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3G
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.44.1 h1:Mt2OZLZpqkzDIdg9YyQzO0Rb/HqCDnnqHlIAGAJ5gqM=
 go.temporal.io/sdk v1.44.1/go.mod h1:vkApR12F9/Y8OR+hkxe7WyXQFuCX6clhzqnAk6rzDAM=
-go.temporal.io/sdk/contrib/envconfig v1.0.0 h1:1Q/swVgB4EW/p3k7rI9/4hpU4/DC57FSRbU90+UisXw=
-go.temporal.io/sdk/contrib/envconfig v1.0.0/go.mod h1:Pj4N1lwUEvxap6quBm8GrVMSUMJhSZkVtxjt3AYnPPg=
+go.temporal.io/sdk/contrib/envconfig v1.0.2 h1:MGHfsuPUtsf7X9M6WYn3zYJj/mWsuYHnA1uuiL0KEuE=
+go.temporal.io/sdk/contrib/envconfig v1.0.2/go.mod h1:MuMiH7hksps2uXnmKuAWaP9P6WbkSDy62kl64t1VJVg=
 go.temporal.io/server v1.32.0-157.0 h1:nzFqNwx+5lXsT0/DSiFyR5vHMnDcT3PVAvmRDqCUn38=
 go.temporal.io/server v1.32.0-157.0/go.mod h1:a76wf30/s28JXh+3nDQtQi8KzOfRQEddpebvmr/oQL4=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/internal/temporalcli/commands.config.go
+++ b/internal/temporalcli/commands.config.go
@@ -259,6 +259,7 @@ var envConfigPropsToFieldNames = map[string]string{
 	"address":                       "Address",
 	"namespace":                     "Namespace",
 	"api_key":                       "APIKey",
+	"authority":                     "Authority",
 	"tls":                           "TLS",
 	"tls.disabled":                  "Disabled",
 	"tls.client_cert_path":          "ClientCertPath",

--- a/internal/temporalcli/commands.config.go
+++ b/internal/temporalcli/commands.config.go
@@ -317,10 +317,8 @@ func writeEnvConfigFile(cctx *CommandContext, conf *envconfig.ClientConfig) erro
 	if configFile == "" {
 		configFile, _ = cctx.Options.EnvLookup.LookupEnv("TEMPORAL_CONFIG_FILE")
 		if configFile == "" {
-			var err error
-			if configFile, err = envconfig.DefaultConfigFilePath(); err != nil {
-				return err
-			}
+			configFile = envconfig.DefaultConfigFilePath()
+
 		}
 	}
 

--- a/internal/temporalcli/commands.config_test.go
+++ b/internal/temporalcli/commands.config_test.go
@@ -25,6 +25,7 @@ func TestConfig_Get(t *testing.T) {
 address = "my-address"
 namespace = "my-namespace"
 api_key = "my-api-key"
+authority = "my-authority"
 codec = { endpoint = "my-endpoint", auth = "my-auth" }
 grpc_meta = { some-heAder1 = "some-value1", some-header2 = "some-value2", some_heaDer3 = "some-value3" }
 some_future_key = "some future value not handled"
@@ -74,6 +75,7 @@ disable_host_verification = true`))
 		"address":                       "my-address",
 		"namespace":                     "my-namespace",
 		"api_key":                       "my-api-key",
+		"authority":                     "my-authority",
 		"codec.endpoint":                "my-endpoint",
 		"codec.auth":                    "my-auth",
 		"grpc_meta.some-header1":        "some-value1",
@@ -117,6 +119,7 @@ disable_host_verification = true`))
 	h.JSONEq(`{
 		"address": "my-address",
 		"api_key": "my-api-key",
+		"authority": "my-authority",
 		"codec": {
 			"auth": "my-auth",
 			"endpoint": "my-endpoint"

--- a/internal/temporalcli/commands.config_test.go
+++ b/internal/temporalcli/commands.config_test.go
@@ -347,6 +347,7 @@ func TestConfig_Set(t *testing.T) {
 		"address":                       "my-address",
 		"namespace":                     "my-namespace",
 		"api_key":                       "my-api-key",
+		"authority":                     "my-authority",
 		"codec.endpoint":                "my-endpoint",
 		"codec.auth":                    "my-auth",
 		"grpc_meta.sOme_header1":        "some-value1",
@@ -377,6 +378,7 @@ func TestConfig_Set(t *testing.T) {
 					"address":   "my-address",
 					"namespace": "my-namespace",
 					"api_key":   "my-api-key",
+					"authority": "my-authority",
 					"tls": map[string]any{
 						"disabled":                  true,
 						"client_cert_path":          "my-client-cert-path",


### PR DESCRIPTION
## Related issues

Closes #1013

## What changed?

- Added `authority` to `envConfigPropsToFieldNames` map so 
  `client-authority` can be get/set via config commands
- Wired `cfg.ClientAuthority` to `profile.Authority` in `client.go`
- Updated `DefaultConfigFilePath()` call sites for envconfig v1.0.2
  signature change (returns `string` instead of `(string, error)`)
- Bumped `go.temporal.io/sdk/contrib/envconfig` to v1.0.2
- Added `authority` field to config tests

## Checklist

**Stability**

- ✅ No breaking changes
- ✅ Works against OSS server
- ✅ Flag named after API concept (client-authority)
- ✅ No duplicate flags
- ✅ No short aliases
- ✅ Added test coverage in commands.config_test.go

**Design**

- ✅ Works against OSS server
- ✅ Flag named after API concept (client-authority)
- ✅ No duplicate flags
- ✅ No short aliases

**Tests**

- [ ] Added functional test (SharedServerSuite) — config set/get test needed

## Manual tests

**Setup**
```
temporal server start-dev --headless
```

**Happy path**
```
$ temporal config set --prop authority --value my-authority
$ temporal config get --prop authority
Property   Value
authority   my-authority
```

**Error case**
```
$ temporal config set --prop authority
Error: required flag --value not set
```
