### PR TITLE
Render links on activity describe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c // indirect
 	github.com/cactus/go-statsd-client/v5 v5.1.0 // indirect
+	github.com/caio/go-tdigest/v5 v5.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
@@ -187,6 +188,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.57.0 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c // indirect
 	github.com/cactus/go-statsd-client/v5 v5.1.0 // indirect
-	github.com/caio/go-tdigest/v5 v5.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
@@ -188,7 +187,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.57.0 // indirect
-	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect

--- a/internal/temporalcli/commands.activity.go
+++ b/internal/temporalcli/commands.activity.go
@@ -470,35 +470,10 @@ func printActivityDescription(cctx *CommandContext, resp *workflowservice.Descri
 	if err := cctx.Printer.PrintStructured(d, printer.StructuredOptions{}); err != nil {
 		return err
 	}
-	return printActivityCallbacks(cctx, resp.GetCallbacks())
-}
-
-func printActivityCallbacks(cctx *CommandContext, callbacks []*activitypb.CallbackInfo) error {
-	if len(callbacks) == 0 {
-		return nil
+	if err := printLinks(cctx, info.GetLinks()); err != nil {
+		return err
 	}
-	rows := make([]struct {
-		State                   string
-		Attempt                 int32
-		RegistrationTime        time.Time `cli:",cardOmitEmpty"`
-		NextAttemptScheduleTime time.Time `cli:",cardOmitEmpty"`
-		BlockedReason           string    `cli:",cardOmitEmpty"`
-		LastAttemptFailure      string    `cli:",cardOmitEmpty"`
-	}, len(callbacks))
-	for i, cb := range callbacks {
-		info := cb.GetInfo()
-		rows[i].State = info.GetState().String()
-		rows[i].Attempt = info.GetAttempt()
-		rows[i].RegistrationTime = timestampToTime(info.GetRegistrationTime())
-		rows[i].NextAttemptScheduleTime = timestampToTime(info.GetNextAttemptScheduleTime())
-		rows[i].BlockedReason = info.GetBlockedReason()
-		if f := info.GetLastAttemptFailure(); f != nil {
-			rows[i].LastAttemptFailure = cctx.MarshalFriendlyFailureBodyText(f, "    ")
-		}
-	}
-	cctx.Printer.Println()
-	cctx.Printer.Println(color.MagentaString("Callbacks:"))
-	return cctx.Printer.PrintStructured(rows, printer.StructuredOptions{Table: &printer.TableOptions{}})
+	return printCallbacks(cctx, resp.GetCallbacks())
 }
 
 func (c *TemporalActivityListCommand) run(cctx *CommandContext, args []string) error {

--- a/internal/temporalcli/commands.go
+++ b/internal/temporalcli/commands.go
@@ -22,10 +22,14 @@ import (
 	"github.com/temporalio/cli/cliext"
 	"github.com/temporalio/cli/internal/printer"
 	"github.com/temporalio/ui-server/v2/server/version"
+	activitypb "go.temporal.io/api/activity/v1"
 	"go.temporal.io/api/common/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/temporalnexus"
 	"go.temporal.io/api/temporalproto"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/sdk/contrib/envconfig"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
@@ -604,6 +608,123 @@ func timestampToTime(t *timestamppb.Timestamp) time.Time {
 		return time.Time{}
 	}
 	return t.AsTime()
+}
+
+// nexusLinkStrings converts Temporal common links into their Nexus link URL
+// string representations, skipping any link variant that has no Nexus
+// equivalent. The conversion helpers live in go.temporal.io/api/temporalnexus
+// (previously in the Go SDK's temporalnexus package).
+func nexusLinkStrings(links []*commonpb.Link) []string {
+	var out []string
+	for _, link := range links {
+		switch {
+		case link.GetWorkflowEvent() != nil:
+			out = append(out, temporalnexus.ConvertLinkWorkflowEventToNexusLink(link.GetWorkflowEvent()).URL.String())
+		case link.GetNexusOperation() != nil:
+			out = append(out, temporalnexus.ConvertLinkNexusOperationToNexusLink(link.GetNexusOperation()).URL.String())
+		case link.GetActivity() != nil:
+			out = append(out, temporalnexus.ConvertLinkActivityToNexusLink(link.GetActivity()).URL.String())
+		}
+	}
+	return out
+}
+
+// printLinks renders Temporal common links as a standalone Nexus links section.
+// Nothing is printed when none of the links have a Nexus representation.
+func printLinks(cctx *CommandContext, links []*commonpb.Link) error {
+	urls := nexusLinkStrings(links)
+	if len(urls) == 0 {
+		return nil
+	}
+	rows := make([]struct {
+		Link string
+	}, len(urls))
+	for i, url := range urls {
+		rows[i].Link = url
+	}
+	cctx.Printer.Println()
+	cctx.Printer.Println(color.MagentaString("Links: %v", len(urls)))
+	cctx.Printer.Println()
+	return cctx.Printer.PrintStructured(rows, printer.StructuredOptions{})
+}
+
+// callbackInfoForPrint is the subset of accessors shared by workflow.v1.CallbackInfo
+// and callback.v1.CallbackInfo (the latter nested inside activity.v1.CallbackInfo).
+// It lets the workflow and activity describe commands render callbacks through a
+// single code path (printCallbacks).
+type callbackInfoForPrint interface {
+	GetCallback() *commonpb.Callback
+	GetState() enums.CallbackState
+	GetAttempt() int32
+	GetRegistrationTime() *timestamppb.Timestamp
+	GetNextAttemptScheduleTime() *timestamppb.Timestamp
+	GetLastAttemptCompleteTime() *timestamppb.Timestamp
+	GetLastAttemptFailure() *failure.Failure
+	GetBlockedReason() string
+}
+
+type callbackForPrint interface {
+	*workflowpb.CallbackInfo | *activitypb.CallbackInfo
+}
+
+func normalizeCallbackForPrint[T callbackForPrint](cb T) (callbackInfoForPrint, string) {
+	switch cb := any(cb).(type) {
+	case *workflowpb.CallbackInfo:
+		trigger := "Unknown"
+		if cb.GetTrigger().GetWorkflowClosed() != nil {
+			trigger = "WorkflowClosed"
+		}
+		return cb, trigger
+	case *activitypb.CallbackInfo:
+		trigger := "Unknown"
+		if cb.GetTrigger().GetActivityClosed() != nil {
+			trigger = "ActivityClosed"
+		}
+		return cb.GetInfo(), trigger
+	default:
+		panic("unsupported callback type")
+	}
+}
+
+// printCallbacks renders the "Callbacks: N" section shared by the workflow and
+// activity describe commands. Nothing is printed when there are no callbacks.
+// This is only reached for text output; JSON output prints the raw describe
+// response instead.
+func printCallbacks[T callbackForPrint](cctx *CommandContext, callbacks []T) error {
+	if len(callbacks) == 0 {
+		return nil
+	}
+	rows := make([]struct {
+		URL                     string
+		Links                   []string `cli:",cardOmitEmpty"`
+		Trigger                 string
+		State                   enums.CallbackState
+		Attempt                 int32
+		RegistrationTime        time.Time `cli:",cardOmitEmpty"`
+		NextAttemptScheduleTime time.Time `cli:",cardOmitEmpty"`
+		LastAttemptCompleteTime time.Time `cli:",cardOmitEmpty"`
+		BlockedReason           string    `cli:",cardOmitEmpty"`
+		LastAttemptFailure      string    `cli:",cardOmitEmpty"`
+	}, len(callbacks))
+	for i, cb := range callbacks {
+		ci, trigger := normalizeCallbackForPrint(cb)
+		rows[i].URL = ci.GetCallback().GetNexus().GetUrl()
+		rows[i].Links = nexusLinkStrings(ci.GetCallback().GetLinks())
+		rows[i].Trigger = trigger
+		rows[i].State = ci.GetState()
+		rows[i].Attempt = ci.GetAttempt()
+		rows[i].RegistrationTime = timestampToTime(ci.GetRegistrationTime())
+		rows[i].NextAttemptScheduleTime = timestampToTime(ci.GetNextAttemptScheduleTime())
+		rows[i].LastAttemptCompleteTime = timestampToTime(ci.GetLastAttemptCompleteTime())
+		rows[i].BlockedReason = ci.GetBlockedReason()
+		if f := ci.GetLastAttemptFailure(); f != nil {
+			rows[i].LastAttemptFailure = cctx.MarshalFriendlyFailureBodyText(f, "    ")
+		}
+	}
+	cctx.Printer.Println()
+	cctx.Printer.Println(color.MagentaString("Callbacks: %v", len(callbacks)))
+	cctx.Printer.Println()
+	return cctx.Printer.PrintStructured(rows, printer.StructuredOptions{})
 }
 
 type nopWriter struct{}

--- a/internal/temporalcli/commands.go
+++ b/internal/temporalcli/commands.go
@@ -617,13 +617,8 @@ func timestampToTime(t *timestamppb.Timestamp) time.Time {
 func nexusLinkStrings(links []*commonpb.Link) []string {
 	var out []string
 	for _, link := range links {
-		switch {
-		case link.GetWorkflowEvent() != nil:
-			out = append(out, temporalnexus.ConvertLinkWorkflowEventToNexusLink(link.GetWorkflowEvent()).URL.String())
-		case link.GetNexusOperation() != nil:
-			out = append(out, temporalnexus.ConvertLinkNexusOperationToNexusLink(link.GetNexusOperation()).URL.String())
-		case link.GetActivity() != nil:
-			out = append(out, temporalnexus.ConvertLinkActivityToNexusLink(link.GetActivity()).URL.String())
+		if nexusLink, ok := temporalnexus.CommonLinkToNexusLink(link); ok {
+			out = append(out, nexusLink.GetUrl())
 		}
 	}
 	return out

--- a/internal/temporalcli/commands.link_test.go
+++ b/internal/temporalcli/commands.link_test.go
@@ -1,0 +1,161 @@
+package temporalcli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/cli/internal/printer"
+	activitypb "go.temporal.io/api/activity/v1"
+	callbackpb "go.temporal.io/api/callback/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+)
+
+func workflowEventLink() *commonpb.Link {
+	return &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestNexusLinkStrings verifies that nexusLinkStrings converts workflow-event,
+// nexus-operation, and activity common links into their Nexus link URLs using
+// the converters that now live in go.temporal.io/api/temporalnexus, and skips
+// variants that have no Nexus equivalent.
+func TestNexusLinkStrings(t *testing.T) {
+	activityLink := &commonpb.Link{
+		Variant: &commonpb.Link_Activity_{
+			Activity: &commonpb.Link_Activity{
+				Namespace:  "ns",
+				ActivityId: "act-id",
+				RunId:      "run-id",
+			},
+		},
+	}
+	nexusOperationLink := &commonpb.Link{
+		Variant: &commonpb.Link_NexusOperation_{
+			NexusOperation: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op-id",
+				RunId:       "run-id",
+			},
+		},
+	}
+	// A link with an unset (unsupported) variant, which must be skipped.
+	otherLink := &commonpb.Link{}
+
+	t.Run("nil and empty", func(t *testing.T) {
+		require.Nil(t, nexusLinkStrings(nil))
+		require.Nil(t, nexusLinkStrings([]*commonpb.Link{}))
+	})
+
+	t.Run("workflow event link", func(t *testing.T) {
+		got := nexusLinkStrings([]*commonpb.Link{workflowEventLink()})
+		require.Equal(t, []string{
+			"temporal:///namespaces/ns/workflows/wf-id/run-id/history?eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		}, got)
+	})
+
+	t.Run("activity and nexus operation links", func(t *testing.T) {
+		got := nexusLinkStrings([]*commonpb.Link{activityLink, nexusOperationLink})
+		require.Len(t, got, 2)
+		require.Contains(t, got[0], "temporal://")
+		require.Contains(t, got[0], "act-id")
+		require.Contains(t, got[1], "temporal://")
+		require.Contains(t, got[1], "op-id")
+	})
+
+	t.Run("skips unsupported variants and preserves order", func(t *testing.T) {
+		got := nexusLinkStrings([]*commonpb.Link{otherLink, workflowEventLink(), otherLink})
+		require.Len(t, got, 1)
+		require.Contains(t, got[0], "wf-id")
+	})
+}
+
+// TestPrintActivityDescription_LinksAndCallbacks verifies that activity describe
+// renders the activity's Nexus links and its callbacks (including callback URL,
+// links, and trigger) like workflow describe does.
+func TestPrintActivityDescription_LinksAndCallbacks(t *testing.T) {
+	var buf bytes.Buffer
+	cctx := &CommandContext{Printer: &printer.Printer{Output: &buf}}
+
+	resp := &workflowservice.DescribeActivityExecutionResponse{
+		Info: &activitypb.ActivityExecutionInfo{
+			ActivityId:   "act-1",
+			RunId:        "run-1",
+			ActivityType: &commonpb.ActivityType{Name: "MyActivity"},
+			Status:       enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+			TaskQueue:    "tq",
+			Attempt:      1,
+			Links:        []*commonpb.Link{workflowEventLink()},
+		},
+		Callbacks: []*activitypb.CallbackInfo{
+			{
+				Trigger: &activitypb.CallbackInfo_Trigger{
+					Variant: &activitypb.CallbackInfo_Trigger_ActivityClosed{
+						ActivityClosed: &activitypb.CallbackInfo_ActivityClosed{},
+					},
+				},
+				Info: &callbackpb.CallbackInfo{
+					Callback: &commonpb.Callback{
+						Variant: &commonpb.Callback_Nexus_{
+							Nexus: &commonpb.Callback_Nexus{Url: "http://callback.example/cb"},
+						},
+						Links: []*commonpb.Link{workflowEventLink()},
+					},
+					State:   enumspb.CALLBACK_STATE_SUCCEEDED,
+					Attempt: 2,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, printActivityDescription(cctx, resp))
+	out := buf.String()
+
+	// Execution info.
+	require.Contains(t, out, "act-1")
+	require.Contains(t, out, "MyActivity")
+	// Top-level activity Links section.
+	require.Contains(t, out, "Links: 1")
+	require.Contains(t, out, "temporal:///namespaces/ns/workflows/wf-id/run-id/history")
+	// Callbacks section with URL, trigger, link, and state.
+	require.Contains(t, out, "Callbacks: 1")
+	require.Contains(t, out, "http://callback.example/cb")
+	require.Contains(t, out, "ActivityClosed")
+	require.Contains(t, out, "Succeeded")
+}
+
+func TestPrintNexusOperationDescription_Links(t *testing.T) {
+	var buf bytes.Buffer
+	cctx := &CommandContext{Printer: &printer.Printer{Output: &buf}}
+
+	desc := &client.NexusOperationExecutionDescription{
+		RawInfo: &nexuspb.NexusOperationExecutionInfo{
+			Links: []*commonpb.Link{workflowEventLink()},
+		},
+	}
+	desc.OperationID = "op-1"
+	desc.OperationRunID = "run-1"
+
+	require.NoError(t, printNexusOperationDescription(cctx, desc))
+	out := buf.String()
+	require.Contains(t, out, "op-1")
+	require.Contains(t, out, "Links: 1")
+	require.Contains(t, out, "temporal:///namespaces/ns/workflows/wf-id/run-id/history")
+}

--- a/internal/temporalcli/commands.link_test.go
+++ b/internal/temporalcli/commands.link_test.go
@@ -33,10 +33,9 @@ func workflowEventLink() *commonpb.Link {
 	}
 }
 
-// TestNexusLinkStrings verifies that nexusLinkStrings converts workflow-event,
-// nexus-operation, and activity common links into their Nexus link URLs using
-// the converters that now live in go.temporal.io/api/temporalnexus, and skips
-// variants that have no Nexus equivalent.
+// TestNexusLinkStrings verifies that nexusLinkStrings converts supported common
+// links into their Nexus link URLs and skips variants that have no Nexus
+// equivalent.
 func TestNexusLinkStrings(t *testing.T) {
 	activityLink := &commonpb.Link{
 		Variant: &commonpb.Link_Activity_{
@@ -53,6 +52,16 @@ func TestNexusLinkStrings(t *testing.T) {
 				Namespace:   "ns",
 				OperationId: "op-id",
 				RunId:       "run-id",
+			},
+		},
+	}
+	workflowLink := &commonpb.Link{
+		Variant: &commonpb.Link_Workflow_{
+			Workflow: &commonpb.Link_Workflow{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reason:     "started activity",
 			},
 		},
 	}
@@ -78,6 +87,13 @@ func TestNexusLinkStrings(t *testing.T) {
 		require.Contains(t, got[0], "act-id")
 		require.Contains(t, got[1], "temporal://")
 		require.Contains(t, got[1], "op-id")
+	})
+
+	t.Run("workflow link", func(t *testing.T) {
+		got := nexusLinkStrings([]*commonpb.Link{workflowLink})
+		require.Equal(t, []string{
+			"temporal:///namespaces/ns/workflows/wf-id/run-id?reason=started+activity",
+		}, got)
 	})
 
 	t.Run("skips unsupported variants and preserves order", func(t *testing.T) {

--- a/internal/temporalcli/commands.nexus_operation.go
+++ b/internal/temporalcli/commands.nexus_operation.go
@@ -302,7 +302,10 @@ func printNexusOperationDescription(cctx *CommandContext, desc *client.NexusOper
 		Identity:               desc.Identity,
 		Summary:                summary,
 	}
-	return cctx.Printer.PrintStructured(d, printer.StructuredOptions{})
+	if err := cctx.Printer.PrintStructured(d, printer.StructuredOptions{}); err != nil {
+		return err
+	}
+	return printLinks(cctx, desc.RawInfo.GetLinks())
 }
 
 func (c *TemporalNexusOperationCancelCommand) run(cctx *CommandContext, args []string) error {

--- a/internal/temporalcli/commands.workflow_view.go
+++ b/internal/temporalcli/commands.workflow_view.go
@@ -15,8 +15,6 @@ import (
 	"go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
-
-	"go.temporal.io/sdk/temporalnexus"
 )
 
 func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []string) error {
@@ -251,44 +249,8 @@ func (c *TemporalWorkflowDescribeCommand) run(cctx *CommandContext, args []strin
 		}, printer.StructuredOptions{})
 	}
 
-	if len(resp.Callbacks) > 0 {
-		cctx.Printer.Println()
-		cctx.Printer.Println(color.MagentaString("Callbacks: %v", len(resp.Callbacks)))
-		cctx.Printer.Println()
-		cbs := make([]struct {
-			URL                     string
-			Links                   []string
-			Trigger                 string
-			State                   enums.CallbackState
-			Attempt                 int32
-			RegistrationTime        time.Time        `cli:",cardOmitEmpty"`
-			NextAttemptScheduleTime time.Time        `cli:",cardOmitEmpty"`
-			LastAttemptCompleteTime time.Time        `cli:",cardOmitEmpty"`
-			LastAttemptFailure      *failure.Failure `cli:",cardOmitEmpty"`
-			BlockedReason           string           `cli:",cardOmitEmpty"`
-		}, len(resp.Callbacks))
-		for i, cb := range resp.Callbacks {
-			cbs[i].URL = cb.GetCallback().GetNexus().GetUrl()
-			for _, link := range cb.GetCallback().GetLinks() {
-				if link.GetWorkflowEvent() != nil {
-					nexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(link.GetWorkflowEvent())
-					cbs[i].Links = append(cbs[i].Links, nexusLink.URL.String())
-				}
-			}
-			cbs[i].State = cb.GetState()
-			cbs[i].Attempt = cb.GetAttempt()
-			cbs[i].LastAttemptFailure = cb.LastAttemptFailure
-			cbs[i].LastAttemptCompleteTime = timestampToTime(cb.LastAttemptCompleteTime)
-			cbs[i].NextAttemptScheduleTime = timestampToTime(cb.NextAttemptScheduleTime)
-			cbs[i].RegistrationTime = timestampToTime(cb.RegistrationTime)
-			cbs[i].Trigger = "Unknown"
-			if cb.GetTrigger().GetWorkflowClosed() != nil {
-				cbs[i].Trigger = "WorkflowClosed"
-			}
-			cbs[i].BlockedReason = cb.GetBlockedReason()
-		}
-		_ = cctx.Printer.PrintStructured(cbs, printer.StructuredOptions{})
-		cctx.Printer.Println()
+	if err := printCallbacks(cctx, resp.Callbacks); err != nil {
+		return err
 	}
 
 	if running {


### PR DESCRIPTION
## Related issues

<!-- Closes #123 -->

## What changed?

Render links on activity describe- #1131

<!-- Describe what this PR does at a high level. -->

## Checklist

<!-- Your PR should satisfy all these requirements. However, feel free to remove items that don't apply to the PR. Consider giving this checklist to an AI agent before opening your PR. -->

**Stability**
- [x] Breaking changes are marked with 💥 in the PR title and release notes
- [x] Changes to JSON output (`-o json` / `-o jsonl`) are treated as breaking changes

**Design**
- [x] This feature does not depend on Cloud-only APIs or behavior (it works against an OSS server)
- [ ] New commands follow `temporal <noun> <verb>` structure (e.g. `temporal workflow start`)
- [ ] New flags are named after the API concept, not the implementation mechanism (good: `--search-attribute`, bad: `--index-field`)
- [ ] New flags don't duplicate an existing flag that serves the same purpose
- [ ] New flags do not have short aliases without strong justification
- [ ] Experimental features are marked with `(Experimental)` in `commands.yaml`

**Help text** (see style guide at the top of `commands.yaml`)
- [ ] All flags shown in help text and examples are implemented and functional
- [ ] Summaries use sentence case and have no trailing period
- [ ] Long descriptions end with a period and include at least one example invocation
- [ ] Examples use long flags (`--namespace`, not `-n`), one flag per line
- [ ] Placeholder values use `YourXxx` form (`YourWorkflowId`, `YourNamespace`)

**Behavior**
- [ ] Results go to stdout; errors and warnings go to stderr
- [ ] Error messages are lowercase with no trailing punctuation

**Tests**
- [ ] Added functional test(s) (`SharedServerSuite`)
- [ ] Added unit test(s) (`func TestXxx`) where applicable

Before:
```
 $ temporal nexus operation describe --operation-id op-1

    OperationId  op-1
    RunId        run-1
    Endpoint     payments
    Service      PaymentService
    Operation    charge
    Status       Running
    State        Started
    Attempt      1
```

  After:
```
  $ temporal nexus operation describe --operation-id op-1

    OperationId  op-1
    RunId        run-1
    Endpoint     payments
    Service      PaymentService
    Operation    charge
    Status       Running
    State        Started
    Attempt      1

  Links: 1
    temporal:///namespaces/default/workflows/payment-workflow/run-1/history?eventID=12&eventType=NexusOperationScheduled&referenceType=EventReference
```


  Before:
```
  $ temporal activity describe --activity-id act-1

  Activity Execution Info:
    ActivityId            act-1
    RunId                 run-1
    Type                  MyActivity
    Status                Running
    TaskQueue             tq
    Attempt               1
    StateTransitionCount  0

  Callbacks:
    STATE      ATTEMPT
    Succeeded  2
```

  After:
```
  $ temporal activity describe --activity-id act-1

  Activity Execution Info:
    ActivityId            act-1
    RunId                 run-1
    Type                  MyActivity
    Status                Running
    TaskQueue             tq
    Attempt               1
    StateTransitionCount  0

  Callbacks: 1

    URL      http://callback.example/cb
    Links
    [temporal:///namespaces/default/workflows/wf-id/run-id/history?eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference]
    Trigger  ActivityClosed
    State    Succeeded
    Attempt  2
```