### PR TITLE
Reject update-options --start-delay for workflow Activities

### DIFF
--- a/internal/temporalcli/commands.activity.go
+++ b/internal/temporalcli/commands.activity.go
@@ -905,6 +905,10 @@ func (c *TemporalActivityUpdateOptionsCommand) run(cctx *CommandContext, args []
 	}
 
 	if c.Command.Flags().Changed("start-delay") {
+		if c.WorkflowId != "" || c.Query != "" {
+			return errors.New("--start-delay is only supported for Standalone Activities, " +
+				"so it cannot be used with --workflow-id or --query")
+		}
 		activityOptions.StartDelay = durationpb.New(c.StartDelay.Duration())
 		updatePath = append(updatePath, "start_delay")
 	}

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -440,12 +440,10 @@ func (s *SharedServerSuite) TestActivityStandalone_UpdateOptions_StartDelay() {
 }
 
 func (s *SharedServerSuite) TestActivityUpdateOptions_StartDelayRejectedForWorkflowActivity() {
-	run := s.waitActivityStarted()
-
 	res := s.Execute(
 		"activity", "update-options",
 		"--activity-id", activityId,
-		"--workflow-id", run.GetID(),
+		"--workflow-id", "anything",
 		"--start-delay", "30s",
 		"--address", s.Address(),
 	)
@@ -454,7 +452,7 @@ func (s *SharedServerSuite) TestActivityUpdateOptions_StartDelayRejectedForWorkf
 
 	res = s.Execute(
 		"activity", "update-options",
-		"--query", fmt.Sprintf("WorkflowId = '%s'", run.GetID()),
+		"--query", "anything",
 		"--start-delay", "30s",
 		"--yes",
 		"--address", s.Address(),

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -439,6 +439,30 @@ func (s *SharedServerSuite) TestActivityStandalone_UpdateOptions_StartDelay() {
 	s.Eventually(started.Load, 2*time.Second, 100*time.Millisecond)
 }
 
+func (s *SharedServerSuite) TestActivityUpdateOptions_StartDelayRejectedForWorkflowActivity() {
+	run := s.waitActivityStarted()
+
+	res := s.Execute(
+		"activity", "update-options",
+		"--activity-id", activityId,
+		"--workflow-id", run.GetID(),
+		"--start-delay", "30s",
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "--start-delay")
+	s.ErrorContains(res.Err, "--workflow-id")
+
+	res = s.Execute(
+		"activity", "update-options",
+		"--query", fmt.Sprintf("WorkflowId = '%s'", run.GetID()),
+		"--start-delay", "30s",
+		"--yes",
+		"--address", s.Address(),
+	)
+	s.ErrorContains(res.Err, "--start-delay")
+	s.ErrorContains(res.Err, "--query")
+}
+
 func (s *SharedServerSuite) TestActivityStandalone_PauseByActivityIdOnly() {
 	handle, stopFailing := s.startStandaloneActivity(newStandaloneActivityID())
 	defer stopFailing()


### PR DESCRIPTION
## What changed?
Reject update-options --start-delay for workflow Activities

**Tests**
- [x] Added functional test(s) (`SharedServerSuite`)
