### PR TITLE
Add option to disable newsfeed in UI

### DIFF
--- a/internal/devserver/server.go
+++ b/internal/devserver/server.go
@@ -76,6 +76,7 @@ type StartOptions struct {
 	UIPort                int    // Required if UIIP is non-empty
 	UIAssetPath           string
 	UICodecEndpoint       string
+	UIDisableNewsFetch    bool
 	PublicPath            string
 	DatabaseFile          string
 	MetricsPort           int
@@ -166,7 +167,6 @@ func (s *Server) SuppressWarnings() {
 }
 
 func (s *StartOptions) buildUIServer() *uiserver.Server {
-	disableNewsFetch, _ := strconv.ParseBool(os.Getenv("TEMPORAL_DISABLE_NEWS_FETCH"))
 	return uiserver.NewServer(uiserveroptions.WithConfigProvider(&uiconfig.Config{
 		Host:                MaybeEscapeIPv6(s.UIIP),
 		Port:                s.UIPort,
@@ -177,7 +177,7 @@ func (s *StartOptions) buildUIServer() *uiserver.Server {
 		Codec:               uiconfig.Codec{Endpoint: s.UICodecEndpoint},
 		CORS:                uiconfig.CORS{CookieInsecure: true},
 		HideLogs:            true,
-		DisableNewsFetch:    disableNewsFetch,
+		DisableNewsFetch:    s.UIDisableNewsFetch,
 	}))
 }
 

--- a/internal/devserver/server.go
+++ b/internal/devserver/server.go
@@ -166,6 +166,7 @@ func (s *Server) SuppressWarnings() {
 }
 
 func (s *StartOptions) buildUIServer() *uiserver.Server {
+	disableNewsFetch, _ := strconv.ParseBool(os.Getenv("TEMPORAL_DISABLE_NEWS_FETCH"))
 	return uiserver.NewServer(uiserveroptions.WithConfigProvider(&uiconfig.Config{
 		Host:                MaybeEscapeIPv6(s.UIIP),
 		Port:                s.UIPort,
@@ -176,6 +177,7 @@ func (s *StartOptions) buildUIServer() *uiserver.Server {
 		Codec:               uiconfig.Codec{Endpoint: s.UICodecEndpoint},
 		CORS:                uiconfig.CORS{CookieInsecure: true},
 		HideLogs:            true,
+		DisableNewsFetch:    disableNewsFetch,
 	}))
 }
 

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -2771,6 +2771,7 @@ type TemporalServerStartDevCommand struct {
 	UiPublicPath       string
 	UiAssetPath        string
 	UiCodecEndpoint    string
+	UiDisableNewsFetch bool
 	SqlitePragma       []string
 	DynamicConfigValue []string
 	LogConfig          bool
@@ -2801,6 +2802,7 @@ func NewTemporalServerStartDevCommand(cctx *CommandContext, parent *TemporalServ
 	s.Command.Flags().StringVar(&s.UiPublicPath, "ui-public-path", "", "The public base path for the Web UI. Defaults to `/`.")
 	s.Command.Flags().StringVar(&s.UiAssetPath, "ui-asset-path", "", "UI custom assets path.")
 	s.Command.Flags().StringVar(&s.UiCodecEndpoint, "ui-codec-endpoint", "", "UI remote codec HTTP endpoint.")
+	s.Command.Flags().BoolVar(&s.UiDisableNewsFetch, "ui-disable-news-fetch", false, "Disable the Web UI newsfeed. When set, the UI will not request the newsfeed and the button to open the newsfeed panel is hidden.")
 	s.Command.Flags().StringArrayVar(&s.SqlitePragma, "sqlite-pragma", nil, "SQLite pragma statements in \"PRAGMA=VALUE\" format.")
 	s.Command.Flags().StringArrayVar(&s.DynamicConfigValue, "dynamic-config-value", nil, "Dynamic configuration value using `KEY=VALUE` pairs. Keys must be identifiers, and values must be JSON values. For example: `YourKey=\"YourString\"` Can be passed multiple times.")
 	s.Command.Flags().BoolVar(&s.LogConfig, "log-config", false, "Print the server config to stderr.")

--- a/internal/temporalcli/commands.server.go
+++ b/internal/temporalcli/commands.server.go
@@ -92,6 +92,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 			}
 		}
 		opts.UIAssetPath, opts.UICodecEndpoint, opts.PublicPath = t.UiAssetPath, t.UiCodecEndpoint, t.UiPublicPath
+		opts.UIDisableNewsFetch = t.UiDisableNewsFetch
 	}
 	// Pragmas and dyn config
 	var err error

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -2950,6 +2950,11 @@ commands:
       - name: ui-codec-endpoint
         type: string
         description: UI remote codec HTTP endpoint.
+      - name: ui-disable-news-fetch
+        type: bool
+        description: |
+          Disable the Web UI newsfeed. When set, the UI will not request the
+          newsfeed and the button to open the newsfeed panel is hidden.
       - name: sqlite-pragma
         type: string[]
         description: SQLite pragma statements in "PRAGMA=VALUE" format.


### PR DESCRIPTION
## Related issues

Related to #[1104](https://github.com/temporalio/cli/pull/1104)

## What changed?

<!-- Describe what this PR does at a high level. -->
This adds a command-line option that configures the embedded UI server to disable the news feed feature.

## Checklist

<!-- Your PR should satisfy all these requirements. However, feel free to remove items that don't apply to the PR. Consider giving this checklist to an AI agent before opening your PR. -->

## Manual tests

<!-- Edit the code samples below to provide setup and happy-path and error-path testing instructions. -->

**Setup #1 (default case)**
```
temporal server start-dev
```

**Happy path #1 (default case)**
Open the Web UI and observe that the news fetch feature is enabled, as it is by default. This is visible by way of a megaphone icon in the top navigation. 



**Setup two (feature disabled)**
```
temporal server start-dev --ui-disable-news-fetch
```

**Happy path two (feature disabled)**
Open the Web UI and observe that the news fetch feature is disabled, since the environment variable is set to disable it, as described in the documentation. This is evident by the megaphone icon being omitted from the top navigation and the Web UI not making a request for the feed.



