### PR TITLE
ci: select explicit release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: "Release tag to build"
         required: true
         type: string
+      previous_tag:
+        description: "Previous release tag"
+        required: true
+        type: string
   release:
     types:
       - published
@@ -60,6 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GORELEASER_PREVIOUS_TAG: ${{ inputs.previous_tag }}
           BUILD_DATE: ${{ steps.date.outputs.date }}
           BUILD_TS_UNIX: ${{ steps.timestamp.outputs.timestamp }}
           GIT_BRANCH: ${{ steps.branch.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build"
+        required: true
+        type: string
   release:
     types:
       - published
@@ -18,6 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -53,6 +59,7 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           BUILD_DATE: ${{ steps.date.outputs.date }}
           BUILD_TS_UNIX: ${{ steps.timestamp.outputs.timestamp }}
           GIT_BRANCH: ${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
## Related issues

Follow-up to the v1.9.0 release asset build.

## What changed?

GoReleaser chooses the first version-sorted tag pointing at `HEAD`. When both `v1.9.0-rc.1` and `v1.9.0` point at the same commit, it selects the RC tag even when the workflow was triggered by publishing the final release.

This change passes the GitHub release tag directly to GoReleaser. Manual workflow runs now require the intended tag, check out that tag, and pass it to GoReleaser as well. This allows the `v1.9.0` assets to be rebuilt without deleting or moving the RC tag.

## Validation

- `git diff --check`
- Confirmed both `v1.9.0` and `v1.9.0-rc.1` point at commit `2ecba7d58c1a2a648791e34af0b80e5331f3dab3`
- Reproduced GoReleaser's `--sort=-version:refname` ordering, which places `v1.9.0-rc.1` before `v1.9.0`

## Follow-up

After merge, manually dispatch the Release workflow with `tag` set to `v1.9.0`.
