### PR TITLE
chore: pin alpine docker image to 3.23.5 (backport to release/1.8.x)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.23.5
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Related issues

Backport of #1188 to `release/1.8.x`, required by [Step 5 of the CLI release
runbook](https://runbooks.tmprl-internal.cloud/oss/releases/oss-cli-release)
before v1.8.3 is cut.

## What changed?

Clean cherry-pick of `a46e993d` — bumps the Dockerfile base image from
`alpine:3.23.4` to `alpine:3.23.5`. One line, no conflicts.

Exact package delta in the built image:

| package | 3.23.4 | 3.23.5 |
|---|---|---|
| `alpine-release` | 3.23.4-r0 | 3.23.5-r0 |
| `ca-certificates-bundle` | 20260413-r0 | 20260611-r0 |
| `libcrypto3` | 3.5.6-r0 | 3.5.7-r0 |
| `libssl3` | 3.5.6-r0 | 3.5.7-r0 |

`openssl 3.5.7-r0` carries fixes for 15 CVEs per the Alpine security database:
CVE-2026-34180, -34181, -34182, -34183, -42764, -42766, -42767, -42768, -42769,
-42770, -45445, -45446, -45447, -7383, -9076.

See #1188 for the full rationale, including why 3.23.5 rather than 3.24.1.

## Why a PR rather than pushing to the release branch

`release/1.8.x` is unprotected, but CI does not run on pushes to it — the
checks on #1185 ran against the PR, not the branch. Going through a PR is the
only way to get this validated before v1.8.3 is cut.

## Manual tests

Built the release-branch Dockerfile on the new base and confirmed the expected
package versions land:

```
$ docker run --rm alpcheck:1.8.x apk info -v | sort | grep -E 'libcrypto3|libssl3|ca-certificates-bundle|alpine-release'
alpine-release-3.23.5-r0
ca-certificates-bundle-20260611-r0
libcrypto3-3.5.7-r0
libssl3-3.5.7-r0
```

Diff against `release/1.8.x` is the single `FROM` line.
