### PR TITLE
Fix inverted `--yes` description on `operator namespace delete`

### DIFF
--- a/internal/temporalcli/commands.gen.go
+++ b/internal/temporalcli/commands.gen.go
@@ -2010,7 +2010,7 @@ func NewTemporalOperatorNamespaceDeleteCommand(cctx *CommandContext, parent *Tem
 		s.Command.Long = "Removes a Namespace from the Service.\n\n```\ntemporal operator namespace delete [options]\n```\n\nFor example:\n\n```\ntemporal operator namespace delete \\\n    --namespace YourNamespaceName\n```"
 	}
 	s.Command.Args = cobra.MaximumNArgs(1)
-	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Request confirmation before deletion.")
+	s.Command.Flags().BoolVarP(&s.Yes, "yes", "y", false, "Don't prompt to confirm deletion.")
 	s.Command.Run = func(c *cobra.Command, args []string) {
 		if err := s.run(cctx, args); err != nil {
 			cctx.Options.Fail(err)

--- a/internal/temporalcli/commands.yaml
+++ b/internal/temporalcli/commands.yaml
@@ -2355,7 +2355,7 @@ commands:
       - name: yes
         short: y
         type: bool
-        description: Request confirmation before deletion.
+        description: Don't prompt to confirm deletion.
 
   - name: temporal operator namespace describe
     summary: Describe a Namespace


### PR DESCRIPTION
## Related issues

Closes #1142

## What changed?

`temporal operator namespace delete` documented `-y, --yes` as **"Request confirmation before deletion."** It does the opposite — it supplies the confirmation so the delete runs unattended. The behavior is correct and unchanged; only the description was wrong.

New wording matches the other 16 `--yes` flags in `commands.yaml`, all of which use "Don't prompt to confirm …". This was the only one that deviated. Repro and detail in #1142.

No test added: the description is display-only metadata with no execution path, which is also why this survived — it can't fail a test, a build, or a review of the Go.

⚠️ **`commands.gen.go` was hand-applied, not regenerated** (no Go toolchain on this machine). The string appears exactly once as a plain literal, so it should be byte-identical to generator output — the `Regen code, confirm unchanged` CI step will confirm.