### PR TITLE
fix: improve connection diagnostics

### DIFF
--- a/internal/temporalcli/commands.go
+++ b/internal/temporalcli/commands.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/temporalio/cli/cliext"
@@ -154,7 +155,7 @@ func (c *CommandContext) preprocessOptions() error {
 				// to its own error handling logic, and just copy the exit code through.
 				os.Exit(exitError.ExitCode())
 			}
-			if writeConnectionError(c.Options.Stderr, err, !color.NoColor) {
+			if writeConnectionError(c.Options.Stderr, err, c.connectionErrorUsesColor()) {
 				os.Exit(1)
 			}
 			fmt.Fprintf(c.Options.Stderr, "Error: %v\n", err)
@@ -205,6 +206,36 @@ func (c *CommandContext) preprocessOptions() error {
 	}
 
 	return nil
+}
+
+func (c *CommandContext) connectionErrorUsesColor() bool {
+	if c.JSONOutput {
+		return false
+	}
+	colorMode := "auto"
+	if c.RootCommand != nil {
+		colorMode = c.RootCommand.Color.Value
+	}
+	return connectionErrorColorPolicy(colorMode, c.Options.Stderr, writerIsTerminal)
+}
+
+func connectionErrorColorPolicy(colorMode string, stderr io.Writer, isTerminal func(io.Writer) bool) bool {
+	switch colorMode {
+	case "always":
+		return true
+	case "never":
+		return false
+	case "auto":
+		return os.Getenv("NO_COLOR") == "" && os.Getenv("TERM") != "dumb" && isTerminal(stderr)
+	default:
+		return false
+	}
+}
+
+func writerIsTerminal(w io.Writer) bool {
+	type fdWriter interface{ Fd() uintptr }
+	f, ok := w.(fdWriter)
+	return ok && (isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd()))
 }
 
 const flagEnvVarAnnotation = "__temporal_env_var"

--- a/internal/temporalcli/connectdiag.go
+++ b/internal/temporalcli/connectdiag.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 	"syscall"
 	"time"
@@ -32,7 +33,9 @@ const (
 	// completed a TLS handshake when offered one.
 	causeServerSpeaksTLS
 	causeClientCertRequired
+	causeClientCertRejected
 	causeCAVerify
+	causeCertificateVerify
 	causeHostnameMismatch
 	causeCertFileUnreadable
 	causeUnauthenticated
@@ -97,8 +100,8 @@ func diagnoseConnection(ctx context.Context, address string, tlsCfg *tls.Config,
 		return d
 	}
 
-	// Stage: DNS (skipped for IP literals)
-	if net.ParseIP(host) == nil {
+	// Stage: DNS (skipped for IP literals, including scoped IPv6 addresses).
+	if !isIPLiteral(host) {
 		addrs, err := net.DefaultResolver.LookupHost(ctx, host)
 		if err != nil {
 			if d.interrupted(ctx, "DNS") {
@@ -177,7 +180,7 @@ func diagnoseConnection(ctx context.Context, address string, tlsCfg *tls.Config,
 // catch post-handshake rejections: TLS 1.3 servers requiring client
 // certificates complete the handshake first and only then send an alert.
 func (d *connectDiagnosis) probeTLS(ctx context.Context, conn net.Conn, host string, tlsCfg *tls.Config) {
-	cfg := tlsCfg.Clone()
+	cfg := tlsProbeConfig(tlsCfg)
 	if cfg.ServerName == "" && !cfg.InsecureSkipVerify {
 		cfg.ServerName = host
 	}
@@ -221,6 +224,7 @@ func (d *connectDiagnosis) classifyTLSError(err error) {
 	var recordErr tls.RecordHeaderError
 	var certErr *tls.CertificateVerificationError
 	var unknownAuthErr x509.UnknownAuthorityError
+	var invalidCertErr x509.CertificateInvalidError
 	var hostnameErr x509.HostnameError
 	switch {
 	case errors.As(err, &recordErr):
@@ -229,12 +233,18 @@ func (d *connectDiagnosis) classifyTLSError(err error) {
 	case errors.As(err, &hostnameErr):
 		d.fail("TLS handshake failed: server certificate is not valid for this host: " + shortErr(err))
 		d.Cause = causeHostnameMismatch
-	case errors.As(err, &unknownAuthErr), errors.As(err, &certErr):
+	case errors.As(err, &unknownAuthErr):
 		d.fail("TLS handshake failed: cannot verify server certificate: " + shortErr(err))
 		d.Cause = causeCAVerify
+	case errors.As(err, &invalidCertErr), errors.As(err, &certErr):
+		d.fail("TLS handshake failed: server certificate verification failed: " + shortErr(err))
+		d.Cause = causeCertificateVerify
 	case classifyTLSAlert(err) == causeClientCertRequired:
 		d.fail("TLS handshake failed: server requires mTLS, no valid client certificate was provided")
 		d.Cause = causeClientCertRequired
+	case classifyTLSAlert(err) == causeClientCertRejected:
+		d.fail("TLS handshake failed: server rejected the supplied client certificate")
+		d.Cause = causeClientCertRejected
 	default:
 		d.fail("TLS handshake failed: " + shortErr(err))
 		d.Cause = causeUnknown
@@ -242,19 +252,20 @@ func (d *connectDiagnosis) classifyTLSError(err error) {
 	}
 }
 
-// classifyTLSAlert detects remote TLS alerts that explicitly indicate the
-// server required or rejected a client certificate. Go does not export alert
-// types for remote errors, so this matches the alert descriptions crypto/tls
-// emits: alert 116 "certificate required" (TLS 1.3) and alert 42 "bad
-// certificate". Generic alerts such as alert 40 "handshake failure" are not
-// sufficient evidence of mTLS. Matching is scoped to TLS probe errors only;
+// classifyTLSAlert detects remote TLS alerts about client certificates. Go does
+// not export alert types for remote errors, so this matches the descriptions
+// crypto/tls emits: alert 116 "certificate required" (TLS 1.3) and alert 42
+// "bad certificate". Generic alerts such as alert 40 "handshake failure" are
+// not sufficient evidence of mTLS. Matching is scoped to TLS probe errors only;
 // if these strings drift in a future Go release, unit tests pin them and the
 // diagnosis degrades to showing the raw error without a suggestion.
 func classifyTLSAlert(err error) connectCause {
 	msg := err.Error()
-	if strings.Contains(msg, "certificate required") ||
-		strings.Contains(msg, "bad certificate") {
+	if strings.Contains(msg, "certificate required") {
 		return causeClientCertRequired
+	}
+	if strings.Contains(msg, "bad certificate") {
+		return causeClientCertRejected
 	}
 	return causeUnknown
 }
@@ -264,15 +275,37 @@ func classifyTLSAlert(err error) connectCause {
 // (or rejects us at the certificate step, which still means it spoke TLS), the
 // mismatch is the likely root cause.
 func probeServerSpeaksTLS(ctx context.Context, conn net.Conn, host string) (connectCause, string) {
-	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true, ServerName: host})
+	tlsConn := tls.Client(conn, tlsProbeConfig(&tls.Config{InsecureSkipVerify: true, ServerName: host}))
 	err := tlsConn.HandshakeContext(ctx)
 	if err == nil {
 		return causeServerSpeaksTLS, ""
 	}
-	if classifyTLSAlert(err) == causeClientCertRequired {
+	switch classifyTLSAlert(err) {
+	case causeClientCertRequired:
 		return causeServerSpeaksTLS, " (and it requires client certificates)"
+	case causeClientCertRejected:
+		return causeServerSpeaksTLS, " (and it rejected the offered client certificate)"
 	}
 	return causeUnknown, ""
+}
+
+// tlsProbeConfig clones cfg and advertises h2 just as gRPC's TLS credentials
+// do. Keeping this separate from the caller's config preserves its reuse by
+// the original client dial.
+func tlsProbeConfig(cfg *tls.Config) *tls.Config {
+	probe := cfg.Clone()
+	for _, proto := range probe.NextProtos {
+		if proto == "h2" {
+			return probe
+		}
+	}
+	probe.NextProtos = append(probe.NextProtos, "h2")
+	return probe
+}
+
+func isIPLiteral(host string) bool {
+	_, err := netip.ParseAddr(host)
+	return err == nil
 }
 
 func classifyGRPCError(err error) (connectCause, string) {

--- a/internal/temporalcli/connectdiag_test.go
+++ b/internal/temporalcli/connectdiag_test.go
@@ -110,12 +110,54 @@ func TestDiagnoseConnection_ClientCertRequired(t *testing.T) {
 
 	// Client trusts the server CA but has no client cert.
 	d := testDiagnose(t, addr, &tls.Config{RootCAs: certPool(t, cert)})
-	// This test also pins the authoritative Go crypto/tls alert text
-	// ("certificate required" / "bad certificate") that classifyTLSAlert
-	// depends on; if it fails after a Go upgrade, revisit classifyTLSAlert.
+	// This test pins the authoritative Go crypto/tls alert text "certificate
+	// required" that classifyTLSAlert depends on; if it fails after a Go
+	// upgrade, revisit classifyTLSAlert.
 	assert.Equal(t, causeClientCertRequired, d.Cause)
 	requireStage(t, d, diagOK, "TCP connection established")
 	requireStage(t, d, diagFail, "server requires mTLS")
+}
+
+func TestClassifyTLSAlert_ClientCertificateRejected(t *testing.T) {
+	err := errors.New("remote error: tls: bad certificate")
+	assert.Equal(t, causeClientCertRejected, classifyTLSAlert(err))
+
+	d := &connectDiagnosis{}
+	d.classifyTLSError(err)
+	assert.Equal(t, causeClientCertRejected, d.Cause)
+	requireStage(t, d, diagFail, "rejected the supplied client certificate")
+	action := suggestAction(d, connectMeta{Address: "example:7233"})
+	require.NotNil(t, action)
+	assert.Contains(t, action.Label, "rejected the supplied client certificate")
+	assert.NotContains(t, action.Label, "--tls-cert-path")
+}
+
+func TestClassifyTLSError_CertificateInvalidIsNotCAFailure(t *testing.T) {
+	err := &tls.CertificateVerificationError{
+		Err: x509.CertificateInvalidError{Cert: &x509.Certificate{}, Reason: x509.Expired},
+	}
+	d := &connectDiagnosis{}
+	d.classifyTLSError(err)
+	assert.Equal(t, causeCertificateVerify, d.Cause)
+	requireStage(t, d, diagFail, "server certificate verification failed")
+	action := suggestAction(d, connectMeta{Address: "example:7233"})
+	require.NotNil(t, action)
+	assert.NotContains(t, action.Label, "--tls-ca-path")
+}
+
+func TestTLSProbeConfigAdvertisesH2WithoutMutatingClientConfig(t *testing.T) {
+	clientCfg := &tls.Config{NextProtos: []string{"http/1.1"}}
+	probeCfg := tlsProbeConfig(clientCfg)
+	assert.Equal(t, []string{"http/1.1"}, clientCfg.NextProtos)
+	assert.Equal(t, []string{"http/1.1", "h2"}, probeCfg.NextProtos)
+	assert.Equal(t, []string{"h2"}, tlsProbeConfig(&tls.Config{}).NextProtos)
+	assert.Equal(t, []string{"h2"}, tlsProbeConfig(&tls.Config{NextProtos: []string{"h2"}}).NextProtos)
+}
+
+func TestIsIPLiteralAcceptsScopedIPv6(t *testing.T) {
+	assert.True(t, isIPLiteral("fe80::1%en0"))
+	assert.True(t, isIPLiteral("127.0.0.1"))
+	assert.False(t, isIPLiteral("temporal.example"))
 }
 
 func TestGenericTLSHandshakeFailureDoesNotImplyClientCertificate(t *testing.T) {
@@ -454,6 +496,12 @@ func TestSuggestFix(t *testing.T) {
 			contains: []string{"requires client certificates", "--tls-cert-path", "--tls-key-path"},
 		},
 		{
+			name:     "rejected mTLS certificate does not imply it is missing",
+			diag:     &connectDiagnosis{Cause: causeClientCertRejected},
+			meta:     connectMeta{Address: "myhost:7233"},
+			contains: []string{"rejected the supplied client certificate", "trusted issuer"},
+		},
+		{
 			name:     "refused on local default port",
 			diag:     &connectDiagnosis{Cause: causeTCPRefused},
 			meta:     connectMeta{Address: "127.0.0.1:7233"},
@@ -481,7 +529,13 @@ func TestSuggestFix(t *testing.T) {
 			name:     "server plaintext",
 			diag:     &connectDiagnosis{Cause: causeServerPlaintext},
 			meta:     connectMeta{Address: "myhost:7233", TLSConfigured: true},
-			contains: []string{"does not appear to use TLS"},
+			contains: []string{"does not appear to use TLS", "profile, environment, API key", "--tls=false"},
+		},
+		{
+			name:     "certificate verification failure does not suggest a CA",
+			diag:     &connectDiagnosis{Cause: causeCertificateVerify},
+			meta:     connectMeta{Address: "myhost:7233"},
+			contains: []string{"certificate was rejected", "server-auth usage"},
 		},
 		{
 			name:     "cert file unreadable",

--- a/internal/temporalcli/connecterror.go
+++ b/internal/temporalcli/connecterror.go
@@ -57,8 +57,12 @@ func connectSummary(d *connectDiagnosis, origErr error) string {
 		return "the server requires TLS but the CLI is connecting without it"
 	case causeClientCertRequired:
 		return "TLS handshake failed: server requires client certificate (mTLS)"
+	case causeClientCertRejected:
+		return "TLS handshake failed: server rejected the supplied client certificate"
 	case causeCAVerify:
 		return "cannot verify server TLS certificate"
+	case causeCertificateVerify:
+		return "server TLS certificate verification failed"
 	case causeHostnameMismatch:
 		return "server TLS certificate does not match host"
 	case causeCertFileUnreadable:
@@ -81,12 +85,14 @@ func suggestAction(d *connectDiagnosis, meta connectMeta) *displayAction {
 		return &displayAction{Label: fmt.Sprintf("Cannot read %q — check that the path exists and is readable.", d.Detail)}
 	case causeClientCertRequired:
 		return &displayAction{Label: "The server requires client certificates (mTLS). Configure both --tls-cert-path and --tls-key-path."}
+	case causeClientCertRejected:
+		return &displayAction{Label: "The server rejected the supplied client certificate. Verify its validity, key, and trusted issuer."}
 	case causeUnauthenticated, causePermissionDenied:
 		// client.Options keeps credentials opaque, so no credential-specific
 		// action is authoritative here.
 		return nil
 	case causeServerPlaintext:
-		return &displayAction{Label: fmt.Sprintf("The server at %s does not appear to use TLS. Remove --tls and related TLS flags, or check the address.", meta.Address)}
+		return &displayAction{Label: fmt.Sprintf("The server at %s does not appear to use TLS. Correct the effective TLS setting (profile, environment, API key, or TLS flags), or check the address. If plaintext is intentional, retry with --tls=false.", meta.Address)}
 	case causeServerSpeaksTLS:
 		return &displayAction{Label: "The server requires TLS. Retry with --tls."}
 	case causeDNS:
@@ -101,6 +107,8 @@ func suggestAction(d *connectDiagnosis, meta connectMeta) *displayAction {
 		return &displayAction{Label: fmt.Sprintf("Nothing is listening at %s — verify the address and that the server is running.", meta.Address)}
 	case causeCAVerify:
 		return &displayAction{Label: "The server certificate is not trusted. Configure its CA certificate with --tls-ca-path."}
+	case causeCertificateVerify:
+		return &displayAction{Label: "The server certificate was rejected. Verify its validity, server-auth usage, and configured server name."}
 	case causeHostnameMismatch:
 		return &displayAction{Label: fmt.Sprintf("The server certificate is not valid for %q. Set --tls-server-name to a certificate name.", host)}
 	case causeTCPTimeout:

--- a/internal/temporalcli/terminal.go
+++ b/internal/temporalcli/terminal.go
@@ -51,6 +51,7 @@ type displayShell int
 const (
 	displayShellPOSIX displayShell = iota
 	displayShellPowerShell
+	displayShellWindows
 )
 
 // writeConnectionError renders err only when it contains a connectError. It
@@ -62,12 +63,16 @@ func writeConnectionError(stderr io.Writer, err error, useColor bool) bool {
 		return false
 	}
 
-	shell := displayShellPOSIX
-	if runtime.GOOS == "windows" {
-		shell = displayShellPowerShell
-	}
+	shell := displayShellForGOOS(runtime.GOOS)
 	_, _ = stderr.Write(renderConnectionReport(connectionErrorReport(connectionErr), useColor, shell))
 	return true
+}
+
+func displayShellForGOOS(goos string) displayShell {
+	if goos == "windows" {
+		return displayShellWindows
+	}
+	return displayShellPOSIX
 }
 
 func connectionErrorReport(err *connectError) connectionReport {
@@ -171,6 +176,10 @@ func renderInvocation(invocation displayInvocation, shell displayShell) (string,
 		parts[i] = escapeTerminalControls(parts[i])
 		if shell == displayShellPowerShell {
 			parts[i] = quotePowerShell(parts[i])
+		} else if shell == displayShellWindows {
+			if !isWindowsShellSafe(parts[i]) {
+				return "", false
+			}
 		} else {
 			parts[i] = quotePOSIX(parts[i])
 		}
@@ -180,6 +189,16 @@ func renderInvocation(invocation displayInvocation, shell displayShell) (string,
 		rendered = "& " + rendered
 	}
 	return rendered, true
+}
+
+// isWindowsShellSafe accepts only words whose unquoted form is interpreted
+// identically by Command Prompt and PowerShell. The CLI's recovery invocations
+// are static; omitting an unsafe future invocation is safer than showing a
+// command that works in only one of the two default Windows shells.
+func isWindowsShellSafe(value string) bool {
+	return value != "" && strings.IndexFunc(value, func(r rune) bool {
+		return !(unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("_@%+=:,./-", r))
+	}) < 0
 }
 
 func quotePOSIX(value string) string {

--- a/internal/temporalcli/terminal_test.go
+++ b/internal/temporalcli/terminal_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"runtime"
+	"io"
 	"strings"
 	"testing"
 
@@ -26,11 +26,7 @@ func TestWriteConnectionErrorHandlesWrappedConnectError(t *testing.T) {
 	assert.Contains(t, stderr.String(), "Error: failed connecting to Temporal server at 127.0.0.1:7233: connection refused")
 	assert.Contains(t, stderr.String(), "Namespace: default")
 	assert.Contains(t, stderr.String(), "✗ TCP connection refused")
-	expectedCommand := "temporal server start-dev"
-	if runtime.GOOS == "windows" {
-		expectedCommand = "& 'temporal' 'server' 'start-dev'"
-	}
-	assert.Contains(t, stderr.String(), expectedCommand)
+	assert.Contains(t, stderr.String(), "temporal server start-dev")
 	assert.NotContains(t, stderr.String(), "\x1b[")
 }
 
@@ -96,6 +92,39 @@ func TestRenderInvocationUsesExplicitShellQuoting(t *testing.T) {
 	)
 	require.True(t, ok)
 	assert.Equal(t, `temporal 'unsafe\nvalue'`, escaped)
+}
+
+func TestRenderInvocationUsesPortableWindowsSyntax(t *testing.T) {
+	assert.Equal(t, displayShellWindows, displayShellForGOOS("windows"))
+	assert.Equal(t, displayShellPOSIX, displayShellForGOOS("linux"))
+
+	rendered, ok := renderInvocation(
+		displayInvocation{Command: []string{"temporal", "server", "start-dev"}},
+		displayShellWindows,
+	)
+	assert.True(t, ok)
+	assert.Equal(t, "temporal server start-dev", rendered)
+
+	_, ok = renderInvocation(
+		displayInvocation{Command: []string{"temporal"}, Args: []string{"unsafe value"}},
+		displayShellWindows,
+	)
+	assert.False(t, ok)
+}
+
+func TestConnectionErrorColorPolicyUsesConfiguredStderr(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm")
+	terminal := func(io.Writer) bool { return true }
+	nonTerminal := func(io.Writer) bool { return false }
+	var stderr bytes.Buffer
+
+	assert.True(t, connectionErrorColorPolicy("always", &stderr, nonTerminal))
+	assert.False(t, connectionErrorColorPolicy("never", &stderr, terminal))
+	assert.True(t, connectionErrorColorPolicy("auto", &stderr, terminal))
+	assert.False(t, connectionErrorColorPolicy("auto", &stderr, nonTerminal))
+	t.Setenv("NO_COLOR", "1")
+	assert.False(t, connectionErrorColorPolicy("auto", &stderr, terminal))
 }
 
 func TestConnectErrorCopiesDiagnosisBeforeRendering(t *testing.T) {


### PR DESCRIPTION
## Related issues

Follow-up to #1114.

## What changed?

- Distinguish invalid server certificates and rejected client certificates from CA and missing-mTLS failures.
- Match gRPC TLS probing with `h2`, correctly skip DNS for scoped IPv6 literals, and provide configuration-source-neutral TLS guidance.
- Render the local-server recovery command safely in both default Windows shells and derive automatic error color from configured stderr.

## Checklist

- [x] Added unit tests where applicable
- [x] Errors and warnings continue to use stderr

## Manual tests

Covered by the connection-diagnostic TLS and rendering tests.

## Validation

- `go test ./... -count=1`
- `go mod tidy` (root and `cliext`), with no module-file drift
- Generated command and flag files match generator output
- Windows cross-compilation of `./internal/temporalcli`