### PR TITLE
fix: document start-dev log-level default

### DIFF
--- a/cliext/flags.gen.go
+++ b/cliext/flags.gen.go
@@ -43,7 +43,7 @@ func (v *CommonOptions) BuildFlags(f *pflag.FlagSet) {
 	f.BoolVar(&v.DisableConfigFile, "disable-config-file", false, "Disable loading config from file.")
 	f.BoolVar(&v.DisableConfigEnv, "disable-config-env", false, "Disable loading config from environment variables.")
 	v.LogLevel = NewFlagStringEnum([]string{"debug", "info", "warn", "error", "never"}, "never")
-	f.Var(&v.LogLevel, "log-level", "Log level. Accepted values: debug, info, warn, error, never.")
+	f.Var(&v.LogLevel, "log-level", "Log level. Default is \"never\" for most commands and \"warn\" for \"server start-dev\". Accepted values: debug, info, warn, error, never.")
 	v.LogFormat = NewFlagStringEnum([]string{"text", "json", "pretty"}, "text")
 	f.Var(&v.LogFormat, "log-format", "Log format. Accepted values: text, json.")
 	v.Output = NewFlagStringEnum([]string{"text", "json", "jsonl", "none"}, "text")

--- a/cliext/option-sets.yaml
+++ b/cliext/option-sets.yaml
@@ -43,7 +43,9 @@ option-sets:
           - warn
           - error
           - never
-        description: Log level.
+        description: |
+          Log level.
+          Default is "never" for most commands and "warn" for "server start-dev".
         default: never
       - name: log-format
         type: string-enum

--- a/internal/temporalcli/commands.help_test.go
+++ b/internal/temporalcli/commands.help_test.go
@@ -31,6 +31,15 @@ func TestHelp_Subcommand(t *testing.T) {
 	assert.NoError(t, res.Err)
 }
 
+func TestOptions_LogLevelDescribesStartDevDefault(t *testing.T) {
+	h := NewCommandHarness(t)
+
+	res := h.Execute("options")
+
+	assert.Contains(t, res.Stdout.String(), `Default is "never" for most commands and "warn" for "server start-dev".`)
+	assert.NoError(t, res.Err)
+}
+
 func TestHelp_WithValueFlag(t *testing.T) {
 	h := NewCommandHarness(t)
 

--- a/internal/temporalcli/commands.server.go
+++ b/internal/temporalcli/commands.server.go
@@ -53,7 +53,7 @@ func (t *TemporalServerStartDevCommand) run(cctx *CommandContext, args []string)
 	// Set the log level value of the server to the overall log level given to the
 	// CLI. But if it is "never" we have to do a special value, and if it was
 	// never changed, we have to use the default of "warn" instead of the CLI
-	// default of "info" since server is noisier.
+	// default of "never" since server is noisier.
 	logLevel := t.Parent.Parent.LogLevel.Value
 	if !t.Parent.Parent.LogLevel.ChangedFromDefault {
 		logLevel = "warn"


### PR DESCRIPTION
## Related issues

N/A

## What changed?

Restores the `server start-dev` log-level default exception in `temporal options`, which is now the canonical help surface for global flags. Also corrects the adjacent stale implementation comment and adds regression coverage.

This preserves the contract from #956: it changed the common default from `info` to `never` for short-lived CLI commands, while deliberately retaining the long-running `server start-dev` default of `warn`. That exception was present in #956’s option metadata but was removed by the subsequent help decluttering change.

## Checklist

- [x] Added applicable unit-test coverage
- [x] Help text describes the actual command behavior

## Manual tests

```
temporal options
# --log-level describes the `never` default and the `server start-dev` `warn` exception.
```

## Validation

```
env GOCACHE=/private/tmp/fix-cli-log-desc-gocache make test
```