### PR TITLE
ci: support merge queues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main
@@ -12,7 +14,7 @@ permissions:
 jobs:
   validate-server-version:
     name: Validate Server Version
-    if: github.event_name == 'push' || github.base_ref == 'main'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,17 @@ jobs:
           path: junit-xml
           retention-days: 14
 
+      - name: Tidy modules, confirm unchanged
+        if: ${{ matrix.checkGenCommands }}
+        shell: bash
+        run: |
+          go mod tidy
+          (
+            cd cliext
+            go mod tidy
+          )
+          git diff --exit-code -- go.mod go.sum cliext/go.mod cliext/go.sum
+
       - name: Regen code, confirm unchanged
         if: ${{ matrix.checkGenCommands }}
         run: |

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,6 +2,8 @@ name: Govulncheck
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,6 @@ github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1-0.20260129151045-8706a1ab5f61 h1:v9EBEMJggmXGbVcIAjGQpKgEB+a9E/Q0brJ6fGWJvhQ=
 github.com/temporalio/tchannel-go v1.22.1-0.20260129151045-8706a1ab5f61/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
-github.com/temporalio/ui-server/v2 v2.50.1 h1:dlyg96lFwOIaiXywDzPnSXVf8GPULLfrXXVXGqRsvJY=
-github.com/temporalio/ui-server/v2 v2.50.1/go.mod h1:jiWHDxRe4RDXLxGwenfV+FSgjXat81okVTTZPQOlc3c=
 github.com/temporalio/ui-server/v2 v2.52.0 h1:BJ5e1teLOITbn4G9zZTuDOsROonI0uRThGlzaQ1aMxs=
 github.com/temporalio/ui-server/v2 v2.52.0/go.mod h1:HKjuLT3J/hM1nRN6Vge2Z63tPWPNUVR/2+5CMbkBQns=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=


### PR DESCRIPTION
## Summary

- run Continuous Integration and Govulncheck for GitHub merge-group commits
- ensure Validate Server Version executes for merge groups instead of being skipped by its PR-specific condition
- verify the root and `cliext` Go modules remain tidy
- remove two stale `ui-server/v2 v2.50.1` checksums exposed by the initial tidy run

## Why

GitHub merge queues test synthetic `merge_group` commits. Required workflows that only listen for `pull_request` do not create checks for those commits, leaving queued pull requests blocked until timeout.

The server-version job also used `github.base_ref`, which is populated for pull requests but not merge groups. Explicitly accepting the `merge_group` event ensures the validation actually runs on the queued commit.

The tidy check provides additional protection for dependency updates that merge without a textual conflict but leave module metadata inconsistent.

## Validation
- end-to-end queue test in `chaptersix-org/temporal-cli`: GitHub created a `gh-readonly-queue/main/...` ref, triggered both workflows, ran Validate Server Version, and merged the test PR through the queue

Sandbox evidence:

- https://github.com/chaptersix-org/temporal-cli/pull/1
- https://github.com/chaptersix-org/temporal-cli/actions/runs/29164112024
- https://github.com/chaptersix-org/temporal-cli/actions/runs/29164112020
