### PR TITLE
Improve config profile discoverability

### DIFF
--- a/cliext/flags.gen.go
+++ b/cliext/flags.gen.go
@@ -35,7 +35,7 @@ func (v *CommonOptions) BuildFlags(f *pflag.FlagSet) {
 	f.StringVar(&v.Env, "env", "default", "Active environment name (`ENV`).")
 	f.StringVar(&v.EnvFile, "env-file", "", "Path to environment settings file. Defaults to `$HOME/.config/temporalio/temporal.yaml`.")
 	f.StringVar(&v.ConfigFile, "config-file", "", "File path to read TOML config from, defaults to `$CONFIG_PATH/temporalio/temporal.toml` where `$CONFIG_PATH` is defined as `$HOME/.config` on Unix, `$HOME/Library/Application Support` on macOS, and `%AppData%` on Windows.")
-	f.StringVar(&v.Profile, "profile", "", "Profile to use for config file.")
+	f.StringVar(&v.Profile, "profile", "", "Configuration profile to use. Overrides the TEMPORAL_PROFILE environment variable and defaults to \"default\".")
 	f.BoolVar(&v.DisableConfigFile, "disable-config-file", false, "If set, disables loading environment config from config file.")
 	f.BoolVar(&v.DisableConfigEnv, "disable-config-env", false, "If set, disables loading environment config from environment variables.")
 	v.LogLevel = NewFlagStringEnum([]string{"debug", "info", "warn", "error", "never"}, "never")

--- a/cliext/option-sets.yaml
+++ b/cliext/option-sets.yaml
@@ -26,7 +26,9 @@ option-sets:
         implied-env: TEMPORAL_CONFIG_FILE
       - name: profile
         type: string
-        description: Profile to use for config file.
+        description: |
+          Configuration profile to use. Overrides the TEMPORAL_PROFILE environment
+          variable and defaults to "default".
         implied-env: TEMPORAL_PROFILE
       - name: disable-config-file
         type: bool

--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -1145,9 +1145,9 @@ func NewTemporalConfigCommand(cctx *CommandContext, parent *TemporalCommand) *Te
 	s.Command.Use = "config"
 	s.Command.Short = "Manage config files (EXPERIMENTAL)"
 	if hasHighlighting {
-		s.Command.Long = "Config files are TOML files that contain profiles, with each profile\ncontaining configuration for connecting to Temporal.\n\n\x1b[1mtemporal config set \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\x1b[0m\n\nThe default config file path is \x1b[1m$CONFIG_PATH/temporalio/temporal.toml\x1b[0m where\n\x1b[1m$CONFIG_PATH\x1b[0m is defined as \x1b[1m$HOME/.config\x1b[0m on Unix,\n\x1b[1m$HOME/Library/Application Support\x1b[0m on macOS, and \x1b[1m%AppData%\x1b[0m on Windows.\nThis can be overridden with the \x1b[1mTEMPORAL_CONFIG_FILE\x1b[0m environment\nvariable or \x1b[1m--config-file\x1b[0m.\n\nThe default profile is \x1b[1mdefault\x1b[0m. This can be overridden with the\n\x1b[1mTEMPORAL_PROFILE\x1b[0m environment variable or \x1b[1m--profile\x1b[0m."
+		s.Command.Long = "Config files are TOML files that contain profiles, with each profile\ncontaining configuration for connecting to Temporal.\n\n\x1b[1mtemporal config set \\\n    --profile YourProfile \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\x1b[0m\n\nThe default config file path is \x1b[1m$CONFIG_PATH/temporalio/temporal.toml\x1b[0m where\n\x1b[1m$CONFIG_PATH\x1b[0m is defined as \x1b[1m$HOME/.config\x1b[0m on Unix,\n\x1b[1m$HOME/Library/Application Support\x1b[0m on macOS, and \x1b[1m%AppData%\x1b[0m on Windows.\nThis can be overridden with the \x1b[1mTEMPORAL_CONFIG_FILE\x1b[0m environment\nvariable or \x1b[1m--config-file\x1b[0m.\n\nThe default profile is \x1b[1mdefault\x1b[0m. This can be overridden with the\n\x1b[1mTEMPORAL_PROFILE\x1b[0m environment variable or \x1b[1m--profile\x1b[0m."
 	} else {
-		s.Command.Long = "Config files are TOML files that contain profiles, with each profile\ncontaining configuration for connecting to Temporal.\n\n```\ntemporal config set \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\n```\n\nThe default config file path is `$CONFIG_PATH/temporalio/temporal.toml` where\n`$CONFIG_PATH` is defined as `$HOME/.config` on Unix,\n`$HOME/Library/Application Support` on macOS, and `%AppData%` on Windows.\nThis can be overridden with the `TEMPORAL_CONFIG_FILE` environment\nvariable or `--config-file`.\n\nThe default profile is `default`. This can be overridden with the\n`TEMPORAL_PROFILE` environment variable or `--profile`."
+		s.Command.Long = "Config files are TOML files that contain profiles, with each profile\ncontaining configuration for connecting to Temporal.\n\n```\ntemporal config set \\\n    --profile YourProfile \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\n```\n\nThe default config file path is `$CONFIG_PATH/temporalio/temporal.toml` where\n`$CONFIG_PATH` is defined as `$HOME/.config` on Unix,\n`$HOME/Library/Application Support` on macOS, and `%AppData%` on Windows.\nThis can be overridden with the `TEMPORAL_CONFIG_FILE` environment\nvariable or `--config-file`.\n\nThe default profile is `default`. This can be overridden with the\n`TEMPORAL_PROFILE` environment variable or `--profile`."
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.AddCommand(&NewTemporalConfigDeleteCommand(cctx, &s).Command)
@@ -1171,9 +1171,9 @@ func NewTemporalConfigDeleteCommand(cctx *CommandContext, parent *TemporalConfig
 	s.Command.Use = "delete [flags]"
 	s.Command.Short = "Delete a config file property (EXPERIMENTAL)\n"
 	if hasHighlighting {
-		s.Command.Long = "Remove a property within a profile.\n\n\x1b[1mtemporal config delete \\\n    --prop tls.client_cert_path\x1b[0m"
+		s.Command.Long = "Remove a property within a profile.\n\n\x1b[1mtemporal config delete \\\n    --profile YourProfile \\\n    --prop tls.client_cert_path\x1b[0m"
 	} else {
-		s.Command.Long = "Remove a property within a profile.\n\n```\ntemporal config delete \\\n    --prop tls.client_cert_path\n```"
+		s.Command.Long = "Remove a property within a profile.\n\n```\ntemporal config delete \\\n    --profile YourProfile \\\n    --prop tls.client_cert_path\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.Prop, "prop", "p", "", "Specific property to delete. If unset, deletes entire profile. Required.")
@@ -1198,9 +1198,9 @@ func NewTemporalConfigDeleteProfileCommand(cctx *CommandContext, parent *Tempora
 	s.Command.Use = "delete-profile [flags]"
 	s.Command.Short = "Delete an entire config profile (EXPERIMENTAL)\n"
 	if hasHighlighting {
-		s.Command.Long = "Remove a full profile entirely. The \x1b[1m--profile\x1b[0m must be set explicitly.\n\n\x1b[1mtemporal config delete-profile \\\n    --profile my-profile\x1b[0m"
+		s.Command.Long = "Remove a full profile entirely. The \x1b[1m--profile\x1b[0m must be set explicitly.\n\n\x1b[1mtemporal config delete-profile \\\n    --profile YourProfile\x1b[0m"
 	} else {
-		s.Command.Long = "Remove a full profile entirely. The `--profile` must be set explicitly.\n\n```\ntemporal config delete-profile \\\n    --profile my-profile\n```"
+		s.Command.Long = "Remove a full profile entirely. The `--profile` must be set explicitly.\n\n```\ntemporal config delete-profile \\\n    --profile YourProfile\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Run = func(c *cobra.Command, args []string) {
@@ -1224,9 +1224,9 @@ func NewTemporalConfigGetCommand(cctx *CommandContext, parent *TemporalConfigCom
 	s.Command.Use = "get [flags]"
 	s.Command.Short = "Show config file properties (EXPERIMENTAL)"
 	if hasHighlighting {
-		s.Command.Long = "Display specific properties or the entire profile.\n\n\x1b[1mtemporal config get \\\n    --prop address\x1b[0m\n\nor\n\n\x1b[1mtemporal config get\x1b[0m"
+		s.Command.Long = "Display specific properties or the entire profile.\n\n\x1b[1mtemporal config get \\\n    --profile YourProfile \\\n    --prop address\x1b[0m\n\nor\n\n\x1b[1mtemporal config get\x1b[0m"
 	} else {
-		s.Command.Long = "Display specific properties or the entire profile.\n\n```\ntemporal config get \\\n    --prop address\n```\n\nor\n\n```\ntemporal config get\n```"
+		s.Command.Long = "Display specific properties or the entire profile.\n\n```\ntemporal config get \\\n    --profile YourProfile \\\n    --prop address\n```\n\nor\n\n```\ntemporal config get\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.Prop, "prop", "p", "", "Specific property to get.")
@@ -1277,9 +1277,9 @@ func NewTemporalConfigSetCommand(cctx *CommandContext, parent *TemporalConfigCom
 	s.Command.Use = "set [flags]"
 	s.Command.Short = "Set config file properties (EXPERIMENTAL)"
 	if hasHighlighting {
-		s.Command.Long = "Assign a value to a property and store it in the config file:\n\n\x1b[1mtemporal config set \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\x1b[0m"
+		s.Command.Long = "Assign a value to a property and store it in the config file:\n\n\x1b[1mtemporal config set \\\n    --profile YourProfile \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\x1b[0m"
 	} else {
-		s.Command.Long = "Assign a value to a property and store it in the config file:\n\n```\ntemporal config set \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\n```"
+		s.Command.Long = "Assign a value to a property and store it in the config file:\n\n```\ntemporal config set \\\n    --profile YourProfile \\\n    --prop address \\\n    --value us-west-2.aws.api.temporal.io:7233\n```"
 	}
 	s.Command.Args = cobra.NoArgs
 	s.Command.Flags().StringVarP(&s.Prop, "prop", "p", "", "Property name. Required.")

--- a/internal/temporalcli/commands.help_test.go
+++ b/internal/temporalcli/commands.help_test.go
@@ -44,6 +44,28 @@ func TestHelp_WithValueFlag(t *testing.T) {
 	}
 }
 
+func TestHelp_ConfigProfileExamples(t *testing.T) {
+	h := NewCommandHarness(t)
+
+	for _, args := range [][]string{
+		{"config", "--help"},
+		{"config", "get", "--help"},
+		{"config", "set", "--help"},
+		{"config", "delete", "--help"},
+		{"config", "delete-profile", "--help"},
+	} {
+		res := h.Execute(args...)
+		require.Contains(t, res.Stdout.String(), "--profile YourProfile", strings.Join(args[:2], " "))
+		require.NoError(t, res.Err)
+	}
+
+	res := h.Execute("config", "list", "--help")
+	descriptionAndExamples := strings.SplitN(res.Stdout.String(), "\nUsage:", 2)
+	require.Len(t, descriptionAndExamples, 2)
+	require.NotContains(t, descriptionAndExamples[0], "--profile")
+	require.NoError(t, res.Err)
+}
+
 func TestHelp_HelpShowsAllFlag(t *testing.T) {
 	h := NewCommandHarness(t)
 	res := h.Execute("help", "--help")

--- a/internal/temporalcli/commands.server_test.go
+++ b/internal/temporalcli/commands.server_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/cli/internal/devserver"
@@ -316,9 +317,10 @@ func TestServer_StartDev_BannerPersistenceFile(t *testing.T) {
 
 	port := strconv.Itoa(devserver.MustGetFreePort("127.0.0.1"))
 	httpPort := strconv.Itoa(devserver.MustGetFreePort("127.0.0.1"))
-	// Use os.TempDir with an explicit defer-remove so Windows file-lock cleanup
-	// (os.RemoveAll in t.TempDir) does not race with a still-open SQLite handle.
-	dbFilename := filepath.Join(os.TempDir(), "devserver-banner-"+t.Name()+".sqlite")
+	// Use a unique file in os.TempDir to isolate repeated invocations from prior
+	// SQLite state. Explicit cleanup avoids making t.TempDir's os.RemoveAll race
+	// a still-open SQLite handle on Windows.
+	dbFilename := filepath.Join(os.TempDir(), "devserver-banner-"+uuid.NewString()+".sqlite")
 	t.Cleanup(func() {
 		_ = os.Remove(dbFilename)
 		_ = os.Remove(dbFilename + "-shm")
@@ -331,7 +333,8 @@ func TestServer_StartDev_BannerPersistenceFile(t *testing.T) {
 	}()
 
 	var cl client.Client
-	// File-backed server takes longer to start due to SQLite initialization.
+	// File-backed server takes longer to start due to SQLite initialization,
+	// especially on slower Windows CI runners.
 	h.EventuallyWithT(func(t *assert.CollectT) {
 		select {
 		case res := <-resCh:
@@ -342,7 +345,7 @@ func TestServer_StartDev_BannerPersistenceFile(t *testing.T) {
 		var err error
 		cl, err = client.Dial(client.Options{HostPort: "127.0.0.1:" + port})
 		assert.NoError(t, err)
-	}, 15*time.Second, 200*time.Millisecond)
+	}, 30*time.Second, 200*time.Millisecond)
 	defer cl.Close()
 
 	h.CancelContext()

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -801,6 +801,7 @@ commands:
 
       ```
       temporal config set \
+          --profile YourProfile \
           --prop address \
           --value us-west-2.aws.api.temporal.io:7233
       ```
@@ -839,6 +840,7 @@ commands:
 
       ```
       temporal config delete \
+          --profile YourProfile \
           --prop tls.client_cert_path
       ```
     options:
@@ -857,7 +859,7 @@ commands:
 
       ```
       temporal config delete-profile \
-          --profile my-profile
+          --profile YourProfile
       ```
 
   - name: temporal config get
@@ -867,6 +869,7 @@ commands:
 
       ```
       temporal config get \
+          --profile YourProfile \
           --prop address
       ```
 
@@ -897,6 +900,7 @@ commands:
 
       ```
       temporal config set \
+          --profile YourProfile \
           --prop address \
           --value us-west-2.aws.api.temporal.io:7233
       ```


### PR DESCRIPTION
## Summary
- Clarify `--profile` precedence and its default value in shared help text.
- Add `--profile YourProfile` to the parent and profile-sensitive `temporal config` examples.
- Keep `temporal config list` profile-agnostic.

## Demo
![Highlighted config profile help examples](https://vhs.charm.sh/vhs-7fCNsoA4L7csjkmNGmJ3lU.gif)

## Follow-up
- [ ] Open a separate PR in `temporalio/cloud-cli` adding `temporal cloud login --profile YourProfile` to the login help example.

## Test plan
- [x] `go test ./internal/commandsgen ./internal/temporalcli -count=1`
- [x] `go build ./cmd/temporal`
- [x] Generated command and flag files reproduce exactly.
- [x] `git diff --check`