### PR TITLE
chore: pin alpine docker image to 3.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.23.5
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Related issues

n/a — routine base image refresh, required by the CLI release runbook (Step 5)
ahead of the v1.8.3 monthly release.

## What changed?

Bumps the Dockerfile base image from `alpine:3.23.4` to `alpine:3.23.5`.

Exact package delta in the built image, verified by building this Dockerfile on
both bases and diffing `apk info -v` (the rest of the 18-package set is
identical):

| package | 3.23.4 | 3.23.5 |
|---|---|---|
| `alpine-release` | 3.23.4-r0 | 3.23.5-r0 |
| `ca-certificates-bundle` | 20260413-r0 | 20260611-r0 |
| `libcrypto3` | 3.5.6-r0 | 3.5.7-r0 |
| `libssl3` | 3.5.6-r0 | 3.5.7-r0 |

`openssl 3.5.7-r0` carries fixes for 15 CVEs per the Alpine security database:
CVE-2026-34180, -34181, -34182, -34183, -42764, -42766, -42767, -42768, -42769,
-42770, -45445, -45446, -45447, -7383, -9076.

Two notes on impact:

- The CLI binary is built with `CGO_ENABLED=0`, so it does not link
  `libssl`/`libcrypto` — those are present only because busybox's `ssl_client`
  pulls them in. The CVEs are very likely not reachable from the CLI, but image
  scanners flag by installed package version, so they show up against a
  `latest`-tagged public image regardless.
- The `ca-certificates-bundle` refresh **is** functionally live: Go's
  `crypto/x509` reads the system trust store from `/etc/ssl/certs` at runtime.

### Why 3.23.5 and not 3.24.1

`3.24.1` has **identical** `libcrypto3` (3.5.7-r0), `libssl3` (3.5.7-r0) and
`ca-certificates-bundle` (20260611-r0), so it offers no security benefit today.
It additionally bumps `musl` 1.2.5-r23 → 1.2.6-r2, `busybox` r30 → r31,
`alpine-baselayout` r0 → r1 and `scanelf`.

Worth noting `3.23.5` (pushed 2026-06-22) is actually a *newer build* than
`3.24.1` (2026-06-16), and there is no `3.24.2`.

Moving to the 3.24 line is worth doing for the longer support runway — better as
its own change on `main` with time to bake, rather than folded into a patch
release.

## Checklist

**Stability**
- [x] Breaking changes are marked with 💥 in the PR title and release notes — n/a
- [x] Changes to JSON output (`-o json` / `-o jsonl`) are treated as breaking changes — n/a

## Manual tests

Built the repo's Dockerfile on each base and compared the full package set:

```
$ docker build --platform linux/amd64 -t alpinetest:3.23.4 -f Dockerfile.3.23.4 .
$ docker build --platform linux/amd64 -t alpinetest:3.23.5 -f Dockerfile.3.23.5 .
$ diff <(docker run --rm alpinetest:3.23.4 apk info -v | sort) \
       <(docker run --rm alpinetest:3.23.5 apk info -v | sort)
< alpine-release-3.23.4-r0
> alpine-release-3.23.5-r0
< ca-certificates-bundle-20260413-r0
> ca-certificates-bundle-20260611-r0
< libcrypto3-3.5.6-r0
< libssl3-3.5.6-r0
> libcrypto3-3.5.7-r0
> libssl3-3.5.7-r0
```

Both images build clean and `adduser`/`apk add` behave identically.

## Follow-up

Once merged, this needs cherry-picking to `release/1.8.x` for the v1.8.3 release.
