### PR TITLE
fix(activity): include options in batch update-options

### DIFF
--- a/internal/temporalcli/commands.activity.go
+++ b/internal/temporalcli/commands.activity.go
@@ -1015,8 +1015,9 @@ func (c *TemporalActivityUpdateOptionsCommand) run(cctx *CommandContext, args []
 		_ = cctx.Printer.PrintStructured(updatedOptions, printer.StructuredOptions{})
 	} else {
 		updateActivitiesOperation := &batch.BatchOperationUpdateActivityOptions{
-			Identity: c.Parent.Identity,
-			Activity: &batch.BatchOperationUpdateActivityOptions_MatchAll{MatchAll: true},
+			Identity:        c.Parent.Identity,
+			Activity:        &batch.BatchOperationUpdateActivityOptions_MatchAll{MatchAll: true},
+			ActivityOptions: activityOptions,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: updatePath,
 			},

--- a/internal/temporalcli/commands.activity_test.go
+++ b/internal/temporalcli/commands.activity_test.go
@@ -188,6 +188,39 @@ func (s *SharedServerSuite) TestActivityOptionsUpdate_Partial() {
 	s.ContainsOnSameLine(out, "BackoffCoefficient", "2")
 }
 
+func (s *SharedServerSuite) TestActivityOptionsUpdate_BatchMatchAll() {
+	run1 := s.waitActivityStarted()
+	run2 := s.waitActivityStarted()
+	query := fmt.Sprintf("WorkflowId = '%s' OR WorkflowId = '%s'", run1.GetID(), run2.GetID())
+
+	// Wait for both Workflow Executions to be visible to the batch query.
+	s.Eventually(func() bool {
+		resp, err := s.Client.ListWorkflow(s.Context, &workflowservice.ListWorkflowExecutionsRequest{
+			Query: query,
+		})
+		s.NoError(err)
+		return len(resp.Executions) == 2
+	}, 3*time.Second, 100*time.Millisecond)
+
+	res := s.Execute(
+		"activity", "update-options",
+		"--query", query,
+		"--task-queue", "batch-updated-task-queue",
+		"--yes",
+		"--address", s.Address(),
+	)
+	s.NoError(res.Err)
+
+	for _, run := range []client.WorkflowRun{run1, run2} {
+		s.Eventually(func() bool {
+			resp, err := s.Client.DescribeWorkflowExecution(s.Context, run.GetID(), run.GetRunID())
+			s.NoError(err)
+			return len(resp.GetPendingActivities()) == 1 &&
+				resp.GetPendingActivities()[0].GetActivityOptions().GetTaskQueue().GetName() == "batch-updated-task-queue"
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+}
+
 func sendActivityCommand(command string, run client.WorkflowRun, s *SharedServerSuite, extraArgs ...string) *CommandResult {
 	args := []string{
 		"activity", command,


### PR DESCRIPTION
## Related issues

N/A — fixes a regression where batch activity option updates using `--query` and `--task-queue` fail validation.

## What changed?

### Why

The batch `activity update-options` request sent an update mask but omitted `ActivityOptions`, so the server rejected the documented query-based command.

### How

Include the constructed activity options in the batch operation request and add a functional regression test that updates the task queue for activities in two workflows matched
by a visibility query.

### Testing

- Added a `SharedServerSuite` functional test covering `activity update-options --query ... --task-queue ...`.
- Confirmed the new test fails before the fix with the reported validation error.
- Ran `go test ./internal/temporalcli -count=1`.
- Ran `git diff --check`.

## Checklist

- [x] This feature works against an OSS server.
- [x] Added functional test(s) (`SharedServerSuite`).

## Manual tests

**Happy path**

```sh
temporal activity update-options \
    --query 'WorkflowType="YourWorkflowType"' \
    --task-queue YourTaskQueue \
    --yes

Expected output:

Started batch for job ID: <job-id>