### PR TITLE
fix: tls is not added for profiles without tls

### DIFF
--- a/internal/temporalcli/commands.config.go
+++ b/internal/temporalcli/commands.config.go
@@ -111,13 +111,19 @@ func (c *TemporalConfigGetCommand) run(cctx *CommandContext, _ []string) error {
 		}
 		return cctx.Printer.PrintStructured(tomlConf.Profiles[profileName], printer.StructuredOptions{})
 	} else {
+		// Capture whether TLS is configured before the loop below. Looking up
+		// any "tls.*" property via reflectEnvConfigProp lazily initializes
+		// confProfile.TLS to a non-nil empty struct, which would otherwise make
+		// TLS appear configured when it is not (#1077).
+		tlsConfigured := confProfile.TLS != nil
+
 		// Get every property individually as a property-value pair except zero
 		// vals
 		var props []prop
 		for k := range envConfigPropsToFieldNames {
 			// TLS is a special case
 			if k == "tls" {
-				if confProfile.TLS != nil {
+				if tlsConfigured {
 					props = append(props, prop{Property: "tls", Value: true})
 				}
 				continue

--- a/internal/temporalcli/commands.config_test.go
+++ b/internal/temporalcli/commands.config_test.go
@@ -151,6 +151,30 @@ disable_host_verification = true`))
 	}
 }
 
+func TestConfig_Get_NoTLSWhenUnconfigured(t *testing.T) {
+	// Regression test for #1077: `config get` (table output) must not display
+	// "tls true" for a profile that has no TLS configuration.
+	h := NewCommandHarness(t)
+	defer h.Close()
+
+	f, err := os.CreateTemp("", "")
+	h.NoError(err)
+	defer os.Remove(f.Name())
+	_, err = f.Write([]byte(`
+[profile.devtest]
+address = "localhost:17233"
+namespace = "default"`))
+	f.Close()
+	h.NoError(err)
+	h.Options.EnvLookup = EnvLookupMap{"TEMPORAL_CONFIG_FILE": f.Name(), "TEMPORAL_PROFILE": "devtest"}
+
+	res := h.Execute("config", "get")
+	h.NoError(res.Err)
+	h.Contains(res.Stdout.String(), "localhost:17233")
+	// No TLS section was configured, so "tls" should not appear at all.
+	h.NotContains(res.Stdout.String(), "tls")
+}
+
 func TestConfig_TLS_Boolean(t *testing.T) {
 	h := NewCommandHarness(t)
 	defer h.Close()


### PR DESCRIPTION
## Related issues

Closes #1077

## What changed?

The helper to iterate over `envConfigPropsToFieldNames` has a side effect if the parent is nil and `failIfParentNotFound=true` it will set `confProfile.TLS = &envconvfig.ClientConfigTLS{}`. When the `k=="tls"` check happens, `confProfile.TLS != nil` and it will emit `tls: true`. Map iteration is non-deterministic and there are 9 `tls.*` keys vs 1 `tls` key so the mutation is more likely to happen before checking the `tls` key.

## Checklist

**Tests**
- [X] Added unit test
